### PR TITLE
use _ids method instead of pluck to embed ids

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -109,8 +109,10 @@ module ActiveModel
         def serialize_ids
           # Use pluck or select_columns if available
           # return collection.ids if collection.respond_to?(:ids)
-          if !option(:include) && associated_object.respond_to?(:pluck)
-            associated_object.pluck(:id)
+          ids_key = "#{key.to_s.singularize}_ids"
+
+          if !option(:include) && source_serializer.object.respond_to?(ids_key)
+            source_serializer.object.send(ids_key)
           else
             associated_object.map do |item|
               item.read_attribute_for_serialization(:id)


### PR DESCRIPTION
Sorry to do this but there was a problem with PR #176. If you use `pluck` to select the `id` column on a `has_many through` association, the `id` column won't be disambiguated. However, you can use the `association_ids` method instead to achieve the same effect as `pluck` but with disambiguation.

I think `pluck` should probably disambiguate the column name, but in the interim this fixes the problem. Sorry for not noticing this sooner.
