### PR TITLE
Use https for rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify gem dependencies in active_model_serializers.gemspec
 gemspec


### PR DESCRIPTION
The Gemfile should use https for rubygems, as per every time I get the warning (in other projects that use the rubygems symbol).
