### PR TITLE
Scope option precedence

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -52,7 +52,7 @@ module ActionController
       end
 
       if serializer
-        options[:scope] = serialization_scope
+        options[:scope] = serialization_scope unless options.has_key?(:scope)
         options[:url_options] = url_options
         json = serializer.new(json, options.merge(default_serializer_options || {}))
       end

--- a/test/serialization_test.rb
+++ b/test/serialization_test.rb
@@ -133,8 +133,8 @@ class RenderJsonTest < ActionController::TestCase
 
     def render_json_with_serializer_and_scope_option
       @current_user = Struct.new(:as_json).new(:current_user => true)
-      @scope = Struct.new(:as_json).new(:current_user => false)
-      render :json => JsonSerializable.new, :scope => @scope
+      scope = Struct.new(:as_json).new(:current_user => false)
+      render :json => JsonSerializable.new, :scope => scope
     end
 
     def render_json_with_serializer_api_but_without_serializer


### PR DESCRIPTION
Make passing a `:scope` to `render` take precedence over the controller's `serialization_scope`.
