### PR TITLE
Added note that objects will not be side-loaded if root is set to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,10 @@ this:
 }
 ```
 
+When side-loading data, your serializer cannot have the `{ root: false }` option, 
+as this would lead to invalid JSON. If you do not have a root key, the `include` 
+instruction will be ignored
+
 You can also specify a different root for the embedded objects than the key
 used to reference them:
 


### PR DESCRIPTION
When trying to side-load objects I was unaware I couldn't have `root` set to false and it wasn't specified in the README. It seems obvious now but lesser so during the hour I spent trying to work out what was going on. Also I notice there is a similar instruction for `meta`. Doesn't do any harm and might save someone else sometime.
