### PR TITLE
Respect global caching configuration

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -24,13 +24,12 @@ module ActiveModel
 
     class_attribute :root
 
-    class_attribute :cache
-    class_attribute :perform_caching
+    class_attribute :cache_enabled
+    self.cache_enabled = false
 
     class << self
-      # set perform caching like root
       def cached(value = true)
-        self.perform_caching = value
+        self.cache_enabled = value
       end
     end
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -71,12 +71,12 @@ module ActiveModel
     self._embed = :objects
     class_attribute :_root_embed
 
-    class_attribute :cache
-    class_attribute :perform_caching
+    class_attribute :cache_enabled
+    self.cache_enabled = false
 
     class << self
       def cached(value = true)
-        self.perform_caching = value
+        self.cache_enabled = value
       end
 
       # Define attributes to be used in the serialization.

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -1,10 +1,15 @@
+require "active_support/core_ext/module/attribute_accessors"
+
 module ActiveModel
   class Serializer
     module Caching
+      mattr_accessor :perform_caching
+      mattr_accessor :cache_store
+
       def to_json(*args)
         if caching_enabled?
           key = expand_cache_key([self.class.to_s.underscore, cache_key, 'to-json'])
-          cache.fetch key do
+          cache_store.fetch key do
             super
           end
         else
@@ -15,7 +20,7 @@ module ActiveModel
       def serialize(*args)
         if caching_enabled?
           key = expand_cache_key([self.class.to_s.underscore, cache_key, 'serialize'])
-          cache.fetch key do
+          cache_store.fetch key do
             serialize_object
           end
         else
@@ -26,7 +31,11 @@ module ActiveModel
       private
 
       def caching_enabled?
-        perform_caching && cache && respond_to?(:cache_key)
+        cache_configured? && cache_enabled && respond_to?(:cache_key)
+      end
+
+      def cache_configured?
+        perform_caching && cache_store
       end
 
       def expand_cache_key(*args)

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -25,11 +25,8 @@ if defined?(Rails)
       end
 
       initializer "caching.active_model_serializer" do |app|
-        ActiveModel::Serializer.perform_caching = app.config.action_controller.perform_caching
-        ActiveModel::ArraySerializer.perform_caching = app.config.action_controller.perform_caching
-
-        ActiveModel::Serializer.cache = Rails.cache
-        ActiveModel::ArraySerializer.cache = Rails.cache
+        ActiveModel::Serializer::Caching.perform_caching = app.config.action_controller.perform_caching
+        ActiveModel::Serializer::Caching.cache_store = Rails.cache
       end
     end
   end


### PR DESCRIPTION
This pull request fixes a bug with the caching feature (that's really only documented in its [initial pull request](https://github.com/rails-api/active_model_serializers/pull/89)).

According to the [docs for ActionController::Caching](http://api.rubyonrails.org/classes/ActionController/Caching.html):

> Note: To turn off all caching, set
> 
> ```
> config.action_controller.perform_caching = false
> ```

Currently, the caching feature does not respect this setting, and additionally overrides it leading to some odd behavior.
### Issue in Dev and Test Environments

Default `config/environments/development.rb` and `config/environments/test.rb` both have:

```
config.action_controller.perform_caching = false
```

This makes sense.  However, with this serializer:

``` ruby
class PostSerializer < ActiveModel::Serializer
    cached

    attributes :id, :title, :body

    def cache_key
      object.cache_key
    end
end
```

_Caching occurs in dev and test._  It shouldn't.
### Issue in Production Environments

Default `config/environments/production.rb`:

```
config.action_controller.perform_caching = true
```

With _this_ serializer:

``` ruby
class PostSerializer < ActiveModel::Serializer
    # cached

    attributes :id, :title, :body

    def cache_key
      object.cache_key
    end
end
```

_i.e._, caching explicitly turned **OFF** (but with a left-behind `cache_key` definition), it _gets cached in production_.  It shouldn't.
### The Fix

The original implementation conflated the global configuration to enable caching with the per-serializer enabling of caching.  This pull request bubbles the configuration concepts (whether caching is globally enabled (`perform_caching`), and whether a cache store is present (`cache_store`)) up to the `Caching` module, and adds a new per-serializer cache-enabling attribute to the `Serializer` and `ArraySerializer` classes (`cache_enabled`) to keep them independent of the `perform_caching` config value.

Tests have been added as well.
#### A brief aside on naming:
- `cache` was renamed to `cache_store` to decrease ambiguity.  The former is mighty generic, and can be read as a verb or a noun.  The latter is much more clearly a noun/object.  This also jibes better with the language used within the Rails codebase.
- `perform_caching` and `cache_enabled` are the closest I could get to accurately describing what they do.  To be _more_ accurate, they should probably be flip-flopped for what each indicates, but `perform_caching` comes from Rails config itself, so we should probably stick with the same language.
