### PR TITLE
Unify way of calling include_attribute? in attibutes and association methods

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -103,10 +103,10 @@ module ActiveModel
         define_include_method attr
 
         # protect inheritance chains and open classes
-        # if a serializer inherits from another OR 
+        # if a serializer inherits from another OR
         #  attributes are added later in a classes lifecycle
         # poison the cache
-        define_method :_fast_attributes do 
+        define_method :_fast_attributes do
           raise NameError
         end
 
@@ -302,7 +302,7 @@ module ActiveModel
 
     def root_name
       return false if self._root == false
-      
+
       class_name = self.class.name.demodulize.underscore.sub(/_serializer$/, '').to_sym unless self.class.name.blank?
       self._root || class_name
     end
@@ -451,7 +451,7 @@ module ActiveModel
         method << "  h = {}\n"
 
         _attributes.each do |name,key|
-          method << "  h[:\"#{key}\"] = read_attribute_for_serialization(:\"#{name}\") if send #{INCLUDE_METHODS[name].inspect}\n"
+          method << "  h[:\"#{key}\"] = read_attribute_for_serialization(:\"#{name}\") if include?(:\"#{name}\")\n"
         end
         method << "  h\nend"
 


### PR DESCRIPTION
There is defined method for that: https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer.rb#L365

which already is used in: https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer.rb#L359
