### PR TITLE
Cache Serializer#attributes instead of #serializable_hash

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -352,13 +352,10 @@ module ActiveModel
     # Returns a hash representation of the serializable
     # object without the root.
     def serializable_hash
-      if perform_caching?
-        cache.fetch expand_cache_key([self.class.to_s.underscore, cache_key, 'serializable-hash']) do
-          _serializable_hash
-        end
-      else
-        _serializable_hash
-      end
+      return nil if @object.nil?
+      @node = attributes
+      include_associations! if _embed
+      @node
     end
 
     def include_associations!
@@ -451,6 +448,16 @@ module ActiveModel
     # Returns a hash representation of the serializable
     # object attributes.
     def attributes
+      if perform_caching?
+        cache.fetch expand_cache_key([self.class.to_s.underscore, cache_key, 'attributes']) do
+          _serializable_attributes
+        end
+      else
+        _serializable_attributes
+      end
+    end
+
+    def _serializable_attributes
       _fast_attributes
       rescue NameError
         method = "def _fast_attributes\n"
@@ -472,13 +479,6 @@ module ActiveModel
     end
 
     alias :read_attribute_for_serialization :send
-
-    def _serializable_hash
-      return nil if @object.nil?
-      @node = attributes
-      include_associations! if _embed
-      @node
-    end
 
     def perform_caching?
       perform_caching && cache && respond_to?(:cache_key)

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -68,7 +68,7 @@ class CachingTest < ActiveModel::TestCase
 
     instance.to_json
 
-    assert_equal(instance.serializable_hash, serializer.cache.read('serializer/Adam/serializable-hash'))
+    assert_equal(instance.attributes, serializer.cache.read('serializer/Adam/attributes'))
     assert_equal(instance.to_json, serializer.cache.read('serializer/Adam/to-json'))
   end
 


### PR DESCRIPTION
This attempts to fix the caching bug described in rails-api/active_model_serializers#262.

The #serializable_hash method is not safe to cache because it has the side-effect of calling #include_associations!. Subsequent cache hits will fail to include the associated records.

This PR moves the caching down to the #attributes method. It does not change the caching on #to_json.

The failing test in #262 passes with this change.
