### PR TITLE
Allow a controller to properly override scope_name

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -284,7 +284,7 @@ module ActiveModel
         end
 
         options[:scope] = controller.serialization_scope unless options.has_key?(:scope)
-        options[:scope_name] = controller._serialization_scope
+        options[:scope_name] = controller._serialization_scope unless options.has_key?(:scope_name)
         options[:url_options] = controller.url_options
 
         serializer.new(resource, options)


### PR DESCRIPTION
Currently the documentation states that you can override the default controller scope and scope name on a per action basis however the scope_name being passed in to override the default is not being used.

This pull request allows you to provide a scope_name and have it carry over into the serializers used.

Example usage taken from README.

``` ruby
class CitiesController < ApplicationController
  serialization_scope nil

  def index
    @cities = City.all

    render :json => @cities, :each_serializer => CitySerializer
  end

  def show
    @city = City.find(params[:id])

    render :json => @city, :scope => current_admin, :scope_name => :current_admin
  end
end
```
