### PR TITLE
Merges options with duplicate keys if values are hashes

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -62,7 +62,13 @@ module ActionController
     end
 
     def build_json_serializer(resource, options)
-      options = default_serializer_options.merge(options || {})
+      options = default_serializer_options.merge(options || {}) do |key, old, new|
+        if old.is_a?(Hash) && new.is_a?(Hash)
+          options[key] = old.merge(new)
+        else
+          options[key] = new
+        end
+      end
 
       serializer =
         options.delete(:serializer) ||

--- a/test/integration/action_controller/serialization_test.rb
+++ b/test/integration/action_controller/serialization_test.rb
@@ -43,11 +43,11 @@ module ActionController
     class DefaultOptionsForSerializerScopeTest < ActionController::TestCase
       class MyController < ActionController::Base
         def default_serializer_options
-          { scope: current_admin }
+          { scope: current_admin, meta: { version: 1 } }
         end
 
         def render_using_scope_set_in_default_serializer_options
-          render json: Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+          render json: Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }), meta: { page: 2 }
         end
 
         private
@@ -66,7 +66,7 @@ module ActionController
       def test_render_using_scope_set_in_default_serializer_options
         get :render_using_scope_set_in_default_serializer_options
         assert_equal 'application/json', @response.content_type
-        assert_equal '{"profile":{"name":"Name 1","description":"Description 1 - current_admin"}}', @response.body
+        assert_equal '{"profile":{"name":"Name 1","description":"Description 1 - current_admin"},"meta":{"version":1,"page":2}}', @response.body
       end
     end
 


### PR DESCRIPTION
This commit adds hash merging handling for duplicate keys. If the key
values are hashes, they are merged. Previously the explicit serializer
options would overwrite the default serializer options if the keys were
duplicates. Rather than overwrite, the hash key/values are now merged.
This allows you to define some default meta information in the default
serializer and append to the meta information in the explicit serializer.

For example, say you want every serialization to contain the version of
your API: meta: { version: 1 } and you also want to append pagination
information to the meta information in the explicit serializer: meta: {
page: 2 }. Previously, the serialized return would have been: meta: { page: 2 }.
After this commit, meta will now be: meta: { version: 1, page: 2 }
