### PR TITLE
Serialize a collection with the base type's serializer or a specified one.

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -394,7 +394,12 @@ module ActiveModel
     # object including the root.
     def as_json(options=nil)
       options ||= {}
+
       if root = options.fetch(:root, @options.fetch(:root, _root))
+        if @object.respond_to?(:each)
+          return ArraySerializer.new(@object, options).as_json
+        end
+
         @options[:hash] = hash = {}
         @options[:unique_values] = {}
 

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -105,6 +105,21 @@ class SerializerTest < ActiveModel::TestCase
     }, hash)
   end
 
+  def test_collection
+    posts = [
+      Post.new({ :title => "Moby Dick", :body => "There once was a whale..." }),
+      Post.new({ :title => "SICP", :body => "Really hard stuff..." })
+    ]
+    post_serializer = PostSerializer.new(posts)
+
+    hash = post_serializer.as_json
+
+    assert_equal([
+      { :title => "Moby Dick", :body => "There once was a whale...", :comments => [] },
+      { :title => "SICP", :body => "Really hard stuff...", :comments => [] }
+    ], hash);
+  end
+
   def test_attributes_method
     user = User.new
     user_serializer = UserSerializer.new(user, :scope => {})


### PR DESCRIPTION
I believe this fixes: https://github.com/josevalim/active_model_serializers/issues/70

I'm betting this will be considered a naive implementation but I'd love ideas on how to make it better.  It may be too flimsy to rely on respond_to?(:each) for detecting a collection.
