### PR TITLE
Fix ArraySerializer's output when falling back on DefaultSerializer

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -83,7 +83,7 @@ module ActiveModel
           serializer = item.active_model_serializer
         end
 
-        serializable = serializer ? serializer.new(item, @options) : DefaultSerializer.new(item, @options)
+        serializable = serializer ? serializer.new(item, @options) : DefaultSerializer.new(item, @options.merge(:root => false))
 
         if serializable.respond_to?(:serializable_hash)
           serializable.serializable_hash

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -2,6 +2,27 @@ require "test_helper"
 require "test_fakes"
 
 class ArraySerializerTest < ActiveModel::TestCase
+
+  def test_array_items_do_not_have_root
+    array = [
+        BasicActiveModel.new(:name => "First model"),
+        BasicActiveModel.new(:name => "Second model")
+    ]
+    expected = { "root" => [
+        { :name => "First model" },
+        { :name => "Second model" }
+    ] }
+
+    default_serializer = array.active_model_serializer.new(array, :root => "root")
+    each_serializer = array.active_model_serializer.new(array, :root => "root", :each_serializer => BasicSerializer)
+
+    default_json = default_serializer.as_json
+    each_json = each_serializer.as_json
+
+    assert_equal(expected, default_json)
+    assert_equal(expected, each_json)
+  end
+
   # serialize different typed objects
   def test_array_serializer
     model    = Model.new

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -1,3 +1,26 @@
+class BasicActiveModel
+  include ActiveModel::Serializers::JSON
+  def initialize(hash = {})
+    @attributes = hash
+  end
+
+  def serializable_hash(*)
+    @attributes
+  end
+
+  def method_missing(method)
+    if @attributes.key? method
+      @attributes[method]
+    else
+      raise NoMethodError
+    end
+  end
+end
+
+class BasicSerializer < ActiveModel::Serializer
+  attributes :name
+end
+
 class Model
   def initialize(hash={})
     @attributes = hash


### PR DESCRIPTION
As detailed in #495, `ArraySerializer`'s output sometimes contains unexpected root keys for each item of the array. This will happen when no serializer is defined for the array item and is caused by passing `:root => true` by default to `DefaultSerializer`. On the other hand, if any `ActiveModel::Serializer` is defined for the object the root keys will not be added.

This commit changes the instantiation of `DefaultSerializer` to pass `:root => false` instead. This ensures consistent results for serializing arrays regardless of whether or not a serializer has been defined for the array items. The tests added not only test that the root keys are not present but also test to make sure that this behaviour is consistent for both `DefaultSerializer` and custom serializers.
