### PR TITLE
Create custom attributes by passing a block

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -246,8 +246,8 @@ module ActiveModel
         end
       end
 
-      def attribute(attr, options={})
-        self._attributes = _attributes.merge(attr => options[:key] || attr)
+      def attribute(attr, options={}, &block)
+        self._attributes = _attributes.merge((options[:key] || attr) => (block || attr))
       end
 
       def associate(klass, attrs) #:nodoc:
@@ -485,8 +485,12 @@ module ActiveModel
     def attributes
       hash = {}
 
-      _attributes.each do |name,key|
-        hash[key] = @object.read_attribute_for_serialization(name)
+      _attributes.each do |key, value|
+        hash[key] = if value.respond_to? :call
+                      @object.instance_eval(&value)
+                    else
+                      @object.read_attribute_for_serialization(value)
+                    end
       end
 
       hash

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -491,6 +491,26 @@ class SerializerTest < ActiveModel::TestCase
     }, serializer.as_json)
   end
 
+  def test_attribute_block
+    serializer_class = Class.new(ActiveModel::Serializer) do
+      root :user
+
+      attribute :fullName do
+        "#{@attributes[:first_name]} #{@attributes[:last_name]}"
+      end
+      attribute :password
+    end
+
+    serializer = serializer_class.new(User.new)
+
+    assert_equal({
+      :user => {
+        :fullName => "Jose Valim",
+        :password => "oh noes yugive my password"
+      }
+    }, serializer.as_json)
+  end
+
   def setup_model
     Class.new do
       class << self


### PR DESCRIPTION
This change allows for the creation of attributes to be serialized that do not necessarily exist on the model being serialized. A block can be passed to the definition of a singular attribute and that block will be evaluated in the context of the model object being serialized. The return value of the block is then used as the value of the attribute for serialization. For example:

``` ruby
class UserSerializer < ActiveModel::Serializer
  attribute :full_name do
    "#{first_name} #{last_name}"
  end
end
```
