### PR TITLE
Change hardcoded class in favor of using provided serializer class in AR integration tests

### DIFF
--- a/test/integration/active_record/active_record_test.rb
+++ b/test/integration/active_record/active_record_test.rb
@@ -58,17 +58,17 @@ module ActiveModel
 
       private
 
-      def embed(klass, options = {})
-        old_assocs = Hash[ARPostSerializer._associations.to_a.map { |(name, association)| [name, association.dup] }]
+      def embed(serializer_class, options = {})
+        old_assocs = Hash[serializer_class._associations.to_a.map { |(name, association)| [name, association.dup] }]
 
-        ARPostSerializer._associations.each_value do |association|
+        serializer_class._associations.each_value do |association|
           association.embed = options[:embed]
           association.embed_in_root = options[:embed_in_root]
         end
 
         yield
       ensure
-        ARPostSerializer._associations = old_assocs
+        serializer_class._associations = old_assocs
       end
     end
   end


### PR DESCRIPTION
In this way, embed private method is more generic and we would be able to add more tests including other serializer classes.
