### PR TITLE
Rename to_json as serialized to support other output types

### DIFF
--- a/lib/active_model/serializer/adapter/null_adapter.rb
+++ b/lib/active_model/serializer/adapter/null_adapter.rb
@@ -1,0 +1,19 @@
+module ActiveModel
+  class Serializer
+    class Adapter
+      class NullAdapter
+        def initialize(adapter)
+          @attributes = adapter.attributes
+        end
+
+        def serialized(options={})
+          @attributes.each_with_object({}) do |(attr, value), h|
+            h[attr] = value
+          end.to_json # FIXME: why does passing options here cause {}?
+        end
+
+        alias_method :as_json, :serialized
+      end
+    end
+  end
+end

--- a/test/adapters/null_adapter_test.rb
+++ b/test/adapters/null_adapter_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class NullAdapterTest < Minitest::Test
+        def setup
+          @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+          @profile_serializer = ProfileSerializer.new(@profile)
+
+          @adapter = NullAdapter.new(@profile_serializer)
+        end
+
+        def test_null_adapter
+          assert_equal('{"name":"Name 1","description":"Description 1"}',
+                       @adapter.serialized)
+        end
+
+        def test_null_adapter_json_alias
+          assert_equal('{"name":"Name 1","description":"Description 1"}',
+                       @adapter.as_json)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
@steveklabnik based on comment discussion, happy for suggestions for a better name or other feedback