### PR TITLE
Bump minor version specified in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The easiest way to install `ActiveModel::Serializers` is to add it to your
 `Gemfile`:
 
 ```ruby
-gem "active_model_serializers", "~> 0.7.0"
+gem "active_model_serializers", "~> 0.8.0"
 ```
 
 Then, install it on the command line:


### PR DESCRIPTION
Just noticed the version for the Gemfile line in the `README` was out of date after the recent `0.8.x` releases.
