### PR TITLE
Howto use AMS with non-ActiveRecord models

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ end
 In this case, Rails will look for a serializer named `PostSerializer`, and if
 it exists, use it to serialize the `Post`.
 
+If you want to use a non `ActiveRecord::Base` model/class, you just need to `include ActiveModel::SerializerSupport` in it.
+
 This also works with `respond_with`, which uses `to_json` under the hood. Also
 note that any options passed to `render :json` will be passed to your
 serializer and available as `@options` inside.


### PR DESCRIPTION
I've added a line in the `README` to explain how to use AMS with non-ActiveRecord models/classes.

I was working with an `ActiveModel::Model` class for which I had to define the `active_model_serializer` method even if the default naming was right.

I've had to look into the source code (in the tests) to find out that it was not a bug, and I just needed to include the `ActiveModel::SerializerSupport` module.

I hope it will make things more clear for other people.
