### PR TITLE
use :root option in render :json

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -41,7 +41,7 @@ module ActionController
 
     def _render_option_json(json, options)
       if json.respond_to?(:to_ary)
-        options[:root] ||= controller_name
+        options[:root] ||= controller_name unless options[:root] == false
       end
 
       serializer = options.delete(:serializer) ||

--- a/test/serialization_test.rb
+++ b/test/serialization_test.rb
@@ -140,6 +140,11 @@ class RenderJsonTest < ActionController::TestCase
       render :json => HypermediaSerializable.new
     end
 
+    def render_json_array_with_no_root
+      render :json => [], :root => false
+    end
+
+
   private
     def default_serializer_options
       if params[:check_defaults]
@@ -249,5 +254,10 @@ class RenderJsonTest < ActionController::TestCase
   def test_render_json_with_links
     get :render_json_with_links
     assert_match '{"link":"http://www.nextangle.com/hypermedia"}', @response.body
+  end
+
+  def test_render_json_array_with_no_root
+    get :render_json_array_with_no_root
+    assert_equal '[]', @response.body
   end
 end


### PR DESCRIPTION
Currently there is no way to serialize an array with no root.

With this commit, ArraySerializer can render arrays with no root, if `root: false` is specified:

`render json: [], root: false`

Somewhat related is issue #31, which asks to use the `ActiveRecord::Base.include_root_in_json` setting when rendering arrays. It seems tricky since that method could be overridden in individual models, and `_render_option_json` does not know the class of the model being rendered. So it seems like it a better solution would be an option in ArraySerializer itself. That would enable this to be a global setting & render calls in index methods would be more DRY. Either way we still need the option in this commit.
