### PR TITLE
`rails generate` runs correctly under Rails 3.0.x

### DIFF
--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -7,6 +7,8 @@ if defined?(Rails)
   module ActiveModel
     class Railtie < Rails::Railtie
       generators do |app|
+        app ||= Rails.application # Rails 3.0.x does not yield `app`
+
         Rails::Generators.configure!(app.config.generators)
         require "generators/resource_override"
       end


### PR DESCRIPTION
- Rails 3.0.x does not yield `app` to `generator` blocks in railties.
  Picks a hopefully reasonable default `Rails.application` in that case.
- Fixes #71
