### PR TITLE
Fixes repo URL in the README's installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For now, the easiest way to install `ActiveModel::Serializers` is to add this
 to your `Gemfile`:
 
 ```ruby
-gem "active_model_serializers", :git => "git://github.com/josevalim/active_model_serializers.git"
+gem "active_model_serializers", :git => "git://github.com/rails-api/active_model_serializers.git"
 ```
 
 Then, install it on the command line:


### PR DESCRIPTION
When the gem moved over to github.com/rails_api/, the README instructions
were still pointing to github.com/josevalim/.
