### PR TITLE
Add @options back into serializers for passing custom options

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -20,7 +20,7 @@ module ActiveModel
       @each_serializer = options[:each_serializer]
       @options         = options.merge(root: nil)
     end
-    attr_accessor :object, :root, :meta_key, :meta
+    attr_accessor :object, :root, :meta_key, :meta, :options
 
     def json_key
       if root.nil?

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -106,8 +106,9 @@ end
       @root     = options.fetch(:root, self.class._root)
       @meta_key = options[:meta_key] || :meta
       @meta     = options[@meta_key]
+      @options  = options.reject{|k,v| [:scope, :root, :meta_key, :meta].include?(k) }
     end
-    attr_accessor :object, :scope, :meta_key, :meta, :root
+    attr_accessor :object, :scope, :meta_key, :meta, :root, :options
 
     def json_key
       if root == true || root.nil?

--- a/test/unit/active_model/serializer/options_test.rb
+++ b/test/unit/active_model/serializer/options_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class OptionsTest < ActiveModel::TestCase
+      def setup
+        @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+      end
+
+      def test_meta
+        profile_serializer = ProfileSerializer.new(@profile, root: 'profile', random_option: "This is an option")
+
+        assert_equal("This is an option", profile_serializer.options[:random_option])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is to maintain the functionality of render :json as noted in the docs

This functionality used to exist in v0.8.1. This adds the ability to
pass other options that will be usable in the serializer via the
options accessor.

This works by adding an attr_accessor for options so it is available
and is set by the remaining options in the provided options hash during
initialization.

Fix #446

Please let me know what you think! 

Cheers 
-Jason
