### PR TITLE
New Cache strategy: Only cache the attributes of AMS

### DIFF
--- a/lib/active_model/serializer/railtie.rb
+++ b/lib/active_model/serializer/railtie.rb
@@ -6,5 +6,10 @@ module ActiveModel
       require 'active_model/serializer/generators/serializer/scaffold_controller_generator'
       require 'active_model/serializer/generators/resource_override'
     end
+
+    initializer "caching.active_model_serializer" do |app|
+      ActiveModel::Serializer.perform_caching = app.config.action_controller.perform_caching
+      ActiveModel::Serializer.cache = Rails.cache
+    end
   end
 end

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -7,10 +7,14 @@ require 'active_model/serializer/railtie' if defined?(Rails)
 begin
   require 'action_controller'
   require 'action_controller/serialization'
-
+  require 'active_support'
+  require 'active_support/core_ext'
+  
   ActiveSupport.on_load(:action_controller) do
     include ::ActionController::Serialization
   end
 rescue LoadError
   # rails not installed, continuing
 end
+
+


### PR DESCRIPTION
New Cache Strategy: Only cache the attributes of AMS

I think It's better to manage attributes only for AMS.

example:

```
imagine we have an AMS A, which contain AMS B, which contain AMS C.

If I fetch json from A, 
It will read A's attributes cache + B's result
B's result = B's attributes cache + C's result
C's result = C's attribute cache

therefore, it can manage cache by itself object and reusing the cache as far as possible

If B's cache expired, C's cache and A's cache is still work, it will lead to as little computation as possible
```
