### PR TITLE
Ensure bundler is updated for travis testing of edge rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - 1.8.7
   - 1.9.2


### PR DESCRIPTION
Bundler 1.2 is required for edge rails, which caused a problem the first time Travis tested against the alternative Gemfile.edge-rails.

This ensures that the latest version of bundler has been installed before tests proceed.
