### PR TITLE
added tests for respond_with

### DIFF
--- a/test/serialization_test.rb
+++ b/test/serialization_test.rb
@@ -85,6 +85,8 @@ class RenderJsonTest < ActionController::TestCase
     serialization_scope :current_user
     attr_reader :current_user
 
+    respond_to :json
+
     def self.controller_path
       'test'
     end
@@ -179,6 +181,18 @@ class RenderJsonTest < ActionController::TestCase
 
     def render_json_array_with_custom_array_serializer
       render :json => [], :serializer => CustomArraySerializer
+    end
+
+    def respond_with_json_empty_array
+      render :json => []
+    end
+
+    def respond_with_json_array_with_custom_serializer
+      respond_with [Object.new], :each_serializer => CustomSerializer
+    end
+
+    def respond_with_json_array_with_custom_array_serializer
+      respond_with [], :serializer => CustomArraySerializer
     end
 
 
@@ -374,6 +388,21 @@ class RenderJsonTest < ActionController::TestCase
 
   def test_render_json_array_with_custom_array_serializer
     get :render_json_array_with_custom_array_serializer
+    assert_equal '{"items":[]}', @response.body
+  end
+
+  def test_respond_with_json_empty_array
+    get :respond_with_json_empty_array
+    assert_equal '{"test":[]}', @response.body
+  end
+
+  def test_respond_with_json_array_with_custom_serializer
+    get :respond_with_json_array_with_custom_serializer
+    assert_match '{"test":[{"hello":true}]}', @response.body
+  end
+
+  def test_respond_with_json_array_with_custom_array_serializer
+    get :respond_with_json_array_with_custom_array_serializer
     assert_equal '{"items":[]}', @response.body
   end
 


### PR DESCRIPTION
Noticed locally that active_model_serializers :serializer and :each_serializer options don't appear to be working with respond_with as might be expected, so added a few tests for respond_with that (1) uses the default serializer, (2) uses a custom each_serializer, and (3) uses a custom serializer.

Wish I could say that I had the fix to make these tests work, but if someone could provide some guidance, I'd be glad to try to add support as soon as I have time. Thanks!
