### PR TITLE
Allow ArraySerializer to inherit :each_serializer root

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -14,11 +14,12 @@ module ActiveModel
     def initialize(object, options={})
       @object          = object
       @scope           = options[:scope]
-      @root            = options.fetch(:root, self.class._root)
       @polymorphic   = options.fetch(:polymorphic, false)
       @meta_key        = options[:meta_key] || :meta
       @meta            = options[@meta_key]
       @each_serializer = options[:each_serializer]
+      @root            = options.fetch(:root, self.class._root)
+      @root            = options[:each_serializer].try(:_root) if @root.nil?
       @resource_name   = options[:resource_name]
       @only            = options[:only] ? Array(options[:only]) : nil
       @except          = options[:except] ? Array(options[:except]) : nil

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -104,6 +104,18 @@ class DifferentProfileSerializer < ActiveModel::Serializer
   attributes :name
 end
 
+class RootProfileSerializer < ActiveModel::Serializer
+
+  root :profiles
+
+  def description
+    description = object.read_attribute_for_serialization(:description)
+    scope ? "#{description} - #{scope}" : description
+  end
+
+  attributes :name, :description
+end
+
 class CategorySerializer < ActiveModel::Serializer
   attributes :name
 

--- a/test/unit/active_model/array_serializer/serialization_test.rb
+++ b/test/unit/active_model/array_serializer/serialization_test.rb
@@ -60,6 +60,18 @@ module ActiveModel
         assert_equal expected, serializer.as_json
       end
 
+      def test_array_serializers_each_serializer_root_inheritance
+        array = [::Model.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+                 ::Model.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })]
+
+        serializer = ArraySerializer.new(array, each_serializer: RootProfileSerializer)
+
+        expected = { profiles: [{ name: 'Name 1', description: 'Description 1' },
+                                { name: 'Name 2', description: 'Description 2' }] }
+
+        assert_equal expected, serializer.as_json
+      end
+
       def test_associated_objects_of_multiple_instances_embedded_in_root
         @association = PostSerializer._associations[:comments]
         @old_association = @association.dup


### PR DESCRIPTION
**This PR replaces #619 as there was too many conflicts after multiple rebases.**

This change make ArraySerializer inherit `each_serializer`'s root when no specific root is set.

I'ts just a way to avoid definig root twice and keep things DRY.

JSON API now requires the same (plural) root for single resource and collections.