### PR TITLE
clean up lazy loading of serialization support

### DIFF
--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -57,7 +57,7 @@ module ActiveModel::SerializerSupport
 end
 
 ActiveSupport.on_load(:active_record) do
-  include ActiveModel::SerializerSupport
+  ActiveRecord::Base.send(:include, ActiveModel::SerializerSupport)
 end
 
 module ActiveModel::ArraySerializerSupport
@@ -78,7 +78,7 @@ begin
   require 'action_controller/serialization'
 
   ActiveSupport.on_load(:action_controller) do
-    include ::ActionController::Serialization
+    ActionController::Base.send(:include, ActionController::Serialization)
   end
 rescue LoadError => ex
   # rails on installed, continuing

--- a/test/serializer_support_test.rb
+++ b/test/serializer_support_test.rb
@@ -9,6 +9,8 @@ class RandomModelCollection
 end
 
 module ActiveRecord
+  class Base
+  end
   class Relation
   end
 end
@@ -25,6 +27,16 @@ class SerializerSupportTest < ActiveModel::TestCase
   test "it automatically includes array_serializer in active_record/relation" do
     ActiveSupport.run_load_hooks(:active_record)
     assert_equal ActiveModel::ArraySerializer, ActiveRecord::Relation.new.active_model_serializer
+  end
+
+  test "it automatically includes serializer support in active_record/base" do
+    ActiveSupport.run_load_hooks(:active_record)
+    assert ActiveRecord::Base.new.respond_to?(:active_model_serializer)
+  end
+
+  test "it automatically includes serializer support in action_controller/base" do
+    ActiveSupport.run_load_hooks(:action_controller)
+    assert ActionController::Base.new.respond_to?(:serialization_scope)
   end
 end
 


### PR DESCRIPTION
This more explicit method of loading AMS-support into ActiveRecord::Base and ActionController::Base fixes a problem using AMS with edge Rails (i.e. Rails 4), yet is also compatible with Rails 3.

Also included are tests to verify AMS-support in ActiveRecord::Base and ActionController::Base after load hooks have been run.
