### PR TITLE
Test : use a deducted serializer on non-ActiveRecord models

### DIFF
--- a/test/serializer_support_test.rb
+++ b/test/serializer_support_test.rb
@@ -4,6 +4,13 @@ class RandomModel
   include ActiveModel::SerializerSupport
 end
 
+class OtherRandomModel
+  include ActiveModel::SerializerSupport
+end
+
+class OtherRandomModelSerializer
+end
+
 class RandomModelCollection
   include ActiveModel::ArraySerializerSupport
 end
@@ -16,6 +23,10 @@ end
 class SerializerSupportTest < ActiveModel::TestCase
   test "it returns nil if no serializer exists" do
     assert_equal nil, RandomModel.new.active_model_serializer
+  end
+
+  test "it returns a deducted serializer if it exists exists" do
+    assert_equal OtherRandomModelSerializer, OtherRandomModel.new.active_model_serializer
   end
 
   test "it returns ArraySerializer for a collection" do


### PR DESCRIPTION
I've added a test to prove that including the `ActiveModel::SerializerSupport` module in a non-ActiveRecord class would make the convention work for finding a Serializer with the default name.
