### PR TITLE
Reduce double map to once; Fixes datamapper eager loading.

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -27,10 +27,12 @@ module ActiveModel
           serializer = item.active_model_serializer
         end
 
-        if serializer
-          serializer.new(item, @options)
+        serializable = serializer ? serializer.new(item, @options) : item
+
+        if serializable.respond_to?(:serializable_hash)
+          serializable.serializable_hash
         else
-          item
+          serializable.as_json
         end
       end
     end
@@ -47,20 +49,12 @@ module ActiveModel
       @options[:hash] = hash = {}
       @options[:unique_values] = {}
 
-      array = serializable_array.map do |item|
-        if item.respond_to?(:serializable_hash)
-          item.serializable_hash
-        else
-          item.as_json
-        end
-      end
-
       if root = @options[:root]
-        hash.merge!(root => array)
+        hash.merge!(root => serializable_array)
         include_meta hash
         hash
       else
-        array
+        serializable_array
       end
     end
   end


### PR DESCRIPTION
The use of #map on the original object array here: https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/array_serializer.rb#L23 causes the serializable_array to be just an array, and no longer a DataMapper::Collection. This breaks eager loading of associations when on line 50 we call #map on the serializable_array here: https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/array_serializer.rb#L50 and call serializable_hash on each entry in the array.

This second map doesn't really need to happen separately. The two maps can be combined. Ostensibly, this improves performance for large arrays being serialized, to not require looping over the collection twice.
