### PR TITLE
Adds support for polymorphic has_many associations

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -386,6 +386,10 @@ module ActiveModel
 
         if association.embed_in_root? && hash.nil?
           raise IncludeError.new(self.class, association.name)
+        elsif association.embed_in_root? and association.instance_of? Association::HasMany and association.polymorphic?
+          association.roots.each do |root|
+            merge_association hash, root, association.serializables, unique_values
+          end
         elsif association.embed_in_root? && association.embeddable?
           merge_association hash, association.root, association.serializables, unique_values
         end

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -200,3 +200,17 @@ class Attachment < Model
     @attributes[:edible]
   end
 end
+
+class AttachmentWithMany < Model
+  def attachables
+    @attributes[:attachables]
+  end
+
+  def readable
+    @attributes[:readable]
+  end
+
+  def edible
+    @attributes[:edible]
+  end
+end


### PR DESCRIPTION
This adds support for has_many polymorphic associations to active_model_serializers.

For an `Attachment` model with many `Attachable` models associated, where an `Email` extends the `Attachable` model,  the output would be something like this:

```
{
  "attachment":  {
     "name": 'logo.png',
      "url": 'http://example.com/logo.png',
      "attachable_ids": [{
         "type": "email",
          "id": 1
       }]
    },
    "emails": [{
        "id": 1,
        "subject":  "foo",
        "body": "bar"
    }]
}
```
