### PR TITLE
[feature] Flatten polymorphic id on has_one associations

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -389,6 +389,11 @@ module ActiveModel
         elsif association.embed_in_root? && association.embeddable?
           merge_association hash, association.root, association.serializables, unique_values
         end
+
+        if options[:flatten]
+          node[association.type_key] = association.send(:polymorphic_key)
+        end
+
       elsif association.embed_objects?
         node[association.key] = association.serialize
       end

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -108,6 +108,11 @@ module ActiveModel
         def initialize(name, options={}, serializer_options={})
           super
           @polymorphic = options[:polymorphic]
+          @flatten = options[:flatten]
+        end
+
+        def key
+          (flatten? and polymorphic?) ? id_key : super
         end
 
         def root
@@ -122,6 +127,10 @@ module ActiveModel
 
         def id_key
           "#{name}_id".to_sym
+        end
+
+        def type_key
+          "#{name}_type".to_sym
         end
 
         def embeddable?
@@ -156,7 +165,7 @@ module ActiveModel
                 object.read_attribute_for_serialization(embed_key)
               end
 
-            if polymorphic?
+            if polymorphic? and not flatten?
               {
                 type: polymorphic_key,
                 id: id
@@ -169,8 +178,9 @@ module ActiveModel
 
         private
 
-        attr_reader :polymorphic
+        attr_reader :polymorphic, :flatten
         alias polymorphic? polymorphic
+        alias flatten? flatten
 
         def use_id_key?
           embed_ids? && !polymorphic?


### PR DESCRIPTION
Specify the association like this:

``` ruby
class MessageSerializer
    attributes :content
    has_one :attachment, polymorphic: true, flatten: true
end
```

Get the JSON value like this.

``` json
{
    "id" : 1,
    "content" : "hello",
    "attachment_id" : 1,
    "attachment_type" : "link"
}
```
