### PR TITLE
Clarify disabling root for ArraySerializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ In an initializer:
 
 ```ruby
 ActiveSupport.on_load(:active_model_serializers) do
-  # Disabled for all serializers
+  # Disable for all serializers (except ArraySerializer)
   ActiveModel::Serializer.root = false
   
-  # Or just for the ArraySerializer
-  # ActiveModel::ArraySerializer.root = false
+  # Disable for ArraySerializer
+  ActiveModel::ArraySerializer.root = false
 end
 ```
 


### PR DESCRIPTION
Setting `AMS::Serializer.root = false` doesn't automatically disable root for the `ArraySerializer` as well.
