### PR TITLE
Update association section on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ class PostSerializer < ActiveModel::Serializer
 
   # only let the user see comments he created.
   def comments
-    post.comments.where(:created_by => scope)
+    object.comments.where(:created_by => scope)
   end
 end
 ```
@@ -307,7 +307,7 @@ class PostSerializer < ActiveModel::Serializer
   has_many :comments
 
   def include_comments?
-    !post.comments_disabled?
+    !object.comments_disabled?
   end
 end
 ```


### PR DESCRIPTION
To reflect deprecation of the prefix of the serializer class being used as the accessor to the object we wish to serialize.
(reason was previously that the name of the object being serialized is not necessarily going to be the prefix of the serializer class and worse the prefix could have been an attribute of the object itself)
Now we only have a single expected case of mis-serialization, and that is when the object has itself a method called object().
