### PR TITLE
Added hidden_attributes method for default hidden attributes.

### DIFF
--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -35,6 +35,9 @@ end
 class Comment < Model
 end
 
+class Desk < Model
+end
+
 ###
 ## Serializers
 ###
@@ -61,4 +64,9 @@ end
 
 class CommentSerializer < ActiveModel::Serializer
   attributes :content
+end
+
+class DeskSerializer < ActiveModel::Serializer
+  attributes :drawer, :lamp
+  hidden_attributes :secret_document
 end

--- a/test/unit/active_model/serializer/filter_test.rb
+++ b/test/unit/active_model/serializer/filter_test.rb
@@ -5,6 +5,7 @@ module ActiveModel
     class FilterOptionsTest < Minitest::Test
       def setup
         @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+        @desk = Desk.new({ drawer: 'My drawer', lamp: 'My lamp', secret_document: 'Some secret document' })
       end
 
       def test_only_option
@@ -19,6 +20,20 @@ module ActiveModel
         assert_equal({
           'profile' => { name: 'Name 1', description: 'Description 1' }
         }, @profile_serializer.as_json)
+      end
+
+      def test_not_expose_hidden_attribute
+        desk_serializer = DeskSerializer.new(@desk)
+        assert_equal({
+          'desk' => { drawer: 'My drawer', lamp: 'My lamp' }
+        }, desk_serializer.as_json)
+      end
+
+      def test_expose_hidden_attribute
+        desk_serializer = DeskSerializer.new(@desk, expose: :secret_document)
+        assert_equal({
+          'desk' => { drawer: 'My drawer', lamp: 'My lamp', secret_document: 'Some secret document' }
+        }, desk_serializer.as_json)
       end
     end
 


### PR DESCRIPTION
Adds the ability to define `hidden_attributes` that are not rendered by default. For example, say you have a `UserSerializer` with a `home_address` attribute that you don't want to remember to exclude every time you use that serializer. Just define your serializer with `hidden_attributes :home_address` and then add the `expose: :home_address` option in the places where you do want `home_address` displayed.
