### PR TITLE
fix uninitialized instance variable warning

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -1,6 +1,5 @@
 require 'active_model/default_serializer'
 require 'active_model/serializable'
-require 'active_model/serializer'
 
 module ActiveModel
   class ArraySerializer

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -113,8 +113,8 @@ end
       @meta_key      = options[:meta_key] || :meta
       @meta          = options[@meta_key]
       @wrap_in_array = options[:_wrap_in_array]
-      @only          = Array(options[:only]) if options[:only]
-      @except        = Array(options[:except]) if options[:except]
+      @only          = options[:only] ? Array(options[:only]) : nil
+      @except        = options[:except] ? Array(options[:except]) : nil
       @key_format    = options[:key_format]
     end
     attr_accessor :object, :scope, :root, :meta_key, :meta, :key_format

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -1,5 +1,4 @@
 require 'active_model/default_serializer'
-require 'active_model/serializer'
 
 module ActiveModel
   class Serializer


### PR DESCRIPTION
Ruby warns that `@only` and `@except` are not initialized because if they are not passed in, they are never assigned.
