### PR TITLE
Rename Test::Unit callbacks fix #616

### DIFF
--- a/lib/action_controller/serialization_test_case.rb
+++ b/lib/action_controller/serialization_test_case.rb
@@ -3,11 +3,11 @@ module ActionController
     extend ActiveSupport::Concern
 
     included do
-      setup :setup_subscriptions
-      teardown :teardown_subscriptions
+      setup :setup_ams_subscriptions
+      teardown :teardown_ams_subscriptions
     end
 
-    def setup_subscriptions
+    def setup_ams_subscriptions
       @serializers = Hash.new(0)
 
       ActiveSupport::Notifications.subscribe("!serialize.active_model_serializers") do |name, start, finish, id, payload|
@@ -16,7 +16,7 @@ module ActionController
       end
     end
 
-    def teardown_subscriptions
+    def teardown_ams_subscriptions
       ActiveSupport::Notifications.unsubscribe("!serialize.active_model_serializers")
     end
 


### PR DESCRIPTION
Rename callbacks since Rails' callbacks has the same names
