### PR TITLE
Rails actionpack responder preserves :location => nil, AM::S should too

### DIFF
--- a/lib/active_model/serializer/responder.rb
+++ b/lib/active_model/serializer/responder.rb
@@ -32,7 +32,7 @@ module ActiveModel
             serialization_scope = controller.send(:serialization_scope)
             options[:scope] = serialization_scope unless options.has_key?(:scope)
             options[:url_options] = controller.send(:url_options)
-            render(given_options.merge(:json => serializer.new(resource, options)))
+            render(given_options.merge(self.options).merge(:json => serializer.new(resource, options)))
           else
             super
           end

--- a/test/responder_test.rb
+++ b/test/responder_test.rb
@@ -143,6 +143,10 @@ class ResponderTest < ActionController::TestCase
       respond_with JsonSerializable.new, :options => true
     end
 
+    def render_json_with_serializer_but_without_location
+      respond_with JsonSerializable.new, :location => nil
+    end
+
     def render_json_with_serializer_and_scope_option
       @current_user = Struct.new(:as_json).new(:current_user => true)
       scope = Struct.new(:as_json).new(:current_user => false)
@@ -299,6 +303,11 @@ class ResponderTest < ActionController::TestCase
     assert_match '"scope":{"current_user":true}', @response.body
     assert_match '"object":{"serializable_object":true}', @response.body
     assert_match '"options":true', @response.body
+  end
+
+  def test_render_json_with_serializer_but_without_location
+    post :render_json_with_serializer_but_without_location
+    assert_equal nil, @response.location
   end
 
   def test_render_json_with_serializer_and_scope_option


### PR DESCRIPTION
In a case where we want to `respond_with thing, location: nil`, Rails will preserve that location and not attempt to find `thing_url` on create, for example.

This turns out to be a bug in the way `display` in the responder is overridden. To remedy this, we can do what Rails does (which is a bit obfuscated, IMO) which is to make sure to merge the original responder options into the `given_options` to preserve location before passing it to `render`.
