### PR TITLE
HasOne Association#embedded_keys should return Symbol.

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -50,7 +50,7 @@ module ActiveModel
       class HasOne < Association
         def initialize(name, *args)
           super
-          @embedded_key = "#{@options[:root] || name}".pluralize
+          @embedded_key = "#{@options[:root] || name}".pluralize.to_sym
           @key ||= "#{name}_id"
         end
       end

--- a/test/integration/active_record/active_record_test.rb
+++ b/test/integration/active_record/active_record_test.rb
@@ -17,7 +17,7 @@ module ActiveModel
             ar_comments: [{ body: 'what a dumb post', ar_tags: [{ name: 'short' }, { name: 'whiny' }] },
                           { body: 'i liked it', ar_tags: [{:name=>"short"}, {:name=>"happy"}] }],
             ar_tags: [{ name: 'short' }, { name: 'whiny' }, { name: 'happy' }],
-            'ar_sections' => [{ 'name' => 'ruby' }]
+            ar_sections: [{ 'name' => 'ruby' }]
           }
         }, post_serializer.as_json)
       end
@@ -51,7 +51,7 @@ module ActiveModel
             ar_comments: [{ body: 'what a dumb post', ar_tags: [{ name: 'short' }, { name: 'whiny' }] },
                           { body: 'i liked it', ar_tags: [{:name=>"short"}, {:name=>"happy"}] }],
             ar_tags: [{ name: 'short' }, { name: 'whiny' }, { name: 'happy' }],
-            'ar_sections' => [{ 'name' => 'ruby' }]
+            ar_sections: [{ 'name' => 'ruby' }]
           }, post_serializer.as_json)
         end
       end

--- a/test/unit/active_model/serializer/has_one_test.rb
+++ b/test/unit/active_model/serializer/has_one_test.rb
@@ -50,7 +50,7 @@ module ActiveModel
         @association.embed = :objects
 
         assert_equal({
-          name: 'Name 1', email: 'mail@server.com', 'profiles' => [{ name: 'N1', description: 'D1' }]
+          name: 'Name 1', email: 'mail@server.com', profiles: [{ name: 'N1', description: 'D1' }]
         }, @user_serializer.serializable_hash)
       end
 
@@ -58,7 +58,7 @@ module ActiveModel
         @association.embed = :objects
 
         assert_equal({
-          'user' => { name: 'Name 1', email: 'mail@server.com', 'profiles' => [{ name: 'N1', description: 'D1' }] }
+          'user' => { name: 'Name 1', email: 'mail@server.com', profiles: [{ name: 'N1', description: 'D1' }] }
         }, @user_serializer.as_json)
       end
 
@@ -84,16 +84,16 @@ module ActiveModel
         end
 
         assert_equal({
-          'user' => { name: 'Name 1', email: 'mail@server.com', 'profiles' => [] }
+          'user' => { name: 'Name 1', email: 'mail@server.com', profiles: [] }
         }, @user_serializer.as_json)
       end
 
       def test_associations_embedding_objects_serialization_using_serializable_hash_and_root_from_options
         @association.embed = :objects
-        @association.embedded_key = 'root'
+        @association.embedded_key = :root
 
         assert_equal({
-          name: 'Name 1', email: 'mail@server.com', 'root' => [{ name: 'N1', description: 'D1' }]
+          name: 'Name 1', email: 'mail@server.com', root: [{ name: 'N1', description: 'D1' }]
         }, @user_serializer.serializable_hash)
       end
 
@@ -112,7 +112,7 @@ module ActiveModel
 
         assert_equal({
           'user' => { name: 'Name 1', email: 'mail@server.com', 'profile_id' => @user.profile.object_id },
-          'profiles' => [{ name: 'N1', description: 'D1' }]
+          profiles: [{ name: 'N1', description: 'D1' }]
         }, @user_serializer.as_json)
       end
 
@@ -129,7 +129,7 @@ module ActiveModel
 
         assert_equal({
           'user' => { name: 'Name 1', email: 'mail@server.com', 'profile_id' => @user.profile.object_id },
-          'profiles' => [{ name: 'fake' }]
+          profiles: [{ name: 'fake' }]
         }, @user_serializer.as_json)
       end
     end


### PR DESCRIPTION
While debugging #414 I realize that `Association::HasOne#embedded_key` returns String while `Association::HasMany#embedded_key` returns Symbol due to [`pluralize` being called on the HasOne](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer/associations.rb#L53). I think they should be made consistent (symbol?).
