### PR TITLE
Add embed_namespace and embed_in_root_key options

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,33 @@ Now, any associations will be supplied as an Array of IDs:
 }
 ```
 
+You may also choose to embed the IDs by the association's name underneath an
+`embed_key` for the resource. For example, say we want to change `comment_ids`
+to `comments` underneath a `links` key:
+
+```ruby
+class PostSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body
+
+  has_many :comments, embed: ids, embed_namespace: :links
+end
+```
+
+The JSON will look like this:
+
+```json
+{
+  "post": {
+    "id": 1,
+    "title": "New post",
+    "body": "A body!",
+    "links": {
+      "comments": [ 1, 2, 3 ]
+    }
+  }
+}
+```
+
 Alternatively, you can choose to embed only the ids or the associated objects per association:
 
 ```ruby
@@ -586,6 +613,42 @@ this:
     { "id": 2, "name": "whiny" },
     { "id": 3, "name": "happy" }
   ]
+}
+```
+
+If you would like to namespace association JSON underneath a certain key in
+the root document (say, `linked`), you can specify an `embed_in_root_key`:
+
+```ruby
+class PostSerializer < ActiveModel::Serializer
+  embed: ids, include: true, embed_in_root_key: :linked
+
+  attributes: :id, :title, :body
+  has_many :comments, :tags
+end
+```
+
+The above would yield the following JSON document:
+
+```json
+{
+  "post": {
+    "id": 1,
+    "title": "New post",
+    "body": "A body!",
+    "comment_ids": [ 1, 2 ]
+  },
+  "linked": {
+    "comments": [
+      { "id": 1, "body": "what a dumb post", "tag_ids": [ 1, 2 ] },
+      { "id": 2, "body": "i liked it", "tag_ids": [ 1, 3 ] },
+    ],
+    "tags": [
+      { "id": 1, "name": "short" },
+      { "id": 2, "name": "whiny" },
+      { "id": 3, "name": "happy" }
+    ]
+  }
 }
 ```
 

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -18,16 +18,20 @@ module ActiveModel
         @embed_key     = options[:embed_key] || :id
         @key           = options[:key]
         @embedded_key  = options[:root] || name
+        @embed_in_root_key = options.fetch(:embed_in_root_key) { CONFIG.embed_in_root_key }
+        @embed_namespace = options.fetch(:embed_namespace) { CONFIG.embed_namespace }
 
         serializer = @options[:serializer]
         @serializer_from_options = serializer.is_a?(String) ? serializer.constantize : serializer
       end
 
       attr_reader :name, :embed_ids, :embed_objects
-      attr_accessor :embed_in_root, :embed_key, :key, :embedded_key, :root_key, :serializer_from_options, :options, :key_format
+      attr_accessor :embed_in_root, :embed_key, :key, :embedded_key, :root_key, :serializer_from_options, :options, :key_format, :embed_in_root_key, :embed_namespace
       alias embed_ids? embed_ids
       alias embed_objects? embed_objects
       alias embed_in_root? embed_in_root
+      alias embed_in_root_key? embed_in_root_key
+      alias embed_namespace? embed_namespace
 
       def embed=(embed)
         @embed_ids     = embed == :id || embed == :ids

--- a/test/unit/active_model/serializer/has_many_test.rb
+++ b/test/unit/active_model/serializer/has_many_test.rb
@@ -168,6 +168,63 @@ module ActiveModel
           'post' => { title: 'Title 1', body: 'Body 1', comments: { my_content: ['fake'] } }
         }, @post_serializer.as_json)
       end
+
+      def test_associations_embedding_ids_including_objects_serialization_with_embed_in_root_key
+        @association.embed_in_root = true
+        @association.embed_in_root_key = :linked
+        @association.embed = :ids
+        assert_equal({
+          linked: {
+            comments: [
+              { content: 'C1' },
+              { content: 'C2' }
+            ]
+          },
+          'post' => {
+            title: 'Title 1', body: 'Body 1',
+            'comment_ids' => @post.comments.map(&:object_id)
+          }
+        }, @post_serializer.as_json)
+      end
+
+      def test_associations_embedding_ids_using_embed_namespace_including_object_serialization_with_embed_in_root_key
+        @association.embed_in_root = true
+        @association.embed_in_root_key = :linked
+        @association.embed = :ids
+        @association.embed_namespace = :links
+        @association.key = :comments
+        assert_equal({
+          linked: {
+            comments: [
+              { content: 'C1' },
+              { content: 'C2' }
+            ]
+          },
+          'post' => {
+            title: 'Title 1', body: 'Body 1',
+            links: {
+              comments: @post.comments.map(&:object_id)
+            }
+          }
+        }, @post_serializer.as_json)
+      end
+
+      def test_associations_embedding_objects_using_embed_namespace
+        @association.embed = :objects
+        @association.embed_namespace = :links
+
+        assert_equal({
+          'post' => {
+            title: 'Title 1', body: 'Body 1',
+            links: {
+              comments: [
+                { content: 'C1' },
+                { content: 'C2' }
+              ]
+            }
+          }
+        }, @post_serializer.as_json)
+      end
     end
   end
 end

--- a/test/unit/active_model/serializer/has_one_test.rb
+++ b/test/unit/active_model/serializer/has_one_test.rb
@@ -161,6 +161,47 @@ module ActiveModel
           'user' => { name: 'Name 1', email: 'mail@server.com', profile: { name: 'fake' } }
         }, @user_serializer.as_json)
       end
+
+      def test_associations_embedding_ids_using_embed_namespace
+        @association.embed_namespace = :links
+        @association.embed = :ids
+        @association.key = :profile
+        assert_equal({
+          'user' => {
+            name: 'Name 1', email: 'mail@server.com',
+            links: {
+              profile: @user.profile.object_id
+            }
+          }
+        }, @user_serializer.as_json)
+      end
+
+      def test_asociations_embedding_objects_using_embed_namespace
+        @association.embed_namespace = :links
+        @association.embed = :objects
+        assert_equal({
+          'user' => {
+            name: 'Name 1', email: 'mail@server.com',
+            links: {
+              profile: { name: 'N1', description: 'D1' }
+            }
+          }
+        }, @user_serializer.as_json)
+      end
+
+      def test_associations_embedding_ids_using_embed_namespace_and_embed_in_root_key
+        @association.embed_in_root = true
+        @association.embed_in_root_key = :linked
+        @association.embed = :ids
+        assert_equal({
+          'user' => {
+            name: 'Name 1', email: 'mail@server.com', 'profile_id' => @user.profile.object_id
+          },
+          linked: {
+            'profiles' => [ { name: 'N1', description: 'D1' } ]
+          }
+        }, @user_serializer.as_json)
+      end
     end
   end
 end


### PR DESCRIPTION
After talking with @steveklabnik in #jsonapi on Freenode, I decided to give this a go. It could probably use some more work (I'm not totally in love with "embed_namespace" and "embed_in_root_key" names, hoping someone can provide alternatives).

The purpose of this pull request is to allow hooks to produce JSON that is compatible with the (current draft!) of the JSONAPI spec. View "Compound Documents" on this page: http://jsonapi.org/format/#id-based-json-api

`embed_namespace` allows you to embed ids/etc underneath a namespaced
key. For example:

``` ruby
class PostSerializer < ActiveModel::Serializer
  embed :ids, embed_namespace: :links

  attributes :name

  has_many :comments
end
```

Gives the following JSON:

``` json
{
  "post": {
    "id": 1,
    "name": "Blog",
    "links": {
      "comments": [ 1, 2, 3 ]
    }
  }
}
```

`embed_in_root_key` option allows you to sideload resources underneath
a namespace in the document root. For example:

``` ruby
class PostSerializer < ActiveModel::Serializer
  embed :ids, include: true, embed_in_root_key: :linked

  attributes :name

  has_many :comments, embed_namespace: :links
end
```

Gives the following JSON:

``` json
{
  "post": {
    "id": 1,
    "name": "Blog",
    "links": {
      "comments": [ 1, 2, 3 ]
    }
  },
  "linked": {
    "comments": [
       { "id": 1, "body": "So cool" },
       { "id": 2, "body": "So so cool"},
       { "id": 3, "body": "The Best"}
     ]
  }
}
```

The two combined as in the above example allow for compliance with the
(current) JSONAPI spec for using "linked/links".
