### PR TITLE
Merges options with duplicate keys if values are hashes

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -263,7 +263,13 @@ module ActiveModel
       # not be manually defined for this method.
       def build_json(controller, resource, options)
         default_options = controller.send(:default_serializer_options) || {}
-        options = default_options.merge(options || {})
+        options = default_options.merge(options || {}) do |key, old, new|
+          if old.is_a?(Hash) && new.is_a?(Hash)
+            options[key] = old.merge(new)
+          else
+            options[key] = new
+          end
+        end
 
         serializer = options.delete(:serializer) ||
           (resource.respond_to?(:active_model_serializer) &&

--- a/test/serialization_test.rb
+++ b/test/serialization_test.rb
@@ -190,12 +190,16 @@ class RenderJsonTest < ActionController::TestCase
       render json: [], serializer: CustomArraySerializer
     end
 
+    def render_json_array_with_metas
+      render json: [], meta: {page: 2}
+    end
 
   private
     def default_serializer_options
       defaults = {}
       defaults.merge!(check_defaults: true) if params[:check_defaults]
       defaults.merge!(root: :awesome) if params[:check_default_root]
+      defaults.merge!(meta: {version: 1}) if params[:check_default_meta]
       defaults.merge!(scope: :current_admin) if params[:check_default_scope]
       defaults.merge!(serializer: AnotherCustomSerializer) if params[:check_default_serializer]
       defaults.merge!(each_serializer: AnotherCustomSerializer) if params[:check_default_each_serializer]
@@ -391,4 +395,8 @@ class RenderJsonTest < ActionController::TestCase
     assert_equal '{"items":[]}', @response.body
   end
 
+  def test_render_json_array_with_default_and_optional_meta
+    get :render_json_array_with_metas, check_default_meta: true
+    assert_equal '{"test":[],"meta":{"version":1,"page":2}}', @response.body
+  end
 end


### PR DESCRIPTION
This commit adds a block to option merging for duplicate keys. If the
key values are hashes they are merged, if not then the new value overwrites
the old. Use case is having meta informmation in your default
serialization options, but also additional meta in your respond_with
params. For example, you always include your API version number as
default meta, in addition to pagination meta info as an option in your
respond_with call.
