### PR TITLE
Test for symbolizing :root key

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -112,7 +112,7 @@ module ActiveModel
 
         def root
           if root = options[:root]
-            root
+            root.to_sym
           elsif polymorphic?
             object.class.to_s.pluralize.demodulize.underscore.to_sym
           else


### PR DESCRIPTION
Ensure that a `String` or `Symbol` can use with `:root`.
