### PR TITLE
Use serializer option for both array, and single objects.

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -41,13 +41,8 @@ module ActionController
     end
 
     def _render_option_json(resource, options)
-      serializer = build_json_serializer(resource, options)
-
-      if serializer
-        super(serializer, options)
-      else
-        super
-      end
+      resource = build_json_serializer(resource, options) || resource
+      super
     end
 
     private
@@ -63,13 +58,13 @@ module ActionController
 
     def build_json_serializer(resource, options = {})
       options = default_serializer_options.merge(options)
+      options[:resource_name] = controller_name
+      options[:scope] ||= serialization_scope
 
-      if serializer = options.fetch(:serializer, ActiveModel::Serializer.serializer_for(resource))
-        options[:scope] = serialization_scope unless options.has_key?(:scope)
-        options[:resource_name] = controller_name if resource.respond_to?(:to_ary)
+      serializer = resource.respond_to?(:to_ary) ? ActiveModel::ArraySerializer :
+        options[:serializer] || ActiveModel::Serializer.serializer_for(resource)
 
-        serializer.new(resource, options)
-      end
+      serializer.new(resource, options) if serializer
     end
   end
 end

--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -18,7 +18,7 @@ module ActiveModel
       @root            = options.fetch(:root, self.class._root)
       @meta_key        = options[:meta_key] || :meta
       @meta            = options[@meta_key]
-      @each_serializer = options[:each_serializer]
+      @each_serializer = options[:serializer]
       @resource_name   = options[:resource_name]
     end
     attr_accessor :object, :scope, :root, :meta_key, :meta


### PR DESCRIPTION
This allows the use of a single `serializer` attribute in both cases of Array, and singular objects. I found myself always having to write extra code in situations where I normally would have been able to refactor down. I've using this myself without any adverse effect, and thought I'd share.
