### PR TITLE
Able to specify keys on the attributes method

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -69,10 +69,15 @@ module ActiveModel
     class << self
       # Define attributes to be used in the serialization.
       def attributes(*attrs)
+
         self._attributes = _attributes.dup
 
         attrs.each do |attr|
-          attribute attr
+          if Hash === attr
+            attr.each {|attr_real, key| attribute attr_real, :key => key }
+          else
+            attribute attr
+          end
         end
       end
 

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -29,6 +29,28 @@ class SerializerTest < ActiveModel::TestCase
     }, hash)
   end
 
+  def test_attributes_method_specifying_keys
+    user = User.new
+    user_serializer = UserAttributesWithKeySerializer.new(user, :scope => {})
+
+    hash = user_serializer.as_json
+
+    assert_equal({
+      :user_attributes_with_key => { :f_name => "Jose", :l_name => "Valim", :ok => true }
+    }, hash)
+  end
+
+  def test_attributes_method_specifying_some_keys
+    user = User.new
+    user_serializer = UserAttributesWithSomeKeySerializer.new(user, :scope => {})
+
+    hash = user_serializer.as_json
+
+    assert_equal({
+      :user_attributes_with_some_key => { :first_name => "Jose", :l_name => "Valim", :ok => true }
+    }, hash)
+  end
+
   def test_attribute_method_with_name_as_serializer_prefix
     object = SomeObject.new("something")
     object_serializer = SomeSerializer.new(object, {})

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -54,6 +54,22 @@ class UserSerializer < ActiveModel::Serializer
   end
 end
 
+class UserAttributesWithKeySerializer < ActiveModel::Serializer
+  attributes :first_name => :f_name, :last_name => :l_name
+
+  def serializable_hash
+    attributes.merge(:ok => true).merge(options[:scope])
+  end
+end
+
+class UserAttributesWithSomeKeySerializer < ActiveModel::Serializer
+  attributes :first_name, :last_name => :l_name
+
+  def serializable_hash
+    attributes.merge(:ok => true).merge(options[:scope])
+  end
+end
+
 class DefaultUserSerializer < ActiveModel::Serializer
   attributes :first_name, :last_name
 end


### PR DESCRIPTION
What do you guys think about this?

Instead of doing this:

``` ruby
attribute :a_foo => :a_bar 
attribute :b_foo => :b_bar 
attribute :c_foo => :c_bar 
```

do this:

``` ruby
attributes :a_foo => :a_bar, :b_foo => :b_bar, :c_foo => :c_bar 
```

I don't know if anyone has proposed this, if so feel free to close this :smiley: 
