### PR TITLE
Include Related Bugs

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -194,6 +194,10 @@ module ActiveModel
           option(:include, source_serializer._root_embed)
         end
 
+        def embeddable?
+          !associated_object.nil?
+        end
+
       protected
 
         def find_serializable(object)
@@ -228,6 +232,14 @@ module ActiveModel
       end
 
       class HasOne < Config #:nodoc:
+        def embeddable?
+          if polymorphic? && associated_object.nil?
+            false
+          else
+            true
+          end
+        end
+
         def polymorphic?
           option :polymorphic
         end
@@ -516,7 +528,7 @@ module ActiveModel
 
         if association.embed_in_root? && hash.nil?
           raise IncludeError.new(self.class, association.name)
-        elsif association.embed_in_root?
+        elsif association.embed_in_root? && association.embeddable?
           merge_association hash, association.root, association.serialize_many, unique_values
         end
       elsif association.embed_objects?

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -1244,4 +1244,24 @@ class SerializerTest < ActiveModel::TestCase
       smoothie.as_json
     end
   end
+
+  def tests_includes_does_not_include_nil_polymoprhic_associations
+    post_serializer = Class.new(ActiveModel::Serializer) do
+      root :post
+      embed :ids, :include => true
+      has_one :author, :polymorphic => true
+      attributes :title
+    end
+
+    post = Post.new(:title => 'Foo')
+
+    actual = post_serializer.new(post).as_json
+
+    assert_equal({
+      :post => {
+        :title => 'Foo',
+        :author => nil
+      }
+    }, actual)
+  end
 end


### PR DESCRIPTION
This PR handles some edge cases around `:include => true` when handling complex serialization graphs. Each commit message details the bug and fix.
