### PR TITLE
Make url_helpers available in serializers

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -67,6 +67,7 @@ module ActionController
       if serializer = options.fetch(:serializer, ActiveModel::Serializer.serializer_for(resource))
         options[:scope] = serialization_scope unless options.has_key?(:scope)
         options[:resource_name] = controller_name if resource.respond_to?(:to_ary)
+        options[:url_options] = url_options
 
         serializer.new(resource, options)
       end

--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -20,8 +20,10 @@ module ActiveModel
       @meta            = options[@meta_key]
       @each_serializer = options[:each_serializer]
       @resource_name   = options[:resource_name]
+      @url_options     = options[:url_options]
     end
     attr_accessor :object, :scope, :root, :meta_key, :meta
+    attr_reader :url_options
 
     def json_key
       if root.nil?
@@ -33,7 +35,7 @@ module ActiveModel
 
     def serializer_for(item)
       serializer_class = @each_serializer || Serializer.serializer_for(item) || DefaultSerializer
-      serializer_class.new(item, scope: scope)
+      serializer_class.new(item, scope: scope, url_options: url_options)
     end
 
     def serializable_object

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -107,9 +107,11 @@ end
       @root          = options.fetch(:root, self.class._root)
       @meta_key      = options[:meta_key] || :meta
       @meta          = options[@meta_key]
+      @url_options   = options[:url_options]
       @wrap_in_array = options[:_wrap_in_array]
     end
     attr_accessor :object, :scope, :root, :meta_key, :meta
+    attr_reader :url_options
 
     def json_key
       if root == true || root.nil?
@@ -166,7 +168,7 @@ end
 
     def build_serializer(association)
       object = send(association.name)
-      association.build_serializer(object, scope: scope)
+      association.build_serializer(object, scope: scope, url_options: url_options)
     end
 
     def serialize(association)

--- a/lib/active_model/serializer/railtie.rb
+++ b/lib/active_model/serializer/railtie.rb
@@ -6,5 +6,11 @@ module ActiveModel
       require 'active_model/serializer/generators/serializer/scaffold_controller_generator'
       require 'active_model/serializer/generators/resource_override'
     end
+
+    initializer 'include_url_helpers' do |app|
+      ActiveSupport.on_load(:active_model_serializers) do
+        include app.routes.url_helpers
+      end
+    end
   end
 end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -35,6 +35,13 @@ end
 class Comment < Model
 end
 
+class Category < Model
+  def posts
+    @posts ||= [Post.new(title: 'First', body: 'Post 1'),
+                Post.new(title: 'Second', body: 'Post 2')]
+  end
+end
+
 ###
 ## Serializers
 ###
@@ -59,6 +66,20 @@ class PostSerializer < ActiveModel::Serializer
   has_many :comments
 end
 
+class HypermediaPostSerializer < PostSerializer
+  attributes :title, :body, :link
+
+  def link
+    post_url
+  end
+end
+
 class CommentSerializer < ActiveModel::Serializer
   attributes :content
+end
+
+class CategorySerializer < ActiveModel::Serializer
+  attributes :name
+
+  has_many :posts, serializer: HypermediaPostSerializer
 end

--- a/test/integration/action_controller/serialization_test.rb
+++ b/test/integration/action_controller/serialization_test.rb
@@ -162,6 +162,23 @@ module ActionController
       end
     end
 
+    class HypermediaSerializerTest < ActionController::TestCase
+      class MyController < ActionController::Base
+        def render_with_hypermedia_links
+          render json: Category.new(name: 'Welcome!')
+        end
+      end
+
+      tests MyController
+
+      def test_render_json_with_links
+        get :render_with_hypermedia_links
+        assert_equal 'application/json', @response.content_type
+        assert_match '"name":"Welcome!"', @response.body
+        assert_match '"link":"http://test.host/post"', @response.body
+      end
+    end
+
     class RailsSerializerTest < ActionController::TestCase
       class MyController < ActionController::Base
         def render_using_rails_behavior

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,11 +7,13 @@ require 'fixtures/poro'
 module TestHelper
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
+    resource :post
     get ':controller(/:action(/:id))'
     get ':controller(/:action)'
   end
 
   ActionController::Base.send :include, Routes.url_helpers
+  ActiveModel::Serializer.send :include, Routes.url_helpers
 end
 
 ActionController::TestCase.class_eval do

--- a/test/unit/active_model/serializer/url_options_test.rb
+++ b/test/unit/active_model/serializer/url_options_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class UrlOptionsTest < ActiveModel::TestCase
+      def setup
+        @post = Post.new(title: 'Hi', body: 'How are you?')
+      end
+
+      def test_url_options_available
+        serializer = PostSerializer.new(@post, url_options: { host: 'example.com' })
+
+        assert_equal({ host: 'example.com' }, serializer.url_options)
+      end
+
+      def test_url_options_available_in_associations
+        category = Category.new(name: 'Welcome', posts: [@post])
+        serializer = CategorySerializer.new(category, url_options: { host: 'example.com' })
+        serialized_post = serializer.associations[:posts].first
+
+        assert_equal(serialized_post[:link], 'http://example.com/post')
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This is built for 0.9, and is a first-pass at getting Rails' `url_helpers` into the serializers. The current approach is a bit tied to Rails, but makes the helpers directly accessible w/in any instance of `ActiveModel::Serializer`. This also works for associations.

An idea I have for an alternative approach is to expose the URL helpers via a `urls` method available from serializer instances, rather than mixing the `url_helpers` directly into `ActiveModel::Serializer`. This would at least provide a seam for non-Rails apps to implement their own solution, while still relying on a `Serializer.urls` API. I could try that here to in a different pull request, if it's desired. Or we could roll with this for now and try that when/if needed.

Thoughts?
