### PR TITLE
Update foreign key naming conventions - fixes #158

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Now, any associations will be supplied as an Array of IDs:
     "id": 1,
     "title": "New post",
     "body": "A body!",
-    "comments": [ 1, 2, 3 ]
+    "comment_ids": [ 1, 2, 3 ]
   }
 }
 ```
@@ -413,7 +413,7 @@ The JSON will look like this:
     "comments": [
       { "id": 1, "body": "what a dumb post" }
     ],
-    "tags": [ 1, 2, 3 ]
+    "tag_ids": [ 1, 2, 3 ]
   }
 }
 ```
@@ -444,11 +444,11 @@ this:
     "id": 1,
     "title": "New post",
     "body": "A body!",
-    "comments": [ 1, 2 ]
+    "comment_ids": [ 1, 2 ]
   },
   "comments": [
-    { "id": 1, "body": "what a dumb post", "tags": [ 1, 2 ] },
-    { "id": 2, "body": "i liked it", "tags": [ 1, 3 ] },
+    { "id": 1, "body": "what a dumb post", "tag_ids": [ 1, 2 ] },
+    { "id": 2, "body": "i liked it", "tag_ids": [ 1, 3 ] },
   ],
   "tags": [
     { "id": 1, "name": "short" },

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -51,7 +51,7 @@ module ActiveModel
         end
 
         def root
-          option(:root) || plural_key
+          option(:root) || @name
         end
 
         def name
@@ -92,7 +92,15 @@ module ActiveModel
       end
 
       class HasMany < Config #:nodoc:
-        alias plural_key key
+        def key
+          if key = option(:key)
+            key
+          elsif embed_ids?
+            "#{@name.to_s.singularize}_ids".to_sym
+          else
+            @name
+          end
+        end
 
         def serialize
           associated_object.map do |item|
@@ -132,16 +140,28 @@ module ActiveModel
           option :polymorphic
         end
 
-        def polymorphic_key
-          associated_object.class.to_s.demodulize.underscore.to_sym
-        end
-
-        def plural_key
-          if polymorphic?
+        def root
+          if root = option(:root)
+            root
+          elsif polymorphic?
             associated_object.class.to_s.pluralize.demodulize.underscore.to_sym
           else
-            key.to_s.pluralize.to_sym
+            @name.to_s.pluralize.to_sym
           end
+        end
+
+        def key
+          if key = option(:key)
+            key
+          elsif embed_ids? && !polymorphic?
+            "#{@name}_id".to_sym
+          else
+            @name
+          end
+        end
+
+        def polymorphic_key
+          associated_object.class.to_s.demodulize.underscore.to_sym
         end
 
         def serialize

--- a/test/association_test.rb
+++ b/test/association_test.rb
@@ -70,7 +70,7 @@ class AssociationTest < ActiveModel::TestCase
       include! :comments, :value => @post.comments
 
       assert_equal({
-        :comments => [ 1 ]
+        :comment_ids => [ 1 ]
       }, @hash)
 
       assert_equal({
@@ -91,7 +91,7 @@ class AssociationTest < ActiveModel::TestCase
       include! :comments, :value => @post.comments, :embed => :ids, :include => false
 
       assert_equal({
-        :comments => [ 1 ]
+        :comment_ids => [ 1 ]
       }, @hash)
 
       assert_equal({}, @root_hash)
@@ -101,7 +101,7 @@ class AssociationTest < ActiveModel::TestCase
       include! :comment, :value => @post.comment
 
       assert_equal({
-        :comment => 1
+        :comment_id => 1
       }, @hash)
 
       assert_equal({
@@ -119,7 +119,7 @@ class AssociationTest < ActiveModel::TestCase
       include! :comments
 
       assert_equal({
-        :comments => [ 1 ]
+        :comment_ids => [ 1 ]
       }, @hash)
 
       assert_equal({
@@ -137,7 +137,7 @@ class AssociationTest < ActiveModel::TestCase
       include! :comment
 
       assert_equal({
-        :comment => 1
+        :comment_id => 1
       }, @hash)
 
       assert_equal({
@@ -159,7 +159,7 @@ class AssociationTest < ActiveModel::TestCase
       }, @hash)
 
       assert_equal({
-        :custom_comments => [
+        :comments => [
           { :id => 1, :body => "ZOMG A COMMENT" }
         ]
       }, @root_hash)
@@ -167,17 +167,17 @@ class AssociationTest < ActiveModel::TestCase
 
     def test_with_default_has_one_with_custom_key
       @post_serializer_class.class_eval do
-        has_one :comment, :key => :custom_comment
+        has_one :comment, :key => :custom_comment_id
       end
 
       include! :comment
 
       assert_equal({
-        :custom_comment => 1
+        :custom_comment_id => 1
       }, @hash)
 
       assert_equal({
-        :custom_comments => [
+        :comments => [
           { :id => 1, :body => "ZOMG A COMMENT" }
         ]
       }, @root_hash)
@@ -207,7 +207,7 @@ class AssociationTest < ActiveModel::TestCase
       include_bare! :comments
 
       assert_equal({
-        :comments => [ 1 ]
+        :comment_ids => [ 1 ]
       }, @hash)
 
       assert_equal({}, @root_hash)
@@ -232,7 +232,7 @@ class AssociationTest < ActiveModel::TestCase
       include_bare! :comments
 
       assert_equal({
-        :comments => [ 1 ]
+        :comment_ids => [ 1 ]
       }, @hash)
 
       assert_equal({
@@ -250,7 +250,7 @@ class AssociationTest < ActiveModel::TestCase
       include_bare! :comment
 
       assert_equal({
-        :comment => 1
+        :comment_id => 1
       }, @hash)
 
       assert_equal({}, @root_hash)
@@ -275,7 +275,7 @@ class AssociationTest < ActiveModel::TestCase
       include_bare! :comment
 
       assert_equal({
-        :comment => 1
+        :comment_id => 1
       }, @hash)
 
       assert_equal({
@@ -333,7 +333,7 @@ class AssociationTest < ActiveModel::TestCase
         :post => {
           :title => "New Post",
           :body => "Body",
-          :comments => [ 1 ]
+          :comment_ids => [ 1 ]
         },
         :comments => [
           { :id => 1, :body => "ZOMG A COMMENT" }
@@ -352,7 +352,7 @@ class AssociationTest < ActiveModel::TestCase
         :post => {
           :title => "New Post",
           :body => "Body",
-          :comments => [ 1 ]
+          :comment_ids => [ 1 ]
         }
       }, json)
     end
@@ -368,7 +368,7 @@ class AssociationTest < ActiveModel::TestCase
         :post => {
           :title => "New Post",
           :body => "Body",
-          :comments => [ 1 ]
+          :comment_ids => [ 1 ]
         }
       }, json)
     end
@@ -384,7 +384,7 @@ class AssociationTest < ActiveModel::TestCase
         :post => {
           :title => "New Post",
           :body => "Body",
-          :comments => [ 1 ]
+          :comment_ids => [ 1 ]
         },
         :comments => [
           { :id => 1, :body => "ZOMG A COMMENT" }

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -281,8 +281,8 @@ class SerializerTest < ActiveModel::TestCase
       :post => {
         :title => "New Post",
         :body => "Body of new post",
-        :comments => [1, 2],
-        :author => nil
+        :comment_ids => [1, 2],
+        :author_id => nil
       }
     }, serializer.as_json)
   end
@@ -305,8 +305,8 @@ class SerializerTest < ActiveModel::TestCase
       :post => {
         :title => "New Post",
         :body => "Body of new post",
-        :comments => [1, 2],
-        :author => nil
+        :comment_ids => [1, 2],
+        :author_id => nil
       },
       :comments => [
         { :title => "Comment1" },
@@ -323,8 +323,8 @@ class SerializerTest < ActiveModel::TestCase
       :post => {
         :title => "New Post",
         :body => "Body of new post",
-        :comments => [1, 2],
-        :author => 1
+        :comment_ids => [1, 2],
+        :author_id => 1
       },
       :comments => [
         { :title => "Comment1" },
@@ -558,7 +558,7 @@ class SerializerTest < ActiveModel::TestCase
       :post => {
         :title => "New Post",
         :body => "It's a new post!",
-        :author => 5
+        :author_id => 5
       }
     }, hash.as_json)
   end
@@ -776,12 +776,12 @@ class SerializerTest < ActiveModel::TestCase
     actual = ActiveModel::ArraySerializer.new([post], :root => :posts).as_json
     assert_equal({
       :posts => [
-        { :title => "New Post", :body => "NEW POST", :id => 1, :comments => [1,2] }
+        { :title => "New Post", :body => "NEW POST", :id => 1, :comment_ids => [1,2] }
       ],
 
       :comments => [
-        { :body => "EWOT", :id => 1, :tags => [1,3] },
-        { :body => "YARLY", :id => 2, :tags => [1,2] }
+        { :body => "EWOT", :id => 1, :tag_ids => [1,3] },
+        { :body => "YARLY", :id => 2, :tag_ids => [1,2] }
       ],
 
       :tags => [


### PR DESCRIPTION
This pull request addresses the issues raised by @tchak in #158:
- It appends an `_id` (or `_ids`) suffix to associations' keys when embedding ids. This brings AMS more in line with API conventions and the expectations of Ember Data. The name of the key can still be overridden with the `key` option.
- When objects are embedded in the root, they are now named according to their serializer, instead of the key used for their associations. This can still be overridden with the `root` option.

Note: This PR will bring Ember Data closer to working out-of-the-box with AMS. However, Ember Data will still need to be updated to recognize the `_ids` suffix for `HasMany` associations.
