### PR TITLE
Alternative serialization configuration: hash&lambdas

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -248,25 +248,24 @@ module ActiveModel
 
     class << self
       # Define attributes to be used in the serialization.
+      #
+      # Attributes can be provided as a list of symbols representing instance methods on
+      # the model or the serializer, or, if preferred, as a hash where the key is the
+      # public API name used for serialization. If a value is provided it is used to call
+      # a method on (first) the serializer or (secondly) on the model to retrieve the value.
+      # The hash value can also be a callable whose return value will be used to populate
+      # the API field.
       def attributes(*attrs)
         self._attributes = _attributes.dup
 
         attrs.each do |attr|
-          attribute attr
-        end
-      end
-
-      # Alternative serialization configurarition using a hash
-      #
-      # The key is the public API name used in the JSON document. If a value is provided
-      # it is used to call a method on (first) the serializer or (secondly) on the model
-      # to retrieve the value. The hash value can also be a callable whose return value
-      # will be used to populate the API field.
-      def attributes_hash(fields_and_procs)
-        self._attributes = _attributes.dup
-
-        fields_and_procs.each do |serialized_field_name, proc_or_internal_method|
-          attribute serialized_field_name, proc_or_internal_method: proc_or_internal_method
+          if attr.is_a? Hash
+            attr.each do |serialized_field_name, proc_or_internal_method|
+              attribute serialized_field_name, proc_or_internal_method: proc_or_internal_method
+            end
+          else
+            attribute attr
+          end
         end
       end
 

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -58,10 +58,10 @@ class SerializerTest < ActiveModel::TestCase
 
   class UserSerializerWithHash < ActiveModel::Serializer
     root :user
-    attributes_hash first_name:         nil,
-                    surname:            :last_name,
-                    full_name:          ->{ "#{@attributes[:first_name]} #{@attributes[:last_name]}"},
-                    secret:             nil
+    attributes  :first_name,
+                surname:            :last_name,
+                full_name:          ->{ "#{@attributes[:first_name]} #{@attributes[:last_name]}"},
+                secret:             nil
 
     def secret
       object.instance_eval do


### PR DESCRIPTION
For serialization needs where the JSON keys and values differ a lot from the raw model, using the current mix of `attribute :something, key: :something_else` and `attributes :thing, :thang, :thong` led to a quite ugly looking serializer with lots and lots of instance methods. This fork implements an alternative syntax, while maintaining backwards compatibility with the previous one.

Instead of this:

``` ruby
class CommentSerializer < ActiveModel::Serializer
  attributes :text, :author_id, :author_username, :created_at, :updated_at, :likes_count, :comments_count, :author_avatar_image_url

  attribute :item_id, key: :post_id
  attribute :id, key: :comment_id

  def author_username
    object.author.username
  end

  def comments_count
    object.item.comments.count
  end

  def author_avatar_image_url
    object.author.avatar.try( :image_url, :pinky )    
  end
end
```

...we can now do this:

``` ruby
class CommentSerializer < ActiveModel::Serializer
  attributes_hash text:             nil,
                  post_id:          :item_id,
                  comment_id:       :id,
                  author_id:        nil,
                  author_username:  ->{ author.username },

                  # Timestamps
                  created_at:       nil,
                  updated_at:       nil,

                  # Counters
                  likes_count:      nil,
                  comments_count:   ->{ item.comments.count },

                  # Resources
                  author_avatar_image_url:  ->{ author.avatar.try( :image_url, :pinky ) }

end
```

Thoughts?
