### PR TITLE
Add docs about caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,3 +675,21 @@ Assuming that the `current_admin` method needs to make a query in the database
 for the current user, the advantage of this approach is that, by setting
 `serialization_scope` to `nil`, the `index` action no longer will need to make
 that query, only the `show` action will.
+
+## Caching
+
+To cache a serializer, call `cached` and define a `cache_key` method:
+
+```ruby
+class PostSerializer < ActiveModel::Serializer
+  cached  # enables caching for this serializer
+
+  attributes :title, :body
+
+  def cache_key
+    [object, current_user]
+  end
+end
+```
+
+The caching interface uses `Rails.cache` under the hood.


### PR DESCRIPTION
Re: https://github.com/rails-api/active_model_serializers/pull/89, https://github.com/rails-api/active_model_serializers/issues/302, and https://github.com/rails-api/active_model_serializers/pull/343

This feature has been in for months, and is being used in production (by us, at least!).  It should really probably be documented.  I was initially unaware that a `cache_key` method was mandatory (not just falling back to `object.cache_key`), and some docs would have saved me a lot of time.
