### PR TITLE
Include url helpers in serializers

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -49,6 +49,7 @@ module ActionController
 
       if serializer
         options[:scope] = serialization_scope
+        options[:url_options] = self.url_options
         json = serializer.new(json, options.merge(default_serializer_options || {}))
       end
       super

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -376,6 +376,10 @@ module ActiveModel
       @object, @options = object, options
     end
 
+    def url_options
+      options[:url_options]
+    end
+
     # Returns a json representation of the serializable
     # object including the root.
     def as_json(options=nil)

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -10,6 +10,10 @@ if defined?(Rails)
         Rails::Generators.configure!(app.config.generators)
         require "generators/resource_override"
       end
+
+      initializer 'active_model_serializers.url_helpers' do |app|
+        ActiveModel::Serializer.send(:include, app.routes.url_helpers)
+      end
     end
   end
 end

--- a/test/serialization_test.rb
+++ b/test/serialization_test.rb
@@ -54,6 +54,18 @@ class RenderJsonTest < ActionController::TestCase
     end
   end
 
+  class HypermediaSerializable
+    def active_model_serializer
+      HypermediaSerializer
+    end
+  end
+
+  class HypermediaSerializer < ActiveModel::Serializer
+    def as_json(*)
+      { :link => hypermedia_url }
+    end
+  end
+
   class TestController < ActionController::Base
     protect_from_forgery
 
@@ -122,6 +134,10 @@ class RenderJsonTest < ActionController::TestCase
 
     def render_json_with_custom_serializer
       render :json => [], :serializer => CustomSerializer
+    end
+
+    def render_json_with_links
+      render :json => HypermediaSerializable.new
     end
 
   private
@@ -228,5 +244,10 @@ class RenderJsonTest < ActionController::TestCase
   def test_render_json_with_custom_serializer
     get :render_json_with_custom_serializer
     assert_match '{"hello":true}', @response.body
+  end
+
+  def test_render_json_with_links
+    get :render_json_with_links
+    assert_match '{"link":"http://www.nextangle.com/hypermedia"}', @response.body
   end
 end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -132,6 +132,13 @@ class SerializerTest < ActiveModel::TestCase
     }, hash)
   end
 
+  def test_serializer_receives_url_options
+    user = User.new
+    user_serializer = UserSerializer.new(user, :url_options => { :host => "test.local" })
+
+    assert_equal({ :host => "test.local" }, user_serializer.url_options)
+  end
+
   def test_pretty_accessors
     user = User.new
     user.superuser = true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,11 +20,13 @@ require 'rails'
 module TestHelper
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
+    resource 'hypermedia'
     match ':controller(/:action(/:id))'
     match ':controller(/:action)'
   end
 
-  ActionController::Base.send :include, Routes.url_helpers
+  ActionController::Base.send  :include, Routes.url_helpers
+  ActiveModel::Serializer.send :include, Routes.url_helpers
 end
 
 ActiveSupport::TestCase.class_eval do


### PR DESCRIPTION
We needed to generate urls to include hypermedia type links. Here's an example.

``` ruby
class Post < ActiveRecord::Base
end

class PostSerializer < ActiveModel::Serializer
  def attributes
    hash = super
    hash[:links] = [
      { :rel => 'self', :href => post_url(post) }
    ]
    hash
  end
end
```
