### PR TITLE
fix inheritance issues

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -105,6 +105,14 @@ module ActiveModel
 
         define_include_method attr
 
+        # protect inheritance chains and open classes
+        # if a serializer inherits from another OR 
+        #  attributes are added later in a classes lifecycle
+        # poison the cache
+        define_method :_fast_attributes do 
+          raise NameError
+        end
+
       end
 
       def associate(klass, attrs) #:nodoc:

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -1311,4 +1311,32 @@ class SerializerTest < ActiveModel::TestCase
       ]
     }, actual)
   end
+  
+  def test_inheritance_does_not_used_cached_attributes
+    parent = Class.new(ActiveModel::Serializer) do
+      attributes :title
+    end
+
+    child = Class.new(parent) do
+      attributes :body
+    end
+
+    data_class = Class.new do 
+      attr_accessor :title, :body
+    end
+
+    item = data_class.new 
+    item.title = "title"
+    item.body = "body"
+
+    2.times do
+      assert_equal({:title => "title"}, 
+                   parent.new(item).attributes)
+      assert_equal({:body => "body", :title => "title"}, 
+                   child.new(item).attributes)
+    end
+
+  end
+
+
 end


### PR DESCRIPTION
There was an issue where inherited serializers used incorrect cached fast_attributes, this adds a test and fixes the issue. 
