### PR TITLE
Implicit detection for has_many serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -138,6 +138,8 @@ module ActiveModel
           # to determine the serializer
           if options[:key] && !options[:serializer]
             options[:serializer] = const_get("#{options[:key].to_s.camelize.singularize}Serializer")
+          elsif !options[:serializer] && klass == Associations::HasMany
+            options[:serializer] = const_get("#{attr.to_s.camelize.singularize}Serializer")
           else
             options[:serializer] ||= const_get("#{attr.to_s.camelize}Serializer")
           end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -211,6 +211,30 @@ class SerializerTest < ActiveModel::TestCase
     }, json)
   end
 
+  def test_implicit_serializer_for_has_many
+    blog_with_posts = Class.new(Blog) do
+      attr_accessor :posts
+    end
+
+    blog_serializer = Class.new(ActiveModel::Serializer) do
+      const_set(:PostSerializer, PostSerializer)
+      has_many :posts
+    end
+
+    user = User.new
+    blog = blog_with_posts.new
+    blog.posts = [Post.new(:title => 'test')]
+
+    json = blog_serializer.new(blog, user).as_json
+    assert_equal({
+     :posts => [{
+       :title => "test", 
+       :body => nil, 
+       :comments => []
+     }]
+    }, json)
+  end
+
   def test_overridden_associations
     author_serializer = Class.new(ActiveModel::Serializer) do
       attributes :first_name


### PR DESCRIPTION
Say you have this serializer:

``` ruby
class BlogSerializer < ActiveModel::Serializer
  has_many :posts
end
```

`ActiveModel::Serializer` will look for a `PostsSerializer`. This commit detects that it's a has_many and correctly assigns a `PostSerializer` instead of the plural version.
