### PR TITLE
Use minitest/autorun

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,7 @@ require "pry"
 
 require "active_model_serializers"
 require "active_support/json"
-require "test/unit"
+require "minitest/autorun"
 
 require 'rails'
 


### PR DESCRIPTION
Allow builds to test against the edge Gemfile by using minitest/autorun instead of requiring test/unit now that Ruby 1.8.2 is no longer supported.
