### PR TITLE
Support "unsymbolizable" strings as attribute names

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -451,7 +451,7 @@ module ActiveModel
         method << "  h = {}\n"
 
         _attributes.each do |name,key|
-          method << "  h[:#{key}] = read_attribute_for_serialization(:#{name}) if send #{INCLUDE_METHODS[name].inspect}\n"
+          method << "  h[:\"#{key}\"] = read_attribute_for_serialization(:\"#{name}\") if send #{INCLUDE_METHODS[name].inspect}\n"
         end
         method << "  h\nend"
 

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -51,6 +51,17 @@ class SerializerTest < ActiveModel::TestCase
     }, hash)
   end
 
+  def test_attributes_method_with_unsymbolizable_key
+    user = User.new
+    user_serializer = UserAttributesWithUnsymbolizableKeySerializer.new(user, :scope => {})
+
+    hash = user_serializer.as_json
+
+    assert_equal({
+      :user_attributes_with_unsymbolizable_key => { :first_name => "Jose", :"last-name" => "Valim", :ok => true }
+    }, hash)
+  end
+
   def test_attribute_method_with_name_as_serializer_prefix
     object = SomeObject.new("something")
     object_serializer = SomeSerializer.new(object, {})

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -70,6 +70,14 @@ class UserAttributesWithSomeKeySerializer < ActiveModel::Serializer
   end
 end
 
+class UserAttributesWithUnsymbolizableKeySerializer < ActiveModel::Serializer
+  attributes :first_name, :last_name => :"last-name"
+
+  def serializable_hash
+    attributes.merge(:ok => true).merge(options[:scope])
+  end
+end
+
 class DefaultUserSerializer < ActiveModel::Serializer
   attributes :first_name, :last_name
 end


### PR DESCRIPTION
When generating the `_fast_attributes` method, attribute names that could not be represented as symbols (at least without escaping) would throw parsing errors.

For instance:

``` ruby
user_id: :"user-id"
```

Throws an exception when serializing:

```
NoMethodError:
  undefined method `-' for :user:Symbol
```

Kinda bummed about the complexity in generating that `_fast_attributes` method. Is that for method caching fanciness?
