### PR TITLE
Add a :root option when defining associations

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -163,6 +163,30 @@ Assuming that the comments also `has_many :tags`, you will get a JSON like this:
 			{ "id": 3, "name": "happy" }
 		]
 	}
+	
+You can also specify a different root for the embedded objects than the key used to reference them, such as like this:
+
+	class PostSerializer < ApplicationSerializer
+		embed :ids, :include => true
+
+		attributes :id, :title, :body
+		has_many :comments, :key => :comment_ids, :root => :comment_objects
+	end
+	
+This would generate JSON that would look like this:
+
+	{
+		"post": {
+			"id": 1,
+			"title": "New post",
+			"body": "A body!",
+			"comment_ids": [ 1 ]
+		},
+		"comment_objects": [
+			{ "id": 1, "body": "what a dumb post" }
+		]
+	}
+
 
 **NOTE**: The `embed :ids` mechanism is primary useful for clients that process data in bulk and load it into a local store. For these clients, the ability to easily see all of the data per type, rather than having to recursively scan the data looking for information, is extremely useful.
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -146,6 +146,10 @@ module ActiveModel
           option(:key) || @name
         end
 
+        def root
+          option(:root) || plural_key
+        end
+
         def name
           option(:name) || @name
         end
@@ -454,7 +458,7 @@ module ActiveModel
         node[association.key] = association.serialize_ids
 
         if association.embed_in_root?
-          merge_association hash, association.plural_key, association.serialize_many, unique_values
+          merge_association hash, association.root, association.serialize_many, unique_values
         end
       elsif association.embed_objects?
         node[association.key] = association.serialize


### PR DESCRIPTION
This pull request allows you to define associations like this:

```
class PostSerializer < ApplicationSerializer
    embed :ids, :include => true

    attributes :id, :title, :body
    has_many :comments, :key => :comment_ids, :root => :comment_objects
end
```

Which will allow you to define different keys for the embedded field vs. what's added to the root level JSON, like this:

```
{
    "post": {
        "id": 1,
        "title": "New post",
        "body": "A body!",
        "comment_ids": [ 1 ]
    },
    "comment_objects": [
        { "id": 1, "body": "what a dumb post" }
    ]
}
```

This is partially to work around some bugs with RestKit (iOS framework, which would explode if it got JSON that had attributes that mirrored associations it was attempting to generate) but it also feels like it makes my JSON cleaner.
