### PR TITLE
Custom options are accessible in serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -116,8 +116,9 @@ end
       @only          = Array(options[:only]) if options[:only]
       @except        = Array(options[:except]) if options[:except]
       @key_format    = options[:key_format]
+      @context       = options[:context]
     end
-    attr_accessor :object, :scope, :root, :meta_key, :meta, :key_format
+    attr_accessor :object, :scope, :root, :meta_key, :meta, :key_format, :context
 
     def json_key
       key = if root == true || root.nil?

--- a/test/unit/active_model/serializer/options_test.rb
+++ b/test/unit/active_model/serializer/options_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class OptionsTest < Minitest::Test
+      def setup
+        @serializer = ProfileSerializer.new(nil, context: {foo: :bar})
+      end
+
+      def test_custom_options_are_accessible_from_serializer
+        assert_equal({foo: :bar}, @serializer.context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Possible to access `@options` in a `Serializer` as it was in `0.8`.

By doing so, you can use the `options` to filter attributes:

```
def filter(keys)
  keys.delete(:foo) if @options[:bar]
  keys
end
```
