### PR TITLE
Array serializer pass except and only options to item serializers

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -19,6 +19,8 @@ module ActiveModel
       @meta            = options[@meta_key]
       @each_serializer = options[:each_serializer]
       @resource_name   = options[:resource_name]
+      @only            = options[:only] ? Array(options[:only]) : nil
+      @except          = options[:except] ? Array(options[:except]) : nil
       @key_format      = options[:key_format] || options[:each_serializer].try(:key_format)
     end
     attr_accessor :object, :scope, :root, :meta_key, :meta, :key_format
@@ -30,7 +32,7 @@ module ActiveModel
 
     def serializer_for(item)
       serializer_class = @each_serializer || Serializer.serializer_for(item) || DefaultSerializer
-      serializer_class.new(item, scope: scope, key_format: key_format)
+      serializer_class.new(item, scope: scope, key_format: key_format, only: @only, except: @except)
     end
 
     def serializable_object

--- a/test/unit/active_model/array_serializer/except_test.rb
+++ b/test/unit/active_model/array_serializer/except_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+module ActiveModel
+  class ArraySerializer
+    class ExceptTest < Minitest::Test
+      def test_array_serializer_pass_except_to_items_serializers
+        array = [Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+                 Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })]
+        serializer = ArraySerializer.new(array, except: [:description])
+
+        expected = [{ name: 'Name 1' },
+                    { name: 'Name 2' }]
+
+        assert_equal expected, serializer.serializable_array
+      end
+    end
+  end
+end

--- a/test/unit/active_model/array_serializer/only_test.rb
+++ b/test/unit/active_model/array_serializer/only_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+module ActiveModel
+  class ArraySerializer
+    class OnlyTest < Minitest::Test
+      def test_array_serializer_pass_only_to_items_serializers
+        array = [Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+                 Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })]
+        serializer = ArraySerializer.new(array, only: [:name])
+
+        expected = [{ name: 'Name 1' },
+                    { name: 'Name 2' }]
+
+        assert_equal expected, serializer.serializable_array
+      end
+    end
+  end
+end


### PR DESCRIPTION
So you can specify only/except options from controller while rendering collections

``` ruby
def index 
  orders = Order.all
  render json: orders, only: params[:only]
end
```
