### PR TITLE
Deal with combining embed_in_root: true and embed: :objects

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -160,12 +160,14 @@ end
             association_serializer = build_serializer(association)
             hash.merge! association_serializer.embedded_in_root_associations
 
-            serialized_data = association_serializer.serializable_object
-            key = association.root_key
-            if hash.has_key?(key)
-              hash[key].concat(serialized_data).uniq!
-            else
-              hash[key] = serialized_data
+            unless association.embed_objects?
+              serialized_data = association_serializer.serializable_object
+              key = association.root_key
+              if hash.has_key?(key)
+                hash[key].concat(serialized_data).uniq!
+              else
+                hash[key] = serialized_data
+              end
             end
           end
         end

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -58,7 +58,7 @@ module ActiveModel
         end
 
         def build_serializer(object, options = {})
-          options[:_wrap_in_array] = embed_in_root?
+          options[:_wrap_in_array] = embed_in_root? && !embed_objects?
           super
         end
       end

--- a/test/integration/active_record/active_record_test.rb
+++ b/test/integration/active_record/active_record_test.rb
@@ -58,6 +58,25 @@ module ActiveModel
         end
       end
 
+      def test_serialization_embedding_ids_inside_embed_objects_including_in_root
+        post_serializer = ARPostSerializer.new(@post)
+
+        embed(ARPostSerializer, embed: :objects, embed_in_root: true) do
+          embed(ARCommentSerializer, embed: :ids, embed_in_root: true) do
+            assert_equal({
+              'ar_post' => {
+                title: 'New post', body: 'A body!!!',
+                ar_comments: [{ :body => 'what a dumb post', "ar_tag_ids" => [3, 2] },
+                              { :body => 'i liked it', "ar_tag_ids" => [3, 1] }],
+                ar_tags: [{ name: 'short' }, { name: 'whiny' }],
+                ar_section: { 'name' => 'ruby' }
+              },
+              ar_tags: [{name: 'happy'}, {name: 'whiny'}, {name: 'short'}]
+            }, post_serializer.as_json)
+          end
+        end
+      end
+
       private
 
       def embed(serializer_class, options = {})


### PR DESCRIPTION
Currently if you have a situation where you have three serializers A, B and C where A has_many B embedded as objects and B has_many C embedded as IDs and you want C to be embedded at the root level of _A_ while rendering A to JSON, the only way to have C picked up by `embedded_in_root_associations` is to specify embed_in_root: true for both B and C.

However this has the side effect of rendering B in two places, at the root and inside serialized A. This unnecessarily increases the size of the JSON payload and also has a significant effect on performance. Since embed: :objects and embed_in_root: true aren't really compatible anyway I believe a better behavior would be to not embed B in the root (since it has embed: :objects) but to include any of B's child associations that do have embed_in_root: true set, so C would be included at the root level.

This is kind of an edge case since I don't believe there are going to be a lot of applications would be using both embed: :objects and embed: :ids like this, but Discourse's serializers does this kind of thing pretty frequently.
