### PR TITLE
added in attribute methods to serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -305,11 +305,16 @@ module ActiveModel
       hash = {}
 
       _attributes.each do |name,key|
-        hash[key] = @object.read_attribute_for_serialization(name)
+        hash[key] = read_attribute_for_serialization(name)
       end
 
       hash
     end
+    
+    def read_attribute_for_serialization(name)
+      respond_to?(name) ? send(name) : @object.read_attribute_for_serialization(name)
+    end
+    
   end
 end
 

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -54,6 +54,14 @@ class SerializerTest < ActiveModel::TestCase
       attributes.merge(:ok => true).merge(scope)
     end
   end
+  
+  class UserWithInitialsSerializer < ActiveModel::Serializer
+    attributes :first_name, :last_name, :initials
+    
+    def initials
+      "JV"
+    end
+  end
 
   class DefaultUserSerializer < ActiveModel::Serializer
     attributes :first_name, :last_name
@@ -100,6 +108,17 @@ class SerializerTest < ActiveModel::TestCase
   end
 
   def test_attributes_method
+    user = User.new
+    user_serializer = UserWithInitialsSerializer.new(user, {})
+
+    hash = user_serializer.as_json
+
+    assert_equal({
+      :user_with_initials => { :first_name => "Jose", :last_name => "Valim", :initials => "JV" }
+    }, hash)
+  end
+  
+  def test_attribute_method
     user = User.new
     user_serializer = UserSerializer.new(user, {})
 


### PR DESCRIPTION
Allowing you to specify the names of methods on your serializer to be included as attributes. Any presentation logic for the serializer belongs in the serializer, not the model. Eg:

``` ruby
class UserSerializer < ActiveModel::Serializer

  attributes :id, :first_name, :full_name

  def first_name
    user.first_name.upcase
  end

  def full_name
    [user.first_name, user.last_name].join(' ')
  end

end
```

Thoughts?
