### PR TITLE
Allow setting :each_serializer in 'render :json' calls

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -40,7 +40,13 @@ module ActiveModel
 
     def serializable_array
       @object.map do |item|
-        if item.respond_to?(:active_model_serializer) && (serializer = item.active_model_serializer)
+        if @options.has_key? :each_serializer
+          serializer = @options[:each_serializer]
+        elsif item.respond_to?(:active_model_serializer)
+          serializer = item.active_model_serializer
+        end
+
+        if serializer
           serializer.new(item, @options)
         else
           item

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -411,6 +411,24 @@ class SerializerTest < ActiveModel::TestCase
     assert_equal({ :items => [ hash.as_json ]}, serializer.as_json)
   end
 
+  class CustomPostSerializer < ActiveModel::Serializer
+    attributes :title
+  end
+
+  def test_array_serializer_with_specified_seriailizer
+    post1 = Post.new(:title => "Post1", :author => "Author1", :id => 1)
+    post2 = Post.new(:title => "Post2", :author => "Author2", :id => 2)
+
+    array = [ post1, post2 ]
+
+    serializer = array.active_model_serializer.new array, :each_serializer => CustomPostSerializer
+
+    assert_equal([
+      { :title => "Post1" },
+      { :title => "Post2" }
+    ], serializer.as_json)
+  end
+
   class CustomBlog < Blog
     attr_accessor :public_posts, :public_user
   end


### PR DESCRIPTION
As discussed in issue #70, this allows you to set:

``` ruby
render :json => @posts, :each_serializer => MySpecialSerializer
```

To have an array rendered with the specified serializer instead of the model's default.
