### PR TITLE
Fix serialization of attribute whose name matches the serializer prefix underscored

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -226,7 +226,6 @@ module ActiveModel
         name = klass.name.demodulize.underscore.sub(/_serializer$/, '')
 
         klass.class_eval do
-          alias_method name.to_sym, :object
           root name.to_sym unless self._root == false
         end
       end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -29,6 +29,17 @@ class SerializerTest < ActiveModel::TestCase
     }, hash)
   end
 
+  def test_attribute_method_with_name_as_serializer_prefix
+    object = SomeObject.new("something")
+    object_serializer = SomeSerializer.new(object, {})
+
+    hash = object_serializer.as_json
+
+    assert_equal({
+      :some => { :some => "something" }
+    }, hash)
+  end
+
   def test_serializer_receives_scope
     user = User.new
     user_serializer = UserSerializer.new(user, :scope => {:scope => true})

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -63,7 +63,7 @@ class MyUserSerializer < ActiveModel::Serializer
 
   def serializable_hash
     hash = attributes
-    hash = hash.merge(:super_user => true) if my_user.super_user?
+    hash = hash.merge(:super_user => true) if object.super_user?
     hash
   end
 end
@@ -141,6 +141,13 @@ end
 class CustomBlogSerializer < ActiveModel::Serializer
   has_many :public_posts, :key => :posts, :serializer => PostSerializer
   has_one :public_user, :key => :user, :serializer => UserSerializer
+end
+
+class SomeSerializer < ActiveModel::Serializer
+  attributes :some
+end
+
+class SomeObject < Struct.new(:some)
 end
 
 # Set up some classes for polymorphic testing


### PR DESCRIPTION
Removed unneeded method aliasing of the prefix of the serializer name to the attr_reader :object, I don't see any usage of it other than in test_fake.rb which I fixed to reference attr_reader :object itself.
The method alias is causing a problem with serialization of an accessor method whose name either mathces the prefix of the serializer of the underscored prefix of it.

Here's an example:

``` ruby
class SomeSerializer < ActiveModel::Serializer
  attributes :some
end

class SomeObject < Struct.new(:some)
end
```

Current behavior:

``` ruby
object = SomeObject.new("some value")
SomeSerializer.new(object, {}).as_json
=> {:some=>{:some=>#<struct SomeObject some="some value">}}
```

Here is what is suppose to happen:

``` ruby
object = SomeObject.new("some value")
SomeSerializer.new(object, {}).as_json
=> {:some=>{:some=>"some value"}}
```
