### PR TITLE
Typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ class PostSerializer < ActiveModel::Serializer
   attributes :id, :title, :body
 
   # look up comments, but use +my_comments+ as the key in JSON
-  has_many :comments, root: :my_comments
+  has_many :comments, key: :my_comments
 end
 ```
 


### PR DESCRIPTION
I didn't look it up in the source, but it appears that, as with attributes, 'key' should be used to change the JSON key and not 'root'.
