### PR TITLE
README : Mention the `options` and `UrlHelpers` issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 **master is under development, there are some incompatible changes with the current stable release.**
 
+Since `0.8` there is no `options` accessor in the serializers. Some issues and pull-requests are attemps to bring back the ability to use Rails url helpers in the serializers, but nothing is really settled yet.
+
 If you want to read the stable documentation visit [0.8 README](https://github.com/rails-api/active_model_serializers/blob/0-8-stable/README.md)
 
 ## Purpose


### PR DESCRIPTION
As recommend by @spastorino in https://github.com/rails-api/active_model_serializers/issues/486 here is a warning about an incompatible change between `0.8` and `0.9`.
