### PR TITLE
Easier to work with polymorphic interface

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -267,7 +267,10 @@ module ActiveModel
           object = associated_object
 
           if object && polymorphic?
-            { polymorphic_key => find_serializable(object).serializable_hash }
+            { 
+              :type => polymorphic_key,
+              polymorphic_key => find_serializable(object).serializable_hash
+            }
           elsif object
             find_serializable(object).serializable_hash
           end
@@ -283,7 +286,10 @@ module ActiveModel
           object = associated_object
 
           if object && polymorphic?
-            { polymorphic_key => object.read_attribute_for_serialization(:id) }
+            { 
+              :type => polymorphic_key,
+              :id => object.read_attribute_for_serialization(:id)
+            }
           elsif object
             object.read_attribute_for_serialization(:id)
           else

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -1025,6 +1025,7 @@ class SerializerTest < ActiveModel::TestCase
       :name => 'logo.png', 
       :url => 'http://example.com/logo.png',
       :attachable => {
+        :type => :email,
         :email => { :subject => 'foo', :body => 'bar' }
       }
     }, actual)
@@ -1061,7 +1062,8 @@ class SerializerTest < ActiveModel::TestCase
       :name => 'logo.png', 
       :url => 'http://example.com/logo.png',
       :attachable => {
-        :email => 1
+        :type => :email,
+        :id => 1
       }
     }, actual)
   end
@@ -1099,7 +1101,8 @@ class SerializerTest < ActiveModel::TestCase
         :name => 'logo.png', 
         :url => 'http://example.com/logo.png',
         :attachable => {
-          :email => 1
+          :type => :email, 
+          :id => 1
         }},
       :emails => [{
         :id => 1,
@@ -1179,15 +1182,15 @@ class SerializerTest < ActiveModel::TestCase
       :oranges => [{
         :plu => "3027",
         :id => 1,
-        :readable => { :email => 1 }
+        :readable => { :type => :email, :id => 1 }
       }],
 
       :attachment => {
         :name => 'logo.png',
         :url => 'http://example.com/logo.png',
-        :attachable => { :email => 1 },
-        :readable => { :email => 1 },
-        :edible => { :orange => 1 }
+        :attachable => { :type => :email, :id => 1 },
+        :readable => { :type => :email, :id => 1 },
+        :edible => { :type => :orange, :id => 1 }
       }
     }, actual)
   end


### PR DESCRIPTION
This touches up the interface from #50 making it easy to work with polymorphic associations in Javascript (suggested by @drogus). Here's how polymorphic associations are handled now:

``` javascript
// serialize id
{
  "association_name": {
    "type": "email",
    "id": 1
  }
}

// serialize object
{
  "association_name": {
    "type": "email",
    "email": { ... }
  }
}
```
