### PR TITLE
Define custom serializer for a class

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -42,6 +42,8 @@ end
         def serializer_for(resource)
           if resource.respond_to?(:to_ary)
             ArraySerializer
+          elsif resource.respond_to?(:serializer_class)
+            resource.serializer_class
           else
             begin
               Object.const_get "#{resource.class.name}Serializer"


### PR DESCRIPTION
How to set a serializer for given class, if I don't want to create another serializer with "xxxSerializer" name?

f.e.

``` rb
class AbstractImage
  def serializer_class
    ImageSerializer
  end
end

class AvatarImage < AbstractImage; end
class CoverImage < AbstractImage; end

# I want all of those classes to be serialized with ImageSerializer, not AbstractImageSerializer, AvatarImageSerializer or DefaultSerializer
```

AFAIR there used to be `#serializer_class` method, but seems like it got removed from [ActiveModel::Serializer](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer.rb#L42) ? Why? 

If there's no particular reason, I'll send a PR fixing it back.
