### PR TITLE
Allows serialization_scope to be disabled with serialization_scope nil

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -33,7 +33,7 @@ module ActionController
     end
 
     def serialization_scope
-      send(_serialization_scope) if respond_to?(_serialization_scope)
+      send(_serialization_scope) if _serialization_scope && respond_to?(_serialization_scope)
     end
 
     def default_serializer_options

--- a/test/no_serialization_scope_test.rb
+++ b/test/no_serialization_scope_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class NoSerializationScopeTest < ActionController::TestCase
+  class ScopeSerializer
+    def initialize(object, options)
+      @object, @options = object, options
+    end
+
+    def as_json(*)
+      { :scope => @options[:scope].as_json }
+    end
+  end
+
+  class ScopeSerializable
+    def active_model_serializer
+      ScopeSerializer
+    end
+  end
+
+  class NoSerializationScopeController < ActionController::Base
+    serialization_scope nil
+
+    def index
+      render :json => ScopeSerializable.new
+    end
+  end
+
+  tests NoSerializationScopeController
+
+  def test_disabled_serialization_scope
+    get :index
+    assert_equal '{"scope":null}', @response.body
+  end
+end


### PR DESCRIPTION
We have an app that doesn't really need `options[:scope]` and calling `current_user` each time--even if not needed--is not ideal.

This is hopefully preferable to `serialization_scope :""` or `serialization_scope :method_that_the_controller_does_not_respond_to` :)
