### PR TITLE
Pass options through when using default serializer

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -83,7 +83,7 @@ module ActiveModel
           serializer = item.active_model_serializer
         end
 
-        serializable = serializer ? serializer.new(item, @options) : DefaultSerializer.new(item)
+        serializable = serializer ? serializer.new(item, @options) : DefaultSerializer.new(item, @options)
 
         if serializable.respond_to?(:serializable_hash)
           serializable.serializable_hash

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -504,7 +504,7 @@ module ActiveModel
     end
 
     def serializable_hash
-      @object.as_json
+      @object.as_json(@options)
     end
   end
 end


### PR DESCRIPTION
When a model has no serializer it uses DefaultSerializer. This class does not pass on the options given to it.

e.g. `respond_with model, include: [:other_model]` will not pass on the `:include` options
