### PR TITLE
Add test demonstrating serializable_hash cache bug.

### DIFF
--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -22,6 +22,10 @@ class CachingTest < ActiveModel::TestCase
   end
 
   class Programmer
+    def active_model_serializer
+      ProgrammerSerializer
+    end
+
     def name
       'Adam'
     end
@@ -33,6 +37,112 @@ class CachingTest < ActiveModel::TestCase
     def read_attribute_for_serialization(name)
       send name
     end
+  end
+
+  class Library
+    attr_accessor :id, :name
+    alias :read_attribute_for_serialization :send
+    def active_model_serializer
+      LibrarySerializer
+    end
+  end
+
+  ##
+  # Serializers
+  class ProgrammerSerializer < ActiveModel::Serializer
+    cached true
+    attributes :name, :skills
+    has_many :libraries, embed: :ids, include: true
+
+    def self.to_s
+      'programmer_serializer'
+    end
+
+    def cache_key
+      object.name
+    end
+
+    def libraries
+      l = Library.new
+      l.id = 1
+      l.name = 'AMS'
+
+      l2 = Library.new
+      l2.id = 2
+      l2.name = 'RoR'
+
+      [l, l2]
+    end
+  end
+
+  class LibrarySerializer < ActiveModel::Serializer
+    cached true
+    attributes :id, :name
+
+    def self.to_s
+      'library_serializer'
+    end
+
+    def cache_key
+      object.name
+    end
+  end 
+
+  ##
+  # ArraySerializers
+  class ProgrammersSerializer < ActiveModel::ArraySerializer
+    cached true
+
+    def self.to_s
+      'array_serializer'
+    end
+
+    def cache_key
+      'cache-key'
+    end
+  end
+
+  def test_serializer_to_json_cache_after_array_serializer_cache_includes_associations
+    ProgrammersSerializer.cache = NullStore.new
+    ProgrammerSerializer.cache = ProgrammersSerializer.cache
+    LibrarySerializer.cache = ProgrammersSerializer.cache
+
+    programmer = Programmer.new
+    instance = ProgrammersSerializer.new [programmer], { root: "programmers" }
+
+    instance.to_json
+
+    assert JSON.parse(ProgrammersSerializer.cache.read('array_serializer/cache-key/to-json')).has_key?("libraries"), "JSON should include sideloaded Libraries"
+    assert_equal instance.to_json, ProgrammersSerializer.cache.read('array_serializer/cache-key/to-json')
+    assert_equal instance.serializable_array, ProgrammersSerializer.cache.read('array_serializer/cache-key/serializable-array')
+
+    # ArraySerializer _does not_ generate the to-json cache, only the 
+    # serialized-hash cache, so let's generate the to-json cache here where the
+    # serialized-hash cache already exists.
+    programmer_instance = ProgrammerSerializer.new programmer
+    programmer_instance.to_json
+
+    # The to-json cache here _will not_ include the associations in the cache 
+    # because when serializable_hash is cached, include_associations! isn't 
+    # called which populated @options[:hash] with the associations to sideload.
+    # Let's save what's cached here to compare with when an ArraySerializer 
+    # isn't the first to serialize a record.
+    programmer_cache_via_array = ProgrammersSerializer.cache.read("programmer_serializer/#{programmer.name}/to-json")
+
+    # Clear cache so we can load the record again directly, not via an
+    # ArraySerializer
+    # puts ProgrammersSerializer.cache.store
+    ProgrammersSerializer.cache.clear
+
+    programmer_instance = ProgrammerSerializer.new programmer
+    programmer_instance.to_json
+    # puts ProgrammersSerializer.cache.store
+
+    programmer_cache_via_direct = ProgrammersSerializer.cache.read("programmer_serializer/#{programmer.name}/to-json")
+
+    # These should be equal, but the programmer_cache_via_array is missing the 
+    # sideload associations.
+    assert_equal programmer_cache_via_direct, programmer_cache_via_array 
   end
 
   def test_serializers_have_a_cache_store
@@ -93,4 +203,5 @@ class CachingTest < ActiveModel::TestCase
     assert_equal instance.serializable_array, serializer.cache.read('array_serializer/cache-key/serializable-array')
     assert_equal instance.to_json, serializer.cache.read('array_serializer/cache-key/to-json')
   end
+
 end


### PR DESCRIPTION
When using caching, if an ArraySerializer generates the cache for an individual record subsequent calls to to_json for that record will not include sideloaded associations.

Let's dig in.

serializer.serializable_hash doesn't simply generate a hash, it has side effects. When sideloaded associations are involved it also populates @options[:hash] with the associations to sideload. 

This means you can't simply cache serializable_hash when associations to be sideloaded are involved since serializable_hash does more than just return a hash.

When serialized_hash is cached before to_json, as is the case when an individual Serializer is used via an ArraySerializer, @options[:hash] doesn't get populated when you subsequently call serializer.to_json since this will use the cached serializable_hash which doesn't populate the @options[:hash] with the data to be sideloaded.

Digging deeper it's the include! method that populates @options[:hash] which is called via serializer.include_associations! which is called via serializer._serializable_hash.
