### PR TITLE
Use Object.const_get when defined rather than checking RUBY_VERSION

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -38,7 +38,7 @@ end
         WARN
       end
 
-      if RUBY_VERSION >= '2.0'
+      if defined?(Object.const_get)
         def serializer_for(resource)
           if resource.respond_to?(:to_ary)
             ArraySerializer


### PR DESCRIPTION
`safe_constantize` eventually ends up poking around in the autoloading code, which means stat'ing files and various things, which is very slow.  JRuby 1.7 has Object.const_get and RUBY_VERSION == '1.9.3', so we should probably check whether it exists and use it if so, rather than testing for RUBY_VERSION.
