### PR TITLE
Remove left over references to scope instance variable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -126,12 +126,12 @@ class PostSerializer < ActiveModel::Serializer
 
   # only let the user see comments he created.
   def comments
-    post.comments.where(:created_by => @scope)
+    post.comments.where(:created_by => options[:scope])
   end
 end
 ```
 
-In a serializer, `@scope` is the current authorization scope (usually
+In a serializer, `options[:scope]` is the current authorization scope (usually
 `current_user`), which the controller gives to the serializer when you call
 `render :json`
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -91,7 +91,7 @@ module ActiveModel
   #       end
   #
   #       def author?
-  #         post.author == scope
+  #         post.author == options[:scope]
   #       end
   #     end
   #

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -71,8 +71,8 @@ class SerializerTest < ActiveModel::TestCase
   end
 
   class CommentSerializer
-    def initialize(comment, scope, options={})
-      @comment, @scope = comment, scope
+    def initialize(comment, options={})
+      @comment = comment
     end
 
     def serializable_hash


### PR DESCRIPTION
Just removed a couple of left over references to `@scope` and switched them over to the new `options[:scope]`.
