### PR TITLE
allow ArraySerializer to serialize an array of Hashes

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -52,7 +52,13 @@ module ActiveModel
       @options[:hash] = hash = {}
       @options[:unique_values] = {}
 
-      array = serializable_array.map(&:serializable_hash)
+      array = serializable_array.map do |item|
+        if item.respond_to?(:serializable_hash)
+          item.serializable_hash
+        else
+          item
+        end
+      end
 
       if root = @options[:root]
         hash.merge!(root => array)

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -402,6 +402,13 @@ class SerializerTest < ActiveModel::TestCase
       { :title => "Comment2" }
     ]}, serializer.as_json)
   end
+  
+  def test_array_serializer_with_hash
+    hash = {:value => "something"}
+    array = [hash]
+    serializer = array.active_model_serializer.new(array, :root => :items)
+    assert_equal({ :items => [ hash ]}, serializer.as_json)
+  end
 
   class CustomBlog < Blog
     attr_accessor :public_posts, :public_user


### PR DESCRIPTION
Currently, active_model_serializers breaks serializing a basic array of hashes. So you can't do something like

`render json: [{value: "something}]`

This commit makes ArraySerializer work with ActiveModel::Serializer objects as well as plain Hash objects.
