### PR TITLE
Update README to reflect override of json key in associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ class PostSerializer < ActiveModel::Serializer
   attributes :id, :title, :body
 
   # look up comments, but use +my_comments+ as the key in JSON
-  has_many :comments, key: :my_comments
+  has_many :comments, root: :my_comments
 end
 ```
 


### PR DESCRIPTION
When adding an association, the key is overridden by passing root in the options (not key as it was previously). I assume this is the intended behavior so this keeps the README in sync.
