### PR TITLE
ActiveModel Serializers support for serialization of a model embedded in a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,56 @@ serializer when you render the object:
 render json: @post, serializer: FancyPostSerializer
 ```
 
+To render an object embedded in a hash, you can simply render the hash, and
+Rails will search for a serializer for the embedded object and use it if available.
+
+```ruby
+render json: {data: @post, platform: 'mobile', format: 'json'}
+```
+
+Given the example above, the output is as follows
+
+```json
+{
+  "data":{"id":1,"title":"post1","body":"body1"},
+  "platform": "mobile",
+  "format": "json"
+}
+```
+
+This will work even if the hash contains multiple objects with serializers.
+
+```ruby
+render json: {post: @post, related_post: @related_post}
+```
+
+This yields the following output
+
+```json
+{
+  "post":{"id":1,"title":"post1","body":"body1"},
+  "related_post":{"id":2,"title":"post2","body":"body2"}
+}
+```
+
+A root may be added to the rendered hash
+
+```ruby
+render json: {post: @post, related_post: @related_post}, root: "some_posts"
+```
+
+Here is the output with a root specified
+
+```json
+{
+  "some_posts":
+    {
+      "post":{"id":1,"title":"post1","body":"body1"},
+      "related_post":{"id":2,"title":"post2","body":"body2"}
+    }
+}
+```
+
 ## Arrays
 
 In your controllers, when you use `render :json` for an array of objects, AMS will

--- a/lib/active_model/hash_serializer.rb
+++ b/lib/active_model/hash_serializer.rb
@@ -1,0 +1,38 @@
+require 'active_model/default_serializer'
+require 'active_model/serializable'
+require 'active_model/serializer'
+
+module ActiveModel
+  class HashSerializer
+    include Serializable
+
+    class << self
+      attr_accessor :_root
+      alias root  _root=
+      alias root= _root=
+    end
+
+    def initialize(object, options={})
+      @object          = object
+      @root            = options[:root]
+      @root            = self.class._root if @root.nil?
+      @root            = options[:resource_name] if @root.nil?
+      @meta_key        = options[:meta_key] || :meta
+      @meta            = options[@meta_key]
+      @value_serializer = options[:value_serializer]
+      @options         = options.merge(root: nil)
+    end
+    attr_accessor :object, :root, :meta_key, :meta
+
+    def serializable_hash
+      @object.inject({}) do |output, key_value_pair|
+        key = key_value_pair.first
+        item = key_value_pair.last
+        serializer = @value_serializer || Serializer.serializer_for(item) || DefaultSerializer
+        new_item = serializer.new(item, @options).serializable_object
+        output.merge(key => new_item)
+      end
+    end
+    alias serializable_object serializable_hash
+  end
+end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -1,4 +1,5 @@
 require 'active_model/array_serializer'
+require 'active_model/hash_serializer'
 require 'active_model/serializable'
 require 'active_model/serializer/associations'
 require 'active_model/serializer/config'
@@ -41,6 +42,8 @@ end
         def serializer_for(resource)
           if resource.respond_to?(:to_ary)
             ArraySerializer
+          elsif resource.respond_to?(:has_key?)
+            HashSerializer
           else
             begin
               Object.const_get "#{resource.class.name}Serializer"
@@ -53,6 +56,8 @@ end
         def serializer_for(resource)
           if resource.respond_to?(:to_ary)
             ArraySerializer
+          elsif resource.respond_to?(:has_key?)
+            HashSerializer
           else
             "#{resource.class.name}Serializer".safe_constantize
           end

--- a/test/integration/action_controller/serialization_test.rb
+++ b/test/integration/action_controller/serialization_test.rb
@@ -193,5 +193,21 @@ module ActionController
         assert_equal '{"my":[{"name":"Name 1","description":"Description 1"}]}', @response.body
       end
     end
+
+    class HashSerializerTest < ActionController::TestCase
+      class MyController < ActionController::Base
+        def render_hash
+          render json: {data: Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }), platform: 'mobile', format: 'json'}
+        end
+      end
+
+      tests MyController
+
+      def test_render_array
+        get :render_hash
+        assert_equal 'application/json', @response.content_type
+        assert_equal '{"data":{"name":"Name 1","description":"Description 1"},"platform":"mobile","format":"json"}', @response.body
+      end
+    end
   end
 end

--- a/test/unit/active_model/hash_serializer/meta_test.rb
+++ b/test/unit/active_model/hash_serializer/meta_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+require 'active_model/serializer'
+
+module ActiveModel
+  class HashSerializer
+    class MetaTest < ActiveModel::TestCase
+      def setup
+        @profile1 = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+        @profile2 = Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })
+        @serializer = HashSerializer.new({profile1: @profile1, profile2: @profile2}, root: 'profiles')
+      end
+
+      def test_meta
+        @serializer.meta = { total: 10 }
+
+        assert_equal({
+          "profiles" => {
+            profile1:
+              {
+                name: 'Name 1',
+                description: 'Description 1'
+              },
+            profile2:
+              {
+                name: 'Name 2',
+                description: 'Description 2'
+              }
+          },
+          meta: {
+            total: 10
+          }
+        }, @serializer.as_json)
+      end
+
+      def test_meta_using_meta_key
+        @serializer.meta_key = :my_meta
+        @serializer.meta     = { total: 10 }
+
+        assert_equal({
+           "profiles" => {
+             profile1:
+               {
+                 name: 'Name 1',
+                 description: 'Description 1'
+               },
+             profile2:
+               {
+                 name: 'Name 2',
+                 description: 'Description 2'
+               }
+           },
+           my_meta: {
+             total: 10
+           }
+         }, @serializer.as_json)
+      end
+    end
+  end
+end

--- a/test/unit/active_model/hash_serializer/root_test.rb
+++ b/test/unit/active_model/hash_serializer/root_test.rb
@@ -1,0 +1,102 @@
+require 'test_helper'
+
+module ActiveModel
+  class HashSerializer
+    class RootAsOptionTest < ActiveModel::TestCase
+      def setup
+        @old_root = HashSerializer._root
+        @profile1 = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+        @profile2 = Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })
+        @serializer = HashSerializer.new({profile1: @profile1, profile2: @profile2}, root: :initialize)
+      end
+
+      def teardown
+        HashSerializer._root = @old_root
+      end
+
+      def test_root_is_not_displayed_using_serializable_hash
+        assert_equal({
+          profile1: { name: 'Name 1', description: 'Description 1' },
+          profile2: { name: 'Name 2', description: 'Description 2' }
+        }, @serializer.serializable_hash)
+      end
+
+      def test_root_using_as_json
+        assert_equal({
+          initialize: {
+            profile1: { name: 'Name 1', description: 'Description 1' },
+            profile2: { name: 'Name 2', description: 'Description 2' }
+          }
+        }, @serializer.as_json)
+      end
+
+      def test_root_as_argument_takes_precedence
+        assert_equal({
+          argument: {
+            profile1: { name: 'Name 1', description: 'Description 1' },
+            profile2: { name: 'Name 2', description: 'Description 2' }
+          }
+        }, @serializer.as_json(root: :argument))
+      end
+
+      def test_using_false_root_in_initialize_takes_precedence
+        HashSerializer._root = 'root'
+        @serializer = HashSerializer.new({profile1: @profile1, profile2: @profile2}, root: false)
+
+        assert_equal({
+          profile1: { name: 'Name 1', description: 'Description 1' },
+          profile2: { name: 'Name 2', description: 'Description 2' }
+        }, @serializer.as_json)
+      end
+    end
+
+    class RootInSerializerTest < ActiveModel::TestCase
+      def setup
+        @old_root = HashSerializer._root
+        HashSerializer._root = :in_serializer
+        @profile1 = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+        @profile2 = Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })
+        @serializer = HashSerializer.new({profile1: @profile1, profile2: @profile2})
+        @rooted_serializer = HashSerializer.new({profile1: @profile1, profile2: @profile2}, root: :initialize)
+      end
+
+      def teardown
+        HashSerializer._root = @old_root
+      end
+
+      def test_root_is_not_displayed_using_serializable_hash
+        assert_equal({
+          profile1: { name: 'Name 1', description: 'Description 1' },
+          profile2: { name: 'Name 2', description: 'Description 2' }
+        }, @serializer.serializable_hash)
+      end
+
+      def test_root_using_as_json
+        assert_equal({
+          in_serializer: {
+            profile1: { name: 'Name 1', description: 'Description 1' },
+            profile2: { name: 'Name 2', description: 'Description 2' }
+          }
+        }, @serializer.as_json)
+      end
+
+      def test_root_in_initializer_takes_precedence
+        assert_equal({
+          initialize: {
+            profile1: { name: 'Name 1', description: 'Description 1' },
+            profile2: { name: 'Name 2', description: 'Description 2' }
+          }
+        }, @rooted_serializer.as_json)
+      end
+
+      def test_root_as_argument_takes_precedence
+        assert_equal({
+          argument: {
+            profile1: { name: 'Name 1', description: 'Description 1' },
+            profile2: { name: 'Name 2', description: 'Description 2' }
+          }
+        }, @rooted_serializer.as_json(root: :argument))
+      end
+    end
+  end
+end

--- a/test/unit/active_model/hash_serializer/scope_test.rb
+++ b/test/unit/active_model/hash_serializer/scope_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module ActiveModel
+  class HashSerializer
+    class ScopeTest < ActiveModel::TestCase
+      def test_hash_serializer_pass_options_to_items_serializers
+        hash = {profile1: Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+                profile2: Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })}
+        serializer = HashSerializer.new(hash, scope: current_user)
+
+        expected = {profile1: { name: 'Name 1', description: 'Description 1 - user' },
+                    profile2: { name: 'Name 2', description: 'Description 2 - user' }}
+
+        assert_equal expected, serializer.serializable_hash
+      end
+
+      private
+
+      def current_user
+        'user'
+      end
+    end
+  end
+end

--- a/test/unit/active_model/hash_serializer/serialize_test.rb
+++ b/test/unit/active_model/hash_serializer/serialize_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+module ActiveModel
+  class HashSerializer
+    class SerializeTest < ActiveModel::TestCase
+      def setup
+        hash = {one: 1, two: 2, three: 3}
+        @serializer = ActiveModel::Serializer.serializer_for(hash).new(hash)
+      end
+
+      def test_serializer_for_hash_returns_appropriate_type
+        assert_kind_of HashSerializer, @serializer
+      end
+
+      def test_hash_serializer_serializes_simple_objects
+        assert_equal({one: 1, two: 2, three: 3}, @serializer.serializable_hash)
+        assert_equal({one: 1, two: 2, three: 3}, @serializer.as_json)
+      end
+
+      def test_hash_serializer_serializes_models
+        hash = {profile1: Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+                profile2: Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })}
+        serializer = HashSerializer.new(hash)
+
+        expected = {profile1: { name: 'Name 1', description: 'Description 1' },
+                    profile2: { name: 'Name 2', description: 'Description 2' }}
+
+        assert_equal expected, serializer.serializable_hash
+        assert_equal expected, serializer.as_json
+      end
+
+      def test_hash_serializers_value_serializer
+        hash = {model1: ::Model.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+                model2: ::Model.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })}
+        serializer = HashSerializer.new(hash, value_serializer: ProfileSerializer)
+
+        expected = {model1: { name: 'Name 1', description: 'Description 1' },
+                    model2: { name: 'Name 2', description: 'Description 2' }}
+
+        assert_equal expected, serializer.serializable_hash
+        assert_equal expected, serializer.as_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
Covered the ActiveRecord::SerializerOverride module with a test, and added documentation for when it is useful as I encountered a problem recently with a client that has a lot of legacy code triggering json serialization for a model nested within a hash directly from controller actions, and we could not simply refactor the model to rely on active model serializers without going and changing all the controller actions because the actions were rendering the json of a hash that contained the model within instead of the model directly. 

Here is the documentation describing the problem included with the code change:
## Serialization of a hash containing a nested (embedded) model

There is a mixin that overrides ActiveRecord::Base#to_json and #as_json to enable
serialization via ActiveModel Serializers. We do not recommend that you use ActiveModel
Serializers in this way in general, but there is one exception. That is when a legacy
app's controller actions for example are rendering json for a model nested within a hash
(e.g. {param1 => value1, param2 => model}), which will not trigger ActiveModel Serializers
for the nested model by default, yet instead rely on normal to_json serialization.
To get around this problem, you can require the file 'active_record/serializer_override'
and include the module ActiveRecord::SerializerOverride, which will override the to_json
and as_json methods of the model to rely on ActiveModel Serializers instead.

Example:

In controller actions of a legacy app, there is a lot of this:

``` ruby
render :json => {param1 => value1, params2 => value2, data => model}
```

Add an initializer file: "config/initializers/active_model_serializers.rb"

with this content:

``` ruby
require 'active_record/serializer_override'
ActiveRecord::Base.send(:include, ActiveRecord::SerializerOverride)
```

or to override to_json and as_json for one model class only:

``` ruby
require 'active_record/serializer_override'
ActiveRecord::Base.send(:include, ActiveRecordModel)
```
