### PR TITLE
embed_in_root only returns the associated objects of a single instance

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -44,7 +44,10 @@ module ActiveModel
 
     def embedded_in_root_associations
       @object.each_with_object({}) do |item, hash|
-        hash.merge!(serializer_for(item).embedded_in_root_associations)
+        serializer_for(item).embedded_in_root_associations.each_pair do |type, objects|
+          hash[type] = hash.fetch(type, []).concat(objects)
+          hash[type].uniq!
+        end
       end
     end
   end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -26,6 +26,8 @@ class Profile < Model
 end
 
 class Post < Model
+  attr_writer :comments
+
   def comments
     @comments ||= [Comment.new(content: 'C1'),
                    Comment.new(content: 'C2')]

--- a/test/unit/active_model/array_serializer/embed_in_root_test.rb
+++ b/test/unit/active_model/array_serializer/embed_in_root_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+module ActiveModel
+  class ArraySerializer
+    class EmbedInRootTest < ActiveModel::TestCase
+      def setup
+        @association = PostSerializer._associations[:comments]
+        @old_association = @association.dup
+
+        @post1 = Post.new({ title: 'Title 1', body: 'Body 1', date: '1/1/2000' })
+        @post2 = Post.new({ title: 'Title 2', body: 'Body 2', date: '1/1/2000' })
+
+        @post2.comments = [
+          Comment.new(content: 'C3'),
+          Comment.new(content: 'C4')
+        ]
+
+        @serializer = ArraySerializer.new([@post1, @post2], root: :posts)
+      end
+
+      def teardown
+        PostSerializer._associations[:comments] = @old_association
+      end
+
+      def test_associated_objects_of_multiple_instances_embedded_in_root
+        @association.embed = :ids
+        @association.embed_in_root = true
+
+        assert_equal({
+            posts: [
+              {title: "Title 1", body: "Body 1", "comment_ids" => @post1.comments.map(&:object_id) },
+              {title: "Title 2", body: "Body 2", "comment_ids" => @post2.comments.map(&:object_id) }
+            ],
+            comments: [
+              {content: "C1"},
+              {content: "C2"},
+              {content: "C3"},
+              {content: "C4"}
+            ]
+          }, @serializer.as_json)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
When using embed: :ids ; embed_in_root: true, and serializing multiple objects,
only the associated objects of the last object in the collection will actually
show up in the serialized data.

For example, if you serialize a collection of two posts, each containing one or
more comments, only the comments of the last post show up. The reason is a
Hash#merge wich overwrites the array rather than appending to it.

This commit fixes this by merging the collection arrays, rather than the top-level
hashes.
