### PR TITLE
Don't wrap array items in root element

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -53,7 +53,7 @@ module ActiveModel
           serializer = DefaultSerializer
         end
 
-        serializable = serializer.new(item, options)
+        serializable = serializer.new(item, options.merge(:root => nil))
 
         if serializable.respond_to?(:serializable_hash)
           serializable.serializable_hash

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -31,6 +31,20 @@ class ArraySerializerTest < ActiveModel::TestCase
     ]}, serializer.as_json)
   end
 
+  def test_active_model_with_root
+    comment1 = ModelWithActiveModelSerializer.new(:title => "Comment1")
+    comment2 = ModelWithActiveModelSerializer.new(:title => "Comment2")
+
+    array = [ comment1, comment2 ]
+
+    serializer = array.active_model_serializer.new(array, :root => :comments)
+
+    assert_equal({ :comments => [
+      { :title => "Comment1" },
+      { :title => "Comment2" }
+    ]}, serializer.as_json)
+  end
+
   def test_array_serializer_with_hash
     hash = {:value => "something"}
     array = [hash]

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -12,6 +12,14 @@ class Model
   end
 end
 
+class ModelWithActiveModelSerializer < Model
+  include ActiveModel::Serializers::JSON
+  attr_accessor :attributes
+  def read_attribute_for_serialization(name)
+    @attributes[name]
+  end
+end
+
 class User
   include ActiveModel::SerializerSupport
 


### PR DESCRIPTION
When serializing an array with a root element, the root option is passed down to the items. If an item's serializer supports this option, it will be again wrapped in the root element. Instead of

```
{ "root": [{ "item_id" : 1 }] }
```

we get 

```
{ "root": [{ "root" : { "item_id" : 1 } }] }
```

This is fixed by omitting the root option when we instantiate the item's serializer.
