### PR TITLE
Allows additional cache options

### DIFF
--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -4,7 +4,7 @@ module ActiveModel
       def to_json(*args)
         if caching_enabled?
           key = expand_cache_key([self.class.to_s.underscore, cache_key, 'to-json'])
-          cache.fetch key do
+          cache.fetch key, cache_fetch_options do
             super
           end
         else
@@ -15,7 +15,7 @@ module ActiveModel
       def serialize(*args)
         if caching_enabled?
           key = expand_cache_key([self.class.to_s.underscore, cache_key, 'serialize'])
-          cache.fetch key do
+          cache.fetch key, cache_fetch_options do
             serialize_object
           end
         else
@@ -31,6 +31,10 @@ module ActiveModel
 
       def expand_cache_key(*args)
         ActiveSupport::Cache.expand_cache_key(args)
+      end
+
+      def cache_fetch_options
+        respond_to?(:cache_options) ? cache_options : {}
       end
     end
   end

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -2,14 +2,16 @@ require "test_helper"
 
 class CachingTest < ActiveModel::TestCase
   class NullStore
-    def fetch(key)
+    def fetch(key, options = {})
       return store[key] if store[key]
 
-      store[key] = yield
+      stored_options[key] = options
+      store[key]   = yield
     end
 
     def clear
       store.clear
+      options.clear
     end
 
     def store
@@ -18,6 +20,10 @@ class CachingTest < ActiveModel::TestCase
 
     def read(key)
       store[key]
+    end
+
+    def stored_options
+      @stored_options ||= {}
     end
   end
 
@@ -93,4 +99,61 @@ class CachingTest < ActiveModel::TestCase
     assert_equal instance.serializable_array, serializer.cache.read('array_serializer/cache-key/serialize')
     assert_equal instance.to_json, serializer.cache.read('array_serializer/cache-key/to-json')
   end
+
+  def test_serializers_uses_cache_with_options
+    serializer = Class.new(ActiveModel::Serializer) do
+      cached true
+      attributes :name, :skills
+
+      def self.to_s
+        'serializer'
+      end
+
+      def cache_key
+        object.name
+      end
+
+      def cache_options
+        { race_condition_ttl: 10, expires_in: 1.minute }
+      end
+    end
+
+    cache = NullStore.new
+    serializer.cache = cache
+    instance = serializer.new Programmer.new
+
+    instance.to_json
+
+    assert_equal cache.stored_options.size, 2
+    cache.stored_options { |key, options| assert_equal options, { race_condition_ttl: 10, expires_in: 1.minute } }
+  end
+
+  def test_array_serializer_uses_cache_with_options
+    serializer = Class.new(ActiveModel::ArraySerializer) do
+      cached true
+
+      def self.to_s
+        'array_serializer'
+      end
+
+      def cache_key
+        'cache-key'
+      end
+
+      def cache_options
+        { race_condition_ttl: 10, expires_in: 1.minute }
+      end
+
+    end
+
+    cache = NullStore.new
+    serializer.cache = cache
+    instance = serializer.new [Programmer.new]
+
+    instance.to_json
+
+    assert_equal cache.stored_options.size, 2
+    cache.stored_options { |key, options| assert_equal options, { race_condition_ttl: 10, expires_in: 1.minute } }
+  end
+
 end


### PR DESCRIPTION
This pull request allows to pass additional options when cache fetching. You only have to add cache_options method in your serializer to be able to add parameters as expires_in, race_condition_ttl, ...

``` ruby
   class ProgrammerSerializer < ActiveModel::Serializer
      cached true
      attributes :name, :skills

      def self.to_s
        'serializer'
      end

      def cache_key
        object.name
      end

      def cache_options
        { race_condition_ttl: 10, expires_in: 1.minute }
      end
    end
```
