### PR TITLE
Document inclusion of belongs_to ActiveRecord associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ development.**
 
 # Installing Serializers
 
-The easiest way to install `ActiveModel::Serializers` is to add it to your 
+The easiest way to install `ActiveModel::Serializers` is to add it to your
 `Gemfile`:
 
 ```ruby
@@ -407,6 +407,8 @@ You may also use the `:serializer` option to specify a custom serializer class a
   has_many :comments, :serializer => CommentShortSerializer
   has_one :reviewer, :polymorphic => true
 ```
+
+Serializers are only concerned with multiplicity, and not ownership. `belongs_to` ActiveRecord associations can be included using `has_one` in your serializer.
 
 ## Embedding Associations
 


### PR DESCRIPTION
With `has_many` and `has_one` tightly mirroring ActiveRecord's naming conventions, I think it can be [confusing](http://stackoverflow.com/questions/13125214/active-model-serializers-belongs-to) that there isn't a `belongs_to` method.

It could also be reasonable to alias `belongs_to` to `has_one`, but I don't see the point in creating new baggage.
