### PR TITLE
Ensure that Responders work with Rails-API

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -30,6 +30,11 @@ module ActionController
     included do
       class_attribute :_serialization_scope
       self._serialization_scope = :current_user
+
+      unless self.respond_to?(:responder=)
+        include ActionController::MimeResponds
+      end
+
       self.responder = ActiveModel::Serializer::Responder
       self.respond_to :json
 


### PR DESCRIPTION
Fix/follow-up to issue #228 that @mdi encountered with `self.responder=` not being defined in `ActionController::API`
