### PR TITLE
Context for ArraySerializer and HasOne associations

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -33,7 +33,7 @@ module ActiveModel
 
     def serializer_for(item)
       serializer_class = @each_serializer || Serializer.serializer_for(item) || DefaultSerializer
-      serializer_class.new(item, scope: scope)
+      serializer_class.new(item, scope: scope, context: self)
     end
 
     def serializable_object

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -110,8 +110,9 @@ end
       @wrap_in_array = options[:_wrap_in_array]
       @only          = Array(options[:only]) if options[:only]
       @except        = Array(options[:except]) if options[:except]
+      @context       = options[:context]
     end
-    attr_accessor :object, :scope, :root, :meta_key, :meta
+    attr_accessor :object, :scope, :root, :meta_key, :meta, :context
 
     def json_key
       if root == true || root.nil?
@@ -174,7 +175,7 @@ end
 
     def build_serializer(association)
       object = send(association.name)
-      association.build_serializer(object, scope: scope)
+      association.build_serializer(object, scope: scope, context: self)
     end
 
     def serialize(association)

--- a/test/unit/active_model/array_serializer/serialization_test.rb
+++ b/test/unit/active_model/array_serializer/serialization_test.rb
@@ -177,6 +177,16 @@ module ActiveModel
       ensure
         UserSerializer._associations[:profile] = @old_association
       end
+
+      def test_context_passed_as_option
+        array = [Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+                 Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })]
+
+        serializer = ArraySerializer.new(array)
+        object = serializer.serializer_for(array.first)
+
+        assert_equal(object.context, serializer)
+      end
     end
   end
 end

--- a/test/unit/active_model/serializer/has_one_test.rb
+++ b/test/unit/active_model/serializer/has_one_test.rb
@@ -161,6 +161,13 @@ module ActiveModel
           'user' => { name: 'Name 1', email: 'mail@server.com', profile: { name: 'fake' } }
         }, @user_serializer.as_json)
       end
+
+      def test_association_context_passed_as_option
+        association = Association::HasOne.new('profile')
+        serializer = @user_serializer.build_serializer(association)
+
+        assert_equal(serializer.context, @user_serializer)
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request adds context to serializers. This means it's possible to differ a serialized response based on context. For example include or exclude certain associations when rendering in an array context. Or simplify responses when embedded in another serializer.

**Example before (infinite loop)**

``` ruby
class OrderSerializer < ActiveModel::Serializer
  has_many :plan_items
end
class PlanItemSerializer < ActiveModel::Serializer
  has_one :order
end
```

**Example after (new)**

``` ruby
class OrderSerializer < ActiveModel::Serializer
  has_many :plan_items

  def filter(keys)
    keys.delete(:plan_items) if @context.kind_of?(PlanItemSerializer)
    keys
  end
end
class PlanItemSerializer < ActiveModel::Serializer
  has_one :order
end
```

Or you could add a handy method to your serializer for checking context:

``` ruby
def in_context?(object=nil)
  if object.present?
    @context.kind_of?(object)
  else
    @context.present?
  end
end
```

I can add the above method to the pull request if anyone wants it.
