### PR TITLE
Document adding serializer support to normal Ruby classes and other ORM's.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ the serializer generator:
 $ rails g serializer post
 ```
 
+### Support for PORO's and other ORM's.
+
+Currently `ActiveModel::Serializers` adds serialization support to all models
+that descend from `ActiveRecord`. If you are using another ORM or if you are
+using objects that are `ActiveModel` compliant, but do not descend from
+`ActiveRecord`. You must add an include statement for
+`ActiveModel::SerializerSupport`.
+
 # ActiveModel::Serializer
 
 All new serializers descend from ActiveModel::Serializer


### PR DESCRIPTION
Since more people are using serializers in other projects, there is a small edge case that was not documented. I thought it would be helpful to document adding serializer support to other types of objects.
