### PR TITLE
Allow serializer#as_json to be called with nil

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -337,6 +337,7 @@ module ActiveModel
     # Returns a json representation of the serializable
     # object including the root.
     def as_json(options={})
+      options ||= {}
       if root = options.fetch(:root, @options.fetch(:root, root_name))
         @options[:hash] = hash = {}
         @options[:unique_values] = {}

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -1449,4 +1449,17 @@ class SerializerTest < ActiveModel::TestCase
       }
     }, post_serializer.as_json)
   end
+
+  def test_as_json_with_nil_options
+    user = User.new
+    user_serializer = DefaultUserSerializer.new(user, {})
+
+    # ActiveSupport 3.1 Object#to_json generates this downstream call
+    assert_equal({
+      :default_user => {
+        :first_name => "Jose",
+        :last_name => "Valim"
+      }
+    }, user_serializer.as_json(nil))
+  end
 end


### PR DESCRIPTION
This is the form that ActiveSupport 3.1 Object#to_json invokes as reported in #457.

Here's a greenfield 3.1.12 app with a minimal test demonstrating the problem: https://github.com/gtd/active_model_serializer_fail/commits/master

I don't think master supports Rails 3.1 anymore, but I'll have a look if there is still a failure path on the rewritten master.
