### PR TITLE
Sideload root only

### DIFF
--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -1558,14 +1558,11 @@ class SerializerTest < ActiveModel::TestCase
       end
     end
 
-    post_serializer = post_serializer_class.new post1, root: :post
+    post_serializer = post_serializer_class.new post1, root: :post, include_root_only: true
     hash = post_serializer.as_json
 
-    assert_equal 1, hash.fetch(:posts).length
-
     assert_equal({
-      post: { id: 1, title: 'Post1', author_id: 1 },
-      posts: [{ id: 1, title: 'Post1', author_id: 1 }],
+      post: { id: 1, title: 'Post 1', author_id: 1 },
       authors: [{ id: 1, name: 'Adam Hawkins', post_ids: [1,2] }]
     }, hash)
   end


### PR DESCRIPTION
Give an option to include associations from the initializer serializer only. This is good when you need to serializer many objects that are all related, but don't want to include the entire graph.

I wonder if this should be on by default. All serializers sideloading everything is path for serious performance problems.
