### PR TITLE
Fix global ``` self.root = false ```

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -220,21 +220,19 @@ module ActiveModel
         self._root = name
       end
       alias_method :root=, :root
-
-      def inherited(klass) #:nodoc:
-        return if klass.anonymous?
-        name = klass.name.demodulize.underscore.sub(/_serializer$/, '')
-
-        klass.class_eval do
-          root name.to_sym unless self._root == false
-        end
-      end
     end
 
     attr_reader :object, :options
 
     def initialize(object, options={})
       @object, @options = object, options
+    end
+
+    def root_name
+      return false if self._root == false
+      
+      class_name = self.class.name.demodulize.underscore.sub(/_serializer$/, '').to_sym unless self.class.name.blank?
+      self._root || class_name
     end
 
     def url_options
@@ -252,7 +250,7 @@ module ActiveModel
     # Returns a json representation of the serializable
     # object including the root.
     def as_json(options={})
-      if root = options.fetch(:root, @options.fetch(:root, _root))
+      if root = options.fetch(:root, @options.fetch(:root, root_name))
         @options[:hash] = hash = {}
         @options[:unique_values] = {}
 

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -274,6 +274,23 @@ class SerializerTest < ActiveModel::TestCase
     assert_equal({ :author => nil }, serializer.new(blog, :scope => user).as_json)
   end
 
+  def test_root_false_on_load_active_model_serializers
+    begin
+      ActiveSupport.on_load(:active_model_serializers) do
+        self.root = false
+      end
+
+      blog = Blog.new
+      serializer = BlogSerializer.new(blog)
+
+      assert_equal({ :author => nil }, serializer.as_json)
+    ensure
+      ActiveSupport.on_load(:active_model_serializers) do
+        self.root = nil
+      end
+    end
+  end
+
   def test_embed_ids
     serializer = post_serializer
 


### PR DESCRIPTION
Using the on_load hook does not change the defined root on
Serializer#inherited.

Related to #179

I'm not sure if this is the right way to implement this. Let me know if I need to change something.
