### PR TITLE
Refactor to decouple controller mixin from AM::Serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -257,38 +257,6 @@ module ActiveModel
       end
       alias_method :root=, :root
 
-      # Used internally to create a new serializer object based on controller
-      # settings and options for a given resource. These settings are typically
-      # set during the request lifecycle or by the controller class, and should
-      # not be manually defined for this method.
-      def build_json(controller, resource, options)
-        default_options = controller.send(:default_serializer_options) || {}
-        options = default_options.merge(options || {})
-
-        serializer = options.delete(:serializer) ||
-          (resource.respond_to?(:active_model_serializer) &&
-           resource.active_model_serializer)
-
-        return serializer unless serializer
-
-        if resource.respond_to?(:to_ary)
-          unless serializer <= ActiveModel::ArraySerializer
-            raise ArgumentError.new("#{serializer.name} is not an ArraySerializer. " +
-                                    "You may want to use the :each_serializer option instead.")
-          end
-
-          if options[:root] != false && serializer.root != false
-            # the serializer for an Array is ActiveModel::ArraySerializer
-            options[:root] ||= serializer.root || controller.controller_name
-          end
-        end
-
-        options[:scope] = controller.serialization_scope unless options.has_key?(:scope)
-        options[:scope_name] = controller._serialization_scope unless options.has_key?(:scope_name)
-        options[:url_options] = controller.url_options
-
-        serializer.new(resource, options)
-      end
     end
 
     attr_reader :object, :options


### PR DESCRIPTION
Since `AM::Serializer.build_json` is highly dependent on the controller it should be a helper function of the controller. Functionality hasn't changed.

Eventually it would be great to unify the usage of the root attribute for arrays and single objects to get rid of the awkward lines 61-65.
