### PR TITLE
auto camelize keys

### DIFF
--- a/lib/active_model/serializer/camelize_keys.rb
+++ b/lib/active_model/serializer/camelize_keys.rb
@@ -1,0 +1,27 @@
+require 'active_support/inflector'
+
+module ActiveModel
+  class Serializer
+    module CamelizeKeys #:nodoc:
+
+      def self.included(base)
+        class << base
+          def attribute(attr, options = {})
+            unless attr.is_a?(Hash)
+              unless options[:key]
+                attr = { attr => attr.to_s.camelize(:lower)}
+              end
+            end
+            super
+          end
+        end
+      end
+
+      def root_name
+        self._root = self.class.name.demodulize.underscore.sub(/_serializer$/, '').camelize(:lower).to_sym if !self._root && !self.class.name.blank?
+        super
+      end
+
+    end
+  end
+end

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -5,6 +5,7 @@ require "active_model"
 require "active_model/array_serializer"
 require "active_model/serializer"
 require "active_model/serializer/associations"
+require "active_model/serializer/camelize_keys"
 require "set"
 
 if defined?(Rails)

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -1311,4 +1311,52 @@ class SerializerTest < ActiveModel::TestCase
       ]
     }, actual)
   end
+
+  def test_camelcase_attributes
+    user = User.new
+    user_serializer = DefaultUserCamelcaseSerializer.new(user)
+
+    hash = user_serializer.as_json
+
+    assert_equal({
+      :defaultUserCamelcase => { :firstName => "Jose", :lastName => "Valim" }
+    }, hash)
+  end
+
+  def test_camelcase_attributes_method
+    user = User.new
+    user_serializer = UserCamelcaseSerializer.new(user, :scope => {})
+
+    hash = user_serializer.as_json
+
+    assert_equal({
+      :userCamelcase => { :firstName => "Jose", :lastName => "Valim", :ok => true}
+    }, hash)
+  end
+
+  def test_camelcase_attributes_method_specifying_some_keys
+    user = User.new
+    user_serializer = UserAttributesWithSomeKeyCamelizeSerializer.new(user, :scope => {})
+
+    hash = user_serializer.as_json
+
+    assert_equal({
+      :userAttributesWithSomeKeyCamelize => { :firstName => "Jose", :l_name => "Valim", :ok => true }
+    }, hash)
+  end
+
+  def test_camelcase_pretty_accessors
+    user = User.new
+    user.superuser = true
+    user_serializer = MyUserCamelizeSerializer.new(user)
+
+    hash = user_serializer.as_json
+
+    assert_equal({
+      :myUserCamelize => {
+        :firstName => "Jose", :lastName => "Valim", :superUser => true
+      }
+    }, hash)
+  end
+
 end

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -180,3 +180,41 @@ class Attachment < Model
     @attributes[:edible]
   end
 end
+
+class UserCamelcaseSerializer < ActiveModel::Serializer
+  include ActiveModel::Serializer::CamelizeKeys
+
+  attributes :first_name, :last_name
+
+  def serializable_hash
+    attributes.merge(:ok => true).merge(options[:scope])
+  end
+end
+
+class DefaultUserCamelcaseSerializer < ActiveModel::Serializer
+  include ActiveModel::Serializer::CamelizeKeys
+
+  attributes :first_name, :last_name
+end
+
+class UserAttributesWithSomeKeyCamelizeSerializer < ActiveModel::Serializer
+  include ActiveModel::Serializer::CamelizeKeys
+
+  attributes :first_name, :last_name => :l_name
+
+  def serializable_hash
+    attributes.merge(:ok => true).merge(options[:scope])
+  end
+end
+
+class MyUserCamelizeSerializer < ActiveModel::Serializer
+  include ActiveModel::Serializer::CamelizeKeys
+
+  attributes :first_name, :last_name
+
+  def serializable_hash
+    hash = attributes
+    hash = hash.merge(:superUser => true) if object.super_user?
+    hash
+  end
+end


### PR DESCRIPTION
Hi

I've added support for keys autocamelizer when using serializers (many js frameworks have name convention for model fields so server should provide keys that way), but treat this as not as finished work and more as an idea. The best realisation from my perspective is to provide dsl like this:

``` ruby
class SomeSerializer
  keys :camelize
```

or add opportunity to call any serializer method that will change keys

``` ruby
keys :my_inflector
```

What do you think, will it be useful? If yes, then I'll add support for it.
