### PR TITLE
Using a HasOne association twice raises an exception (Undefined method `map')

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -53,7 +53,7 @@ module ActiveModel
         end
 
         def build_serializer(object, options = {})
-          if object.respond_to?(:to_ary)
+          if object.respond_to?(:to_ary) && !(@serializer_class && @serializer_class <= ArraySerializer)
             use_array_serializer!
           else
             @serializer_class ||= Serializer.serializer_for(object) || DefaultSerializer

--- a/test/unit/active_model/serializer/associations/build_serializer_test.rb
+++ b/test/unit/active_model/serializer/associations/build_serializer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Association
+      class BuildSerializerTest < ActiveModel::TestCase
+        def setup
+          @association = Association::HasOne.new('post', serializer: PostSerializer)
+          @post = Post.new({ title: 'Title 1', body: 'Body 1', date: '1/1/2000' })
+        end
+
+        def test_build_serializer_for_array_called_twice
+          2.times do
+            serializer      = @association.build_serializer([@post])
+            each_serializer = serializer.serializer_for(@post)
+
+            assert_instance_of(ArraySerializer, serializer)
+            assert_instance_of(PostSerializer,  each_serializer)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When an `Association` detects that it is serializing an array, it calls `use_array_serializer!` to set the serializer to `ArraySerializer`, and set `@options[:each_serializer]` to the current serializer.

When `use_array_serializer!` is called a second time, `:each_serializer` is now `ArraySerializer` which causes things to blow up.

The symptom is "Undefined method `map'", since the ArraySerializer tries to iterate over a single object.

The `HasMany` association already contained a check to prevent calling `use_array_serializer!` twice, this PR adds a similar check to `HasOne`.
