### PR TITLE
alias belongs_to to has_one

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -63,6 +63,8 @@ module ActiveModel
         end
       end
 
+      class BelongsTo < HasOne;end
+
       class HasMany < Association
         def initialize(name, *args)
           super


### PR DESCRIPTION
It seems like the most intuitive behavior for working with associations is to have belongs_to work since that's how we declare these relationships in rails
