### PR TITLE
Update travis.yml to use the right Rubinius versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ rvm:
   - 1.9.3
   - ree
   - jruby
-  - rbx
+  - rbx-18mode
+  - rbx-19mode
 gemfile:
   - Gemfile
   - gemfiles/Gemfile.edge-rails
@@ -23,7 +24,9 @@ matrix:
     - gemfile: gemfiles/Gemfile.edge-rails
       rvm: jruby
     - gemfile: gemfiles/Gemfile.edge-rails
-      rvm: rbx
+      rvm: rbx-18mode
   allow_failures:
     - gemfile: gemfiles/Gemfile.edge-rails
       rvm: 1.9.3
+    - gemfile: gemfiles/Gemfile.edge-rails
+      rvm: rbx-19mode


### PR DESCRIPTION
http://about.travis-ci.org/docs/user/languages/ruby/#Rubinius%3A-1.8-and-1.9-modes%2C-periodic-upgrades
