### PR TITLE
SerializerGenerator use define? with const.

### DIFF
--- a/lib/generators/serializer/serializer_generator.rb
+++ b/lib/generators/serializer/serializer_generator.rb
@@ -30,7 +30,7 @@ module Rails
         # Only works on 3.2
         # elsif (n = Rails::Generators.namespace) && n.const_defined?(:ApplicationSerializer)
         #   "ApplicationSerializer"
-        elsif defined?(ApplicationSerializer)
+        elsif Object.const_defined?(:ApplicationSerializer)
           "ApplicationSerializer"
         else
           "ActiveModel::Serializer"


### PR DESCRIPTION
defined? requires not symbol but const.

This commit broke tests.
https://github.com/josevalim/active_model_serializers/commit/a2d73faa63355e897873b4813b08d2db5f4a3617
http://travis-ci.org/#!/josevalim/active_model_serializers/builds/1215004
