### PR TITLE
Adding scope_name method to alias scope in Serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # unreleased
 
+* Add an alias for `scope` method to be the name of the context. By default
+  this is `current_user`. The name is automatically set when using
+  `serialization_scope` in the controller.
+
 # VERSION 0.7
 
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -261,6 +261,13 @@ module ActiveModel
 
     def initialize(object, options={})
       @object, @options = object, options
+
+      scope_name = @options[:scope_name]
+      if scope_name && !respond_to?(scope_name)
+        self.class.class_eval do
+          define_method scope_name, lambda { scope }
+        end
+      end
     end
 
     def root_name

--- a/lib/active_model/serializer/responder.rb
+++ b/lib/active_model/serializer/responder.rb
@@ -31,6 +31,7 @@ module ActiveModel
           if serializer
             serialization_scope = controller.send(:serialization_scope)
             options[:scope] = serialization_scope unless options.has_key?(:scope)
+            options[:scope_name] = controller.send(:_serialization_scope)
             options[:url_options] = controller.send(:url_options)
             render(given_options.merge(self.options).merge(:json => serializer.new(resource, options)))
           else

--- a/test/serialization_scope_name_test.rb
+++ b/test/serialization_scope_name_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+require 'pathname'
+
+class DefaultScopeNameTest < ActionController::TestCase
+  TestUser = Struct.new(:name, :admin)
+
+  class UserSerializer < ActiveModel::Serializer
+    attributes :admin?
+    def admin?
+      current_user.admin
+    end
+  end
+
+  class UserTestController < ActionController::Base
+    protect_from_forgery
+
+    before_filter { request.format = :json }
+
+    def current_user
+      TestUser.new('Pete', false)
+    end
+
+    def render_new_user
+      respond_with TestUser.new('pete', false), :serializer => UserSerializer
+    end
+  end
+
+ tests UserTestController
+
+  def test_default_scope_name
+    get :render_new_user
+    assert_equal '{"user":{"admin":false}}', @response.body
+  end
+end
+
+class SerializationScopeNameTest < ActionController::TestCase
+  TestUser = Struct.new(:name, :admin)
+
+  class AdminUserSerializer < ActiveModel::Serializer
+    attributes :admin?
+    def admin?
+      current_admin.admin
+    end
+  end
+
+  class AdminUserTestController < ActionController::Base
+    protect_from_forgery
+
+    serialization_scope :current_admin
+    before_filter { request.format = :json }
+
+    def current_admin
+      TestUser.new('Bob', true)
+    end
+
+    def render_new_user
+      respond_with TestUser.new('pete', false), :serializer => AdminUserSerializer
+    end
+  end
+
+  tests AdminUserTestController
+
+  def test_override_scope_name_with_controller
+    get :render_new_user
+    assert_equal '{"admin_user":{"admin":true}}', @response.body
+  end
+end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -1338,5 +1338,18 @@ class SerializerTest < ActiveModel::TestCase
 
   end
 
+  def test_scope_name_method
+    serializer = Class.new(ActiveModel::Serializer) do
+      def has_permission?
+        current_user.super_user?
+      end
+    end
 
+    user = User.new
+    user.superuser = true
+    post = Post.new(:title => 'Foo')
+
+    a_serializer = serializer.new(post, :scope => user, :scope_name => :current_user)
+    assert a_serializer.has_permission?
+  end
 end


### PR DESCRIPTION
Allows you to declare a more explicit name for the scope such as:

```
scope_name :current_user
```

I didn't see a change log, and the release notes don't look like they are being maintained. I'd be happy to add a note to the README if this is something you're interested in though.
