### PR TITLE
ActiveModel::Serializer.include_root_in_json option

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -248,6 +248,9 @@ module ActiveModel
     self._embed = :objects
     class_attribute :_root_embed
 
+    class_attribute :include_root_in_json
+    self.include_root_in_json = true
+
     class << self
       # Define attributes to be used in the serialization.
       def attributes(*attrs)
@@ -396,7 +399,7 @@ module ActiveModel
     # object including the root.
     def as_json(options=nil)
       options ||= {}
-      if root = options.fetch(:root, @options.fetch(:root, _root))
+      if include_root_in_json && root = options.fetch(:root, @options.fetch(:root, _root))
         @options[:hash] = hash = {}
         @options[:unique_values] = {}
 

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -277,6 +277,21 @@ class SerializerTest < ActiveModel::TestCase
     assert_equal({ :author => nil }, serializer.new(blog, :scope => user).as_json)
   end
 
+  def test_include_root_in_json
+    user = User.new
+    blog = Blog.new
+
+    serializer = Class.new(BlogSerializer)
+
+    # include root in json by default
+    assert_equal({ :blog => { :author => nil } }, serializer.new(blog, :scope => user).as_json)
+
+    # AS.include_root_in_json = false
+    serializer.include_root_in_json = false
+
+    assert_equal({ :author => nil }, serializer.new(blog, :scope => user).as_json)
+  end
+
   def test_embed_ids
     serializer = post_serializer
 


### PR DESCRIPTION
ActiveModel::Serializer.include_root_in_json option.
can be set to false to omit root from json globally. defaults to true.
fixes #31
