### PR TITLE
Change HABTM to has_many :through

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -117,9 +117,9 @@ module ActiveModel
       associations.each_with_object({}) do |(name, association), hash|
         if included_associations.include? name
           if association.embed_ids?
-            hash[association.key] = serialize_ids association
+            hash[association.key] = serialize_ids(association)
           elsif association.embed_objects?
-            hash[association.embedded_key] = serialize association
+            hash[association.embedded_key] = serialize(association)
           end
         end
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -36,15 +36,27 @@ ActiveRecord::Schema.define do
   end
 end
 
+class ARPostsTag < ActiveRecord::Base
+  belongs_to :ar_post, class_name: "ARPost"
+  belongs_to :ar_tag, class_name: "ARTag"
+end
+
 class ARPost < ActiveRecord::Base
   has_many :ar_comments, class_name: 'ARComment'
-  has_and_belongs_to_many :ar_tags, class_name: 'ARTag', join_table: :ar_posts_tags
+  has_many :ar_post_tags, class_name: 'ARPostsTag'
+  has_many :ar_tags, through: :ar_post_tags
   belongs_to :ar_section, class_name: 'ARSection'
+end
+
+class ARCommentsTag < ActiveRecord::Base
+  belongs_to :ar_comment, class_name: 'ARCommentsTag'
+  belongs_to :ar_tag, class_name: "ARTag"
 end
 
 class ARComment < ActiveRecord::Base
   belongs_to :ar_post, class_name: 'ARPost'
-  has_and_belongs_to_many :ar_tags, class_name: 'ARTag', join_table: :ar_comments_tags
+  has_many :ar_comment_tags, class_name: 'ARCommentsTag'
+  has_many :ar_tags, through: :ar_comment_tags
 end
 
 class ARTag < ActiveRecord::Base
@@ -78,9 +90,11 @@ ARPost.create(title: 'New post',
               body:  'A body!!!',
               ar_section: ARSection.create(name: 'ruby')).tap do |post|
 
-  short_tag = post.ar_tags.create(name: 'short')
-  whiny_tag = post.ar_tags.create(name: 'whiny')
-  happy_tag = post.ar_tags.create(name: 'happy')
+  short_tag = ARTag.create(name: 'short')
+  whiny_tag = ARTag.create(name: 'whiny')
+  happy_tag = ARTag.create(name: 'happy')
+
+  post.ar_tags.concat short_tag, whiny_tag, happy_tag
 
   post.ar_comments.create(body: 'what a dumb post').tap do |comment|
     comment.ar_tags.concat short_tag, whiny_tag
@@ -89,4 +103,6 @@ ARPost.create(title: 'New post',
   post.ar_comments.create(body: 'i liked it').tap do |comment|
     comment.ar_tags.concat short_tag, happy_tag
   end
+
+  post.save
 end


### PR DESCRIPTION
HABTM is basically bridge to has_many :through now.

Quoting from ActiveRecord changelog (https://github.com/rails/rails/blob/master/activerecord/CHANGELOG.md):

  has_and_belongs_to_many is now transparently implemented in terms of has_many :through.
  Behavior should remain the same, if not, it is a bug.
