### PR TITLE
allow singular embed when serializing association

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -72,11 +72,11 @@ module ActiveModel
         end
 
         def embed_ids?
-          option(:embed, source_serializer._embed) == :ids
+          [:id, :ids].include? option(:embed, source_serializer._embed)
         end
 
         def embed_objects?
-          option(:embed, source_serializer._embed) == :objects
+          [:object, :objects].include? option(:embed, source_serializer._embed)
         end
 
         def embed_in_root?


### PR DESCRIPTION
Having

``` ruby
has_one :post, embed: :ids
```

looks especially weird as it's a one-to-one association, hence there is only one id. The following looks better:

``` ruby
has_one :post, embed: :id
```
