### PR TITLE
Add support for specifying the serializer for an association as a String...

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -39,7 +39,8 @@ module ActiveModel
         end
 
         def target_serializer
-          option(:serializer)
+          serializer = option(:serializer)
+          serializer.is_a?(String) ? serializer.constantize : serializer
         end
 
         def source_serializer

--- a/test/association_test.rb
+++ b/test/association_test.rb
@@ -392,4 +392,26 @@ class AssociationTest < ActiveModel::TestCase
       }, json)
     end
   end
+
+  class StringSerializerOption < AssociationTest
+    class StringSerializer < ActiveModel::Serializer
+      attributes :id, :body
+    end
+
+    def test_specifying_serializer_class_as_string
+      @post_serializer_class.class_eval do
+        has_many :comments, :embed => :objects
+      end
+
+      include_bare! :comments, :serializer => "AssociationTest::StringSerializerOption::StringSerializer"
+
+      assert_equal({
+        :comments => [
+          { :id => 1, :body => "ZOMG A COMMENT" }
+        ]
+      }, @hash)
+
+      assert_equal({}, @root_hash)
+    end
+  end
 end


### PR DESCRIPTION
This enables the deferral of the resolution of the serializer class to prevent NameError exceptions due to reference cycles between serializer classes.

In my application we are using a series of modules to namespace our serializers for organizational purposes. We ran into an issue where referencing one serializer from another, that in turn references another serializer class defined further down in the original file results in a NameError exception being thrown.

This patch and accompanying test lets you work around this case by specifying the serializer as a string, which in constantized when its time to generate the output -- deferring resolution until the entire file is parsed and thus avoiding the `NameError`.

Cheers!
