### PR TITLE
Update PORO description

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ $ rails g serializer post
 ### Support for POROs
 
 Currently `ActiveModel::Serializers` expects objects to implement
-read\_attribute\_for\_serialization. That's all you need to do to have
-your POROs supported. 
+read\_attribute\_for\_serialization, or include `ActiveModel::SerializerSupport`.
+That's all you need to do to have your POROs supported.
 
 # ActiveModel::Serializer
 


### PR DESCRIPTION
It's not entirely clear how `read_attribute_for_serialization` is supposed to be implemented. I had to look back at the older README to find the mention of `ActiveModel::SerializerSupport`.

``` ruby
class Poro
   include ActiveModel::SerializerSupport

   # ...
end
```

Is there a better way to handle this?
