### PR TITLE
Update README documentation on Serializer#filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ authorization context to your serializer. By default, the context
 is the current user of your application, but this
 [can be customized](#customizing-scope).
 
-Serializers provides a method named `filter` used to determine what
-attributes and associations should be included in the output. This is
-typically used to customize output based on `current_user`. For example:
+Serializers provides a method named `filter`, which should return an array
+used to determine what attributes and associations should be included in the output.
+This is typically used to customize output based on `current_user`. For example:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
@@ -282,7 +282,8 @@ end
 ```
 
 And it's also safe to mutate keys argument by doing keys.delete(:author)
-in case you want to avoid creating two extra arrays.
+in case you want to avoid creating two extra arrays. Note that if you do an
+in-place modification, you still need to return the modified array.
 
 If you would like the key in the outputted JSON to be different from its name
 in ActiveRecord, you can declare the attribute with the different name


### PR DESCRIPTION
Documentation fix clarifying that `#filter` needs to return an array. Previously it said that "And it's also safe to mutate keys argument by doing keys.delete(:author) in case you want to avoid creating two extra arrays." -- I had taken this to mean that I could just modify the original `keys` argument and the return value of `filters` would be discarded, which is wrong. I added clarification that if you do modify the original array, you have to return it!

This lead to a tricky bug for me, where I wanted to filter out keys that had undefined values:

```
def filter(keys)
  keys.reject!{ |key| object[key].nil?}
end
```

I was using the in-place `Array#reject!` because I thought the original array argument would be used. This was tricky because while `reject!` normally returns the array, when nothing was rejected, it returns `nil`, causing this to to fail.
