### PR TITLE
Remove custom serializer from association options

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -17,7 +17,7 @@ module ActiveModel
       @root            = options.fetch(:root, self.class._root)
       @meta_key        = options[:meta_key] || :meta
       @meta            = options[@meta_key]
-      @each_serializer = options[:each_serializer]
+      @each_serializer = options.delete(:each_serializer)
       @options         = options.merge(root: nil)
     end
     attr_accessor :object, :root, :meta_key, :meta, :options

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -19,7 +19,7 @@ module ActiveModel
         @key           = options[:key]
         @embedded_key  = options[:root] || name
 
-        serializer = @options[:serializer]
+        serializer = @options.delete(:serializer)
         @serializer_class = serializer.is_a?(String) ? serializer.constantize : serializer
       end
 

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -35,6 +35,13 @@ end
 class Comment < Model
 end
 
+class Category < Model
+  def posts
+    @attributes[:posts] ||= [Post.new(title: 'First', body: 'Post 1'),
+                             Post.new(title: 'Second', body: 'Post 2')]
+  end
+end
+
 ###
 ## Serializers
 ###
@@ -66,4 +73,10 @@ end
 
 class CommentSerializer < ActiveModel::Serializer
   attributes :content
+end
+
+class CategorySerializer < ActiveModel::Serializer
+  attributes :name
+
+  has_many :posts
 end

--- a/test/unit/active_model/serializer/associations_test.rb
+++ b/test/unit/active_model/serializer/associations_test.rb
@@ -15,5 +15,22 @@ module ActiveModel
                      another_inherited_serializer_klass._associations.keys)
       end
     end
+
+    class AssociationsWithCustomSerializer < ActiveModel::TestCase
+      def setup
+        post = Post.new(title: 'Hi', description: 'How are you?', comments: [Comment.new])
+        @category = Category.new(name: 'Hello, World!', posts: [post])
+      end
+
+      def test_does_not_pass_custom_serializer_option_to_nested_associations
+        category_serializer = Class.new(CategorySerializer) do
+          has_many :posts, serializer: PostSerializer
+        end
+        serializer = category_serializer.new(@category)
+        comments = serializer.associations[:posts].first[:comments]
+
+        assert_equal([{content:'C1'}, {content:'C2'}], comments)
+      end
+    end
   end
 end


### PR DESCRIPTION
As of SHA: c8cfe94f299619382d2178344e99d6c6d0e02cb1, we now pass the `options` hash for one serializer down the associations. However, that also means we're now passing along the `:serializer` and `:each_serializer` options specified on a `has_one` or `has_many` association. This change will delete those values from the options hash when initializing the respective `Association` object.
