### PR TITLE
Break up serializer to serializable_hash mapping

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -44,6 +44,16 @@ module ActiveModel
     end
 
     def serializable_array
+      serializers_array.map do |serializable|
+        if serializable.respond_to?(:serializable_hash)
+          serializable.serializable_hash
+        else
+          serializable.as_json
+        end
+      end
+    end
+
+    def serializers_array
       object.map do |item|
         if options.has_key? :each_serializer
           serializer = options[:each_serializer]
@@ -52,13 +62,7 @@ module ActiveModel
         end
         serializer ||= DefaultSerializer
 
-        serializable = serializer.new(item, options.merge(root: nil))
-
-        if serializable.respond_to?(:serializable_hash)
-          serializable.serializable_hash
-        else
-          serializable.as_json
-        end
+        serializer.new(item, options.merge(root: nil))
       end
     end
   end


### PR DESCRIPTION
This pull request breaks up the mapping of serializer class instantiation to `serializable_hash` / `as_json`. One method maps the serializer instances and the original `serializable_array` emits them as serializable hashes.

This is for those that wish to extend `ActiveModel::ArraySerializer` but only want to modify specific behaviour such as `serializable_array` but wish to take advantage of the helpful serializer instantiation.
