### PR TITLE
Fixed root(false) vs root=false inconsistency

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -204,6 +204,7 @@ module ActiveModel
       def root(name)
         self._root = name
       end
+      alias_method :root=, :root
 
       def inherited(klass) #:nodoc:
         return if klass.anonymous?

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -382,7 +382,12 @@ class SerializerTest < ActiveModel::TestCase
       root false
     end
 
+    another_serializer = Class.new(BlogSerializer) do
+      self.root = false
+    end
+
     assert_equal({ :author => nil }, serializer.new(blog, :scope => user).as_json)
+    assert_equal({ :author => nil }, another_serializer.new(blog, :scope => user).as_json)
 
     # test inherited false root
     serializer = Class.new(serializer)


### PR DESCRIPTION
Add alias_method `ActiveModel::Serializer.root=` to be consistency with `ActiveModel::ArraySerializer.root=`.

By the way, I include a test for alias method as well, but I'm not sure it is a necessary.
#137
