### PR TITLE
Add section on Arrays to README

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -32,7 +32,7 @@ module ActiveModel
   # It serializes an Array, checking if each element that implements
   # the +active_model_serializer+ method.
   #
-  # To disable serialization of root elements, in an initializer:
+  # To disable serialization of root elements:
   #
   #     ActiveModel::ArraySerializer.root = false
   #


### PR DESCRIPTION
This commit adds documentation for serializing arrays and also using custom serializers on single objects.

I originally did these commits in another branch, but rebased to the latest master since that branch was just merged.
