### PR TITLE
Serializers now inherit attributes and associations.

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -13,8 +13,8 @@ module ActiveModel
 
     class << self
       def inherited(base)
-        base._attributes = []
-        base._associations = {}
+        base._attributes = (self._attributes || []).dup
+        base._associations = (self._associations || {}).dup
       end
 
       def setup

--- a/test/unit/active_model/serializer/attributes_test.rb
+++ b/test/unit/active_model/serializer/attributes_test.rb
@@ -24,6 +24,18 @@ module ActiveModel
           'profile' => { name: 'Name 1', description: 'Description 1' }
         }, @profile_serializer.as_json)
       end
+
+      def test_attributes_inheritance
+        inherited_serializer_klass = Class.new(ProfileSerializer) do
+          attributes :comments
+        end
+        another_inherited_serializer_klass = Class.new(ProfileSerializer)
+
+        assert_equal([:name, :description, :comments],
+                     inherited_serializer_klass._attributes)
+        assert_equal([:name, :description],
+                     another_inherited_serializer_klass._attributes)
+      end
     end
   end
 end

--- a/test/unit/active_model/serializer/has_many_test.rb
+++ b/test/unit/active_model/serializer/has_many_test.rb
@@ -21,6 +21,18 @@ module ActiveModel
         assert_equal 'comments', @association.name
       end
 
+      def test_associations_inheritance
+        inherited_serializer_klass = Class.new(PostSerializer) do
+          has_many :some_associations
+        end
+        another_inherited_serializer_klass = Class.new(PostSerializer)
+
+        assert_equal(PostSerializer._associations.length + 1,
+          inherited_serializer_klass._associations.length)
+        assert_equal(PostSerializer._associations.length,
+          another_inherited_serializer_klass._associations.length)
+      end
+
       def test_associations_embedding_ids_serialization_using_serializable_hash
         @association.embed = :ids
 


### PR DESCRIPTION
This solves the issue with attributes and associations inheritance.

Closes #449
