### PR TITLE
Return empty hash when url_options not provided

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -449,7 +449,7 @@ module ActiveModel
     end
 
     def url_options
-      @options[:url_options]
+      @options[:url_options] || {}
     end
 
     # Returns a json representation of the serializable

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -143,6 +143,12 @@ class SerializerTest < ActiveModel::TestCase
     assert_equal({ :host => "test.local" }, user_serializer.url_options)
   end
 
+  def test_serializer_returns_empty_hash_without_url_options
+    user = User.new
+    user_serializer = UserSerializer.new(user)
+    assert_equal({}, user_serializer.url_options)
+  end
+
   def test_pretty_accessors
     user = User.new
     user.superuser = true


### PR DESCRIPTION
ActionPack url_for expects a hash for url_options when doing a merge. The serializer class in active_model_serializers overrides url_options so when they aren't supplied will return nil. This means that we can't use route helpers in the serializer.

This patch ensures that a hash is always returned.
