### PR TITLE
Close #86

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -257,7 +257,7 @@ module ActiveModel
       end
 
       def attribute(attr, options={})
-        self._attributes = _attributes.merge(attr => options[:key] || attr)
+        self._attributes = _attributes.merge(attr => options[:key] || attr.to_s.gsub(/\?$/, '').to_sym)
 
         unless method_defined?(attr)
           class_eval "def #{attr}() object.read_attribute_for_serialization(:#{attr}) end", __FILE__, __LINE__

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -890,4 +890,48 @@ class SerializerTest < ActiveModel::TestCase
     end
     assert_equal ActiveModel::Serializer, loaded
   end
+
+  def tests_query_attributes_strip_question_mark
+    todo = Class.new do
+      def overdue?
+        true
+      end
+
+      def read_attribute_for_serialization(name)
+        send name
+      end
+    end
+
+    serializer = Class.new(ActiveModel::Serializer) do
+      attribute :overdue?
+    end
+
+    actual = serializer.new(todo.new).as_json
+
+    assert_equal({
+      :overdue => true
+    }, actual)
+  end
+
+  def tests_query_attributes_allow_key_option
+    todo = Class.new do
+      def overdue?
+        true
+      end
+
+      def read_attribute_for_serialization(name)
+        send name
+      end
+    end
+
+    serializer = Class.new(ActiveModel::Serializer) do
+      attribute :overdue?, :key => :foo
+    end
+
+    actual = serializer.new(todo.new).as_json
+
+    assert_equal({
+      :foo => true
+    }, actual)
+  end
 end


### PR DESCRIPTION
Title says it all. `overdue?` becomes `overdue` unless `key` is given.
