### PR TITLE
Routes helpers available inside ArraySerializer

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -39,6 +39,10 @@ module ActiveModel
       @options = options
     end
 
+    def url_options
+      @options[:url_options] || {}
+    end
+
     def serialize_object
       serializable_array
     end

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -22,6 +22,12 @@ if defined?(Rails)
           extend ::AbstractController::Railties::RoutesHelpers.with(app.routes)
           include app.routes.mounted_helpers
         end
+
+        ActiveSupport.on_load(:active_model_array_serializers) do
+          include AbstractController::UrlFor
+          extend ::AbstractController::Railties::RoutesHelpers.with(app.routes)
+          include app.routes.mounted_helpers
+        end
       end
 
       initializer "caching.active_model_serializer" do |app|
@@ -93,3 +99,4 @@ rescue LoadError => ex
 end
 
 ActiveSupport.run_load_hooks(:active_model_serializers, ActiveModel::Serializer)
+ActiveSupport.run_load_hooks(:active_model_array_serializers, ActiveModel::ArraySerializer)

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -82,4 +82,27 @@ class ArraySerializerTest < ActiveModel::TestCase
       { "value" => "something" }
     ], serializer.as_json)
   end
+
+  def test_active_support_on_load_hooks_fired
+    loaded = nil
+    ActiveSupport.on_load(:active_model_array_serializers) do
+      loaded = self
+    end
+    assert_equal ActiveModel::ArraySerializer, loaded
+  end
+
+  def test_serializer_receives_url_options
+    array = []
+    options = {url_options: { host: "test.local" }}
+    serializer = array.active_model_serializer.new(array, options)
+
+    assert_equal({ host: "test.local" }, serializer.url_options)
+  end
+
+  def test_serializer_returns_empty_hash_without_url_options
+    array = []
+    serializer = array.active_model_serializer.new array
+
+    assert_equal({}, serializer.url_options)
+  end
 end


### PR DESCRIPTION
I'm trying to do something like this:

``` ruby
class TasksSerializer < ActiveModel::ArraySerializer

  self.root = false

  def as_json(*args)
    {
      _results: super,
      _links: links
    }
  end

  def links
    {
      tasks: tasks_url
    }
  end
end
```

So I need to use the route helper `tasks_url`.

I'm not sure what is the best way to implement that, but here is my suggestion.
