### PR TITLE
ArraySerializer will include pagination if it can

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -55,10 +55,23 @@ module ActiveModel
       array = serializable_array.map(&:serializable_hash)
 
       if root = @options[:root]
+        if pages?
+          hash[:meta] = {
+            :pagination => {
+              :current => @object.current_page,
+              :total => @object.num_pages
+            }
+          }
+        end
+
         hash.merge!(root => array)
       else
         array
       end
+    end
+
+    def pages?
+      object.respond_to?(:num_pages) && object.respond_to?(:current_page)
     end
   end
 


### PR DESCRIPTION
This PR adds pagination information for collections. If the collection has some pagination methods, then include them in a meta object. 

``` ruby
{
  :meta => {:pagination => {:total => 5, :current => 1 }},
  :posts => [...]
}
```

I decided to root with a meta key because this leaves room for other meta information in the future (maybe URLS). @wycats also mentioned he was considering this strategy so I figured this was a good bet.
