### PR TITLE
Support for setting root element

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -304,7 +304,12 @@ module ActiveModel
       return false if self._root == false
       
       class_name = self.class.name.demodulize.underscore.sub(/_serializer$/, '').to_sym unless self.class.name.blank?
-      self._root || class_name
+
+      if self._root == true
+        class_name
+      else
+        self._root || class_name
+      end
     end
 
     def url_options

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -318,6 +318,16 @@ class SerializerTest < ActiveModel::TestCase
     assert_equal({ :author => nil }, serializer.new(blog, :scope => user).as_json)
   end
 
+  def test_true_root
+    blog = Blog.new
+
+    assert_equal({
+      :blog_with_root => {
+        :author => nil,
+      }
+    }, BlogWithRootSerializer.new(blog).as_json)
+  end
+
   def test_root_false_on_load_active_model_serializers
     begin
       ActiveSupport.on_load(:active_model_serializers) do

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -146,6 +146,10 @@ class BlogSerializer < ActiveModel::Serializer
   has_one :author, :serializer => AuthorSerializer
 end
 
+class BlogWithRootSerializer < BlogSerializer
+  root true
+end
+
 class CustomPostSerializer < ActiveModel::Serializer
   attributes :title
 end


### PR DESCRIPTION
This pull request solves this problem:

config/initializers/active_model_serializers.rb

``` ruby
ActiveSupport.on_load(:active_model_serializers) do
  ActiveModel::Serializer.root      = false
  ActiveModel::ArraySerializer.root = false
end
```

app/serializers/api/dispatcher/v1/panel_serializer.rb

``` ruby
class Api::Dispatcher::V1::PanelSerializer < ActiveModel::Serializer
  ...
end
```

app/serializers/api/frontend/v1/base_serializer.rb

``` ruby
class Api::Frontend::V1::BaseSerializer < ActiveModel::Serializer
  root true
  embed :ids
end
```

app/serializers/api/frontend/v1/panel_serializer.rb

``` ruby
class Api::Frontend::V1::PanelSerializer < Api::Frontend::V1::BaseSerializer
  ...
end
```

app/serializers/api/frontend/v1/tag_serializer.rb

``` ruby
class Api::Frontend::V1::TagSerializer < Api::Frontend::V1::BaseSerializer
  ...
end
```

``` ruby
Api::Dispatcher::V1::PanelSerializer.new(panel).as_json
=> { :id => 1, ... }

Api::Frontend::V1::PanelSerializer.new(panel).as_json
=> { :panel => { :id => 1, ... }}

Api::Frontend::V1::TagSerializer.new(tag).as_json
=> { :tag => { :id => 1, ... }}
```
