### PR TITLE
Use ActiveSupport::Notifications

### DIFF
--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -1,5 +1,6 @@
 require "active_support"
 require "active_support/core_ext/string/inflections"
+require "active_support/notifications"
 require "active_model"
 require "active_model/serializer"
 


### PR DESCRIPTION
My idea is that we can use notifications to get a look into how the serializers are performing. 

I use this for event names: `name.class.serializer`. I wasn't sure what the naming would be. 

`serializable_hash` and `include!` are instrumented. With Rails 4 we can use the new notifications (classes that respond to started and ended) to generate a serialization tree. 
