### PR TITLE
Use pluck(:id) or _id methods instead of associated objects

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -355,9 +355,6 @@ module ActiveModel
       serializable_hashes = (hash[key] ||= [])
 
       serializables.each do |serializable|
-        puts key
-        puts serializable.inspect
-
         unless already_serialized.include? serializable.object
           already_serialized[serializable.object] = true
           serializable_hashes << serializable.serializable_hash


### PR DESCRIPTION
Per #140, this commit modifies association behaviour so that if you're only embedding IDs, the association serializer won't instantiate all of the associated objects just to get the ID. Instead, it will use `pluck(:id)` on collections or the `#{association_name}_id` method on the source object, with a fallback to instantiating the object if these methods aren't available.

Tests all pass and it works great in my relatively complex app. However, I'd appreciate suggestions for improvement.
