### PR TITLE
compatibility with rails >= 3.0

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ActiveModel::Serializer::VERSION
 
-  gem.add_dependency 'activemodel', '~> 3.0'
-  gem.add_development_dependency "rails", "~> 3.0"
+  gem.add_dependency 'activemodel', '>= 3.0'
+  gem.add_development_dependency "rails", ">= 3.0"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
I've been using AMS with Rails 4.0 beta without problem, and I see no need to limit compatibility.
