### PR TITLE
Update Rubinius Gemfiles, Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.1.0
   - ruby-head
   - jruby
-  - rbx
+  - rbx-2
 gemfile:
   - Gemfile
   - Gemfile.rails3

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :ruby do
-  gem 'sqlite3'
+  # sqlite3 1.3.9 does not work with rubinius 2.2.5:
+  # https://github.com/sparklemotion/sqlite3-ruby/issues/122
+  gem 'sqlite3', '1.3.8'
 end
 
 platforms :mri do
@@ -13,12 +15,6 @@ end
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
-end
-
-platforms :rbx do
-  gem 'json'
-  gem 'rubysl', '~> 2.0'
-  gem 'racc', '~> 1.4.10'
 end
 
 gem 'rails', '~> 4.0.0'

--- a/Gemfile.edge
+++ b/Gemfile.edge
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '1.3.8'
 end
 
 platforms :mri do
@@ -13,12 +13,6 @@ end
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
-end
-
-platforms :rbx do
-  gem 'json'
-  gem 'rubysl', '~> 2.0'
-  gem 'racc', '~> 1.4.10'
 end
 
 # Use Rails master + current dependencies

--- a/Gemfile.rails3
+++ b/Gemfile.rails3
@@ -2,9 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '1.3.8'
 end
 
 platforms :mri do
@@ -14,13 +13,6 @@ end
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
-end
-
-platforms :rbx do
-  gem 'json'
-  gem 'rubysl', '~> 2.0'
-  gem 'rubysl-test-unit', '~> 2.0'
-  gem 'racc', '~> 1.4.10'
 end
 
 gem 'minitest', '~> 4.0'


### PR DESCRIPTION
Simplify the Gemfile setup for Travis by specifying `rbx-2`.

This commit updates the Travis version of Rubinius to 2.2.5+, which includes the ruby standard library. Thus platform-specific Gemfile configuration is no longer needed for Rubinius.

Also, Rubinius 2.2.5 does not work with sqilte3 1.3.9, so require sqlite3 version 1.3.8 until it does.

:computer: To run the tests locally, you will need to use Rubinius 2.2.5+.

See http://www.benjaminfleischer.com/2013/12/05/testing-rubinius-on-travis-ci/
