### PR TITLE
Fix `#as_json` glitch caused by JSON and Rails

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -323,7 +323,7 @@ module ActiveModel
     # Returns a json representation of the serializable
     # object including the root.
     def as_json(args={})
-      super(root: args.fetch(:root, options.fetch(:root, root_name)))
+      super(root: args.to_hash.fetch(:root, options.fetch(:root, root_name)))
     end
 
     def serialize_object


### PR DESCRIPTION
This should solve rails-api/active_model_serializers#340.

When requiring Rails, `as_json` somehow ends up with a
JSON::Ext::Generator::State instance as arguments, instead of a plain old Hash,
which causes this:

```
2.0.0 (main):0 > require "active_model_serializers"
=> true
2.0.0 (main):0 > require "json"
=> true
2.0.0 (main):0 > JSON.dump  ActiveModel::Serializer.new(Object.new)
=> "\"#<ActiveModel::Serializer:0x007f7a2101a458>\""
2.0.0 (main):0 > require "rails"
=> true
2.0.0 (main):0 > JSON.dump  ActiveModel::Serializer.new(Object.new)
NoMethodError: undefined method `fetch' for #<JSON::Ext::Generator::State:0x007f7a2093bfb0>
from /home/drr/code/af/map/code/.bundle/ruby/2.0.0/gems/active_model_serializers-0.8.1/lib/active_model/serializer.rb:341:in `as_json'`'`
```
