### PR TITLE
Private attributes

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -262,9 +262,17 @@ module ActiveModel
         end
       end
 
+      def private_attributes(*attrs)
+        self._private_attributes = _attributes.dup
+
+        attrs.each do |attr|
+          attribute attr, :private => true
+        end
+      end
+
       def attribute(attr, options={})
         if options[:private]
-          self._private_attributes = _attributes.merge(attr => options[:key] || attr)
+          self._private_attributes = _private_attributes.merge(attr => options[:key] || attr)
         else
           self._attributes = _attributes.merge(attr => options[:key] || attr)
         end


### PR DESCRIPTION
My app has a lot of user specific information. This information should only be included if the serialized object is the serialization scope. This PR adds a little sugar around it. This makes way is easier than overriding `attributes` and doing conditionals IMO.

New API:

``` ruby
class UserSerializer < ActiveModel::Serializer
  has_many :preferences, :private => true
  attribute :api_key, :private => true
  private_attributes :email, :foo, :bar
```

Previous solutions

``` ruby
def attributes
  if options[:scope] == object
    super.merge(:email => object.email) # etc
  else
    super
  end
end
```

This PR also defines `scope` method on the serializer which can be used internally. This is cleaner than referencing instance variables since they point to internal implementation. `scope` makes it easier for people to maintain their own serializers if the super class implementation changes.
