### PR TITLE
Use the DefaultSerializer for embedded objects when no serializer is specified

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -67,7 +67,7 @@ module ActiveModel
         elsif object.respond_to?(:active_model_serializer) && (ams = object.active_model_serializer)
           ams.new(object, serializer_options)
         else
-          object
+          DefaultSerializer.new(object, serializer_options)
         end
       end
 

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -919,6 +919,42 @@ class SerializerTest < ActiveModel::TestCase
     }, serializer.as_json)
   end
 
+  def test_embed_ids_include_true_without_explicit_serializer
+    serializer_class = post_serializer
+
+    serializer_class.class_eval do
+      root :post
+      embed :ids, include: true
+      has_many :comments
+    end
+
+    comment_class = CommentWithoutExplicitSerializer
+
+    post = Post.new(title: "Fix ALL the bugs", body: "Body of new post", email: "arne@arnebrasseur.net")
+    comments = [comment_class.new(title: "Comment1", id: 1)]
+    post.comments = comments
+
+    serializer = serializer_class.new(post)
+
+    assert_equal({
+    post: {
+      title: "Fix ALL the bugs",
+      body: "Body of new post",
+      comment_ids: [1],
+      author_id: nil
+    },
+    authors: [],
+    comments: [
+      {
+        id: 1,
+        title: "Comment1",
+        default_serialization_provided_by_model: true
+      }
+    ],
+    }, serializer.as_json)
+
+  end
+
   # the point of this test is to illustrate that deeply nested serializers
   # still side-load at the root.
   def test_embed_with_include_inserts_at_root

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -54,6 +54,14 @@ class Comment < Model
   def active_model_serializer; CommentSerializer; end
 end
 
+class CommentWithoutExplicitSerializer < Model
+  def as_json(*)
+    @attributes.slice(:title, :id).merge(
+      default_serialization_provided_by_model: true
+    )
+  end
+end
+
 class UserSerializer < ActiveModel::Serializer
   attributes :first_name, :last_name
 


### PR DESCRIPTION
When using `embed :ids, include: true`, and the model class being embedded does
not implement `active_model_serializer`, then a default serialization should
happen.

The else branch in `ActiveModel::Serializer::Association#find_serializable` did
not yet have a test case, and would cause the following error :

```
 NoMethodError: undefined method `object' for #<Model:0x123>
    active_model_serializers/lib/active_model/serializer.rb:411:in `block in merge_association'
```

This is because `merge_association` calls `find_serializable`, and expects an
object that responds to `#object` and `#serializable_hash`, which is not the
case for the model instance itself. This commit wraps the object in a
DefaultSerializer so it satisfies the interface the caller expects.
