### PR TITLE
Bring back :only/:except options

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -108,6 +108,8 @@ end
       @meta_key      = options[:meta_key] || :meta
       @meta          = options[@meta_key]
       @wrap_in_array = options[:_wrap_in_array]
+      @only          = Array(options[:only]) if options[:only]
+      @except        = Array(options[:except]) if options[:except]
     end
     attr_accessor :object, :scope, :root, :meta_key, :meta
 
@@ -140,7 +142,13 @@ end
     end
 
     def filter(keys)
-      keys
+      if @only
+        keys & @only
+      elsif @except
+        keys - @except
+      else
+        keys
+      end
     end
 
     def embedded_in_root_associations

--- a/test/unit/active_model/serializer/filter_test.rb
+++ b/test/unit/active_model/serializer/filter_test.rb
@@ -2,6 +2,26 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
+    class FilterOptionsTest < Minitest::Test
+      def setup
+        @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+      end
+
+      def test_only_option
+        @profile_serializer = ProfileSerializer.new(@profile, only: :name)
+        assert_equal({
+          'profile' => { name: 'Name 1' }
+        }, @profile_serializer.as_json)
+      end
+
+      def test_except_option
+        @profile_serializer = ProfileSerializer.new(@profile, except: :comments)
+        assert_equal({
+          'profile' => { name: 'Name 1', description: 'Description 1' }
+        }, @profile_serializer.as_json)
+      end
+    end
+
     class FilterAttributesTest < Minitest::Test
       def setup
         @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })


### PR DESCRIPTION
I noticed in 0.9 rewrite only/except options have been removed. I think they can be neatly implemented using filter as seen in this PR. Thoughts?
