### PR TITLE
Ensure custom serializer option isn't passed to nested associations.

### DIFF
--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -27,8 +27,8 @@ end
 
 class Post < Model
   def comments
-    @comments ||= [Comment.new(content: 'C1'),
-                   Comment.new(content: 'C2')]
+    @attributes[:comments] ||=  [Comment.new(content: 'C1'),
+                                 Comment.new(content: 'C2')]
   end
 end
 

--- a/test/unit/active_model/array_serializer/serialization_test.rb
+++ b/test/unit/active_model/array_serializer/serialization_test.rb
@@ -51,16 +51,8 @@ module ActiveModel
         @association.embed_in_root = true
 
         @post1 = Post.new({ title: 'Title 1', body: 'Body 1', date: '1/1/2000' })
-        @post2 = Post.new({ title: 'Title 2', body: 'Body 2', date: '1/1/2000' })
-
-        class << @post2
-          attr_writer :comments
-        end
-
-        @post2.comments = [
-          Comment.new(content: 'C3'),
-          Comment.new(content: 'C4')
-        ]
+        @post2 = Post.new({ title: 'Title 2', body: 'Body 2', date: '1/1/2000',
+                            comments: [Comment.new(content: 'C3')] })
 
         @serializer = ArraySerializer.new([@post1, @post2], root: :posts)
         assert_equal({
@@ -71,8 +63,7 @@ module ActiveModel
             comments: [
               {content: "C1"},
               {content: "C2"},
-              {content: "C3"},
-              {content: "C4"}
+              {content: "C3"}
             ]
           }, @serializer.as_json)
       ensure

--- a/test/unit/active_model/serializer/associations_test.rb
+++ b/test/unit/active_model/serializer/associations_test.rb
@@ -15,5 +15,22 @@ module ActiveModel
                      another_inherited_serializer_klass._associations.keys)
       end
     end
+
+    class AssociationsWithCustomSerializer < ActiveModel::TestCase
+      def setup
+        @post = Post.new(title: 'Hi', description: 'How are you?',
+                         comments: [Comment.new(content: 'C1')])
+      end
+
+      def test_does_not_pass_custom_serializer_option_to_nested_associations
+        post_serializer = Class.new(PostSerializer) do
+          has_many :comments, serializer: CommentSerializer
+        end
+        serializer = post_serializer.new(@post)
+        comment = serializer.associations[:comments].first
+
+        assert_equal({content:'C1'}, comment)
+      end
+    end
   end
 end


### PR DESCRIPTION
These tests cover a missing case and ensure any custom serializer options (specified via `has_one :foo, serializer: CustomSerializer`, for example) are not passed down to nested associations.
