### PR TITLE
Fix serialization_scope to check for private/protected methods

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -33,7 +33,7 @@ module ActionController
     end
 
     def serialization_scope
-      send(_serialization_scope) if _serialization_scope && respond_to?(_serialization_scope)
+      send(_serialization_scope) if _serialization_scope && respond_to?(_serialization_scope, true)
     end
 
     def default_serializer_options


### PR DESCRIPTION
The semantics of `respond_to?` on Ruby 2.0 have changed to return `false` for protected methods, which is usually the case for helpers like `current_user`.

Since the scope is being loaded by `send`, it will access private/protected methods anyway.
