### PR TITLE
`has_one` association changes when objects embedding is enabled.

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -150,7 +150,7 @@ end
         if included_associations.include? name
           if association.embed_in_root?
             associated_data = Array(send(association.name))
-            hash[association.root_key] = serialize(association, associated_data)
+            hash[association.root_key] = serialize(association.dup, associated_data)
           end
         end
       end

--- a/test/unit/active_model/serializer/has_one_test.rb
+++ b/test/unit/active_model/serializer/has_one_test.rb
@@ -133,6 +133,16 @@ module ActiveModel
         }, @user_serializer.as_json)
       end
 
+      def test_associations_embedding_in_root_does_not_polute_association
+        @association.embed_in_root = true
+
+        serializer_class = @association.serializer_class
+
+        @user_serializer.embedded_in_root_associations
+
+        assert_equal(@association.serializer_class, serializer_class)
+      end
+
       def test_associations_embedding_objects_using_a_given_serializer
         @association.serializer_class = Class.new(ActiveModel::Serializer) do
           def name


### PR DESCRIPTION
This should not happen since embedded objects serialize class usually will be
different from the object serialize class.

This should fix #464 and #456

Please review.
Thanks.
