### PR TITLE
Fix default_serializer_options, closes #112 & #113

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -40,6 +40,8 @@ module ActionController
     end
 
     def _render_option_json(json, options)
+      options = default_serializer_options.merge(options) if default_serializer_options
+
       serializer = options.delete(:serializer) ||
         (json.respond_to?(:active_model_serializer) && json.active_model_serializer)
 
@@ -59,7 +61,7 @@ module ActionController
       if serializer
         options[:scope] = serialization_scope unless options.has_key?(:scope)
         options[:url_options] = url_options
-        json = serializer.new(json, options.merge(default_serializer_options || {}))
+        json = serializer.new(json, options)
       end
       super
     end


### PR DESCRIPTION
Allow options such as :serializer, :scope, :root etc to be set via default_serializer_options and allow the inline options to override such defaults.

This also partially addresses #108, but I'm still looking for better options.
