### PR TITLE
Fix failing tests for edge rails

### DIFF
--- a/test/generators_test.rb
+++ b/test/generators_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Foo < Rails::Application
-  if Rails.version.start_with? '4'
+  if Rails.version.to_s.start_with? '4'
     config.eager_load = false
     config.secret_key_base = 'abc123'
   end


### PR DESCRIPTION
- Edge Rails returns an instance of 'Gem::Version' for 'Rails.version' due to [#8501](https://github.com/rails/rails/issues/8501)
- Travis build was failing because of this as 'Rails.version.start_with? '4'' was giving 'undefined method' on 'Gem::Version' instance
