### PR TITLE
Allow users to opt-out from the ActionController extensions

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -29,6 +29,11 @@ module ActionController
 
     include ActionController::Renderers
 
+    class << self
+      attr_accessor :enabled
+    end
+    self.enabled = true
+
     included do
       class_attribute :_serialization_scope
       self._serialization_scope = :current_user

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -8,8 +8,10 @@ begin
   require 'action_controller'
   require 'action_controller/serialization'
 
-  ActiveSupport.on_load(:action_controller) do
-    include ::ActionController::Serialization
+  ActiveSupport.on_load(:after_initialize) do
+    if ::ActionController::Serialization.enabled
+      ActionController::Base.send(:include, ::ActionController::Serialization)
+    end
   end
 rescue LoadError
   # rails not installed, continuing


### PR DESCRIPTION
My take on https://github.com/rails-api/active_model_serializers/pull/589

That way users can set `ActionController::Serialization.enabled = false` in an initializer or environment file.

The `after_initialize` hook is slightly unusual, but as far as I can tell it doesn't have any downside.

@steveklabnik is that solution acceptable?

cc @tjoyal, @christianblais, @arthurnn
