### PR TITLE
Allow serializers to implement options

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -368,8 +368,8 @@ module ActiveModel
     end
 
     def include?(name)
-      return false if options.key?(:only) && !Array(options[:only]).include?(name)
-      return false if options.key?(:except) && Array(options[:except]).include?(name)
+      return false if @options.key?(:only) && !Array(@options[:only]).include?(name)
+      return false if @options.key?(:except) && Array(@options[:except]).include?(name)
       send INCLUDE_METHODS[name]
     end
 


### PR DESCRIPTION
Serializer defines attr_reader for options and object, all internal access is via @object and @options (except this spot). 

For a future version I wonder if we should not be parking these attr_readers or using something like __options and __object so there is less confusion and chance for error
