### PR TITLE
Fixes filter method being called multiple times. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ authorization context to your serializer. By default, the context
 is the current user of your application, but this
 [can be customized](#customizing-scope).
 
-Serializers provides a method named `filter` used to determine what
+Serializers provides a method named `filter_attributes` and `filter_associations` used to determine what
 attributes and associations should be included in the output. This is
 typically used to customize output based on `current_user`. For example:
 
@@ -271,7 +271,7 @@ typically used to customize output based on `current_user`. For example:
 class PostSerializer < ActiveModel::Serializer
   attributes :id, :title, :body, :author
 
-  def filter(keys)
+  def filter_attributes(keys)
     if scope.admin?
       keys
     else

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -119,14 +119,14 @@ end
     end
 
     def attributes
-      (filtered_keys & self.class._attributes).each_with_object({}) do |name, hash|
+      filter_attributes(self.class._attributes.dup).each_with_object({}) do |name, hash|
         hash[name] = send(name)
       end
     end
 
     def associations
       associations = self.class._associations
-      included_associations = filtered_keys & associations.keys
+      included_associations = filter_associations(associations.keys)
       associations.each_with_object({}) do |(name, association), hash|
         if included_associations.include? name
           if association.embed_ids?
@@ -139,17 +139,17 @@ end
       end
     end
 
-    def filtered_keys
-      @filtered_keys ||= filter(self.class._attributes + self.class._associations.keys)
+    def filter_attributes(keys)
+      keys
     end
 
-    def filter(keys)
+    def filter_associations(keys)
       keys
     end
 
     def embedded_in_root_associations
       associations = self.class._associations
-      included_associations = filtered_keys & associations.keys
+      included_associations = filter_associations(associations.keys)
       associations.each_with_object({}) do |(name, association), hash|
         if included_associations.include? name
           if association.embed_in_root?

--- a/test/unit/active_model/serializer/filter_test.rb
+++ b/test/unit/active_model/serializer/filter_test.rb
@@ -7,7 +7,7 @@ module ActiveModel
         @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
         @profile_serializer = ProfileSerializer.new(@profile)
         @profile_serializer.instance_eval do
-          def filter(keys)
+          def filter_attributes(keys)
             keys - [:description]
           end
         end
@@ -29,8 +29,12 @@ module ActiveModel
         @post = Post.new({ title: 'Title 1', body: 'Body 1', date: '1/1/2000' })
         @post_serializer = PostSerializer.new(@post)
         @post_serializer.instance_eval do
-          def filter(keys)
+          def filter_attributes(keys)
             keys & [:title]
+          end
+          
+          def filter_associations(keys)
+            keys - [:comments]
           end
         end
       end
@@ -45,10 +49,15 @@ module ActiveModel
         }, @post_serializer.as_json)
       end
 
-      def test_filter_only_called_once
+      def test_filter_associations_and_filter_attributes
         @post_serializer.instance_eval do
-          def filter(keys)
-            @_keys ||= keys & [:title, :comments]
+          
+          def filter_attributes(keys)
+            keys & [:title]
+          end
+          
+          def filter_associations(keys) 
+            keys 
           end
         end
 


### PR DESCRIPTION
Fixes #459 by adding filtered_keys method. It combines attributes.keys with association keys and passes them to filter method memoizing result. 
