### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# unreleased
+# UNRELEASED
 
 * On Ruby 1.8, we now generate an `id` method that properly serializes `id`
   columns. See issue #127 for more.
@@ -10,11 +10,17 @@
 * Pass through serialization options (such as `:include`) when a model
   has no serializer defined.
 
-# VERSION 0.7
+# VERSION 0.7.0
 
+* ```embed_key``` option to allow embedding by attributes other than IDs
+* Fix rendering nil with custom serializer
+* Fix global ```self.root = false```
+* Add support for specifying the serializer for an association as a String
+* Able to specify keys on the attributes method
+* Serializer Reloading via ActiveSupport::DescendantsTracker
+* Reduce double map to once; Fixes datamapper eager loading.
 
-
-# VERSION 0.6
+# VERSION 0.6.0
 
 * Serialize sets properly
 * Add root option to ArraySerializer
@@ -25,7 +31,7 @@
 * Allow serialization_scope to be disabled with serialization_scope nil
 * Array serializer should support pure ruby objects besides serializers
 
-# VERSION 0.5 (May 16, 2012)
+# VERSION 0.5.0 (May 16, 2012)
 
 * First tagged version
 * Changes generators to always generate an ApplicationSerializer


### PR DESCRIPTION
Make it more consistent.
I've added some PR titles to 0.7, I'm not sure it's 100% comprehensive like this :(
The version numbers must match rubygems versions, I fixed it here.
Thanks
