### PR TITLE
Add serialization_scope and default_serializer_options

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -1,22 +1,66 @@
 require 'active_support/core_ext/class/attribute'
 
 module ActionController
+  # Action Controller Serialization
+  #
+  # Overrides render :json to check if the given object implements +active_model_serializer+
+  # as a method. If so, use the returned serializer instead of calling +to_json+ on the object.
+  #
+  # This module also provides a serialization_scope method that allows you to configure the
+  # +serialization_scope+ of the serializer. Most apps will likely set the +serialization_scope+
+  # to the current user:
+  #
+  #    class ApplicationController < ActionController::Base
+  #      serialization_scope :current_user
+  #    end
+  #
+  # If you need more complex scope rules, you can simply override the serialization_scope:
+  #
+  #    class ApplicationController < ActionController::Base
+  #      private
+  #
+  #      def serialization_scope
+  #        current_user
+  #      end
+  #    end
+  #
   module Serialization
     extend ActiveSupport::Concern
 
     include ActionController::Renderers
 
+    included do
+      class_attribute :_serialization_scope
+      self._serialization_scope = :current_user
+    end
+
+    def serialization_scope
+      send(_serialization_scope) if _serialization_scope && respond_to?(_serialization_scope, true)
+    end
+
+    def default_serializer_options
+      {}
+    end
+
     def _render_option_json(resource, options)
+      options = default_serializer_options.merge(options)
       serializer = ActiveModel::Serializer.serializer_for(resource)
 
       if serializer
+        options[:scope] = serialization_scope unless options.has_key?(:scope)
         # omg hax
-        object = serializer.new(resource)
+        object = serializer.new(resource, options)
         adapter = ActiveModel::Serializer.adapter.new(object)
 
         super(adapter, options)
       else
         super
+      end
+    end
+
+    module ClassMethods
+      def serialization_scope(scope)
+        self._serialization_scope = scope
       end
     end
   end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -88,9 +88,10 @@ module ActiveModel
     end
 
     attr_accessor :object
+    attr_accessor :options
 
-    def initialize(object)
-      @object = object
+    def initialize(object, options={})
+      @object, @options = object, options
     end
 
     def attributes(options = {})
@@ -109,6 +110,10 @@ module ActiveModel
           block.call(name, serializer, options[:options])
         end
       end
+    end
+
+    def scope
+      @options[:scope]
     end
   end
 end

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -19,7 +19,58 @@ module ActionController
         assert_equal '{"name":"Name 1","description":"Description 1"}', @response.body
       end
     end
+
+    class ImplicitSerializerScopeTest < ActionController::TestCase
+      class MyController < ActionController::Base
+        def render_using_implicit_serializer_and_scope
+          render json: Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+        end
+
+        private
+
+        def current_user
+          'current_user'
+        end
+      end
+
+      tests MyController
+
+      def test_redner_using_implicit_serializer_and_scope
+        get :render_using_implicit_serializer_and_scope
+
+        assert_equal 'application/json', @response.content_type
+        assert_equal '{"name":"Name 1","description":"Description 1 - current_user"}', @response.body
+      end
+    end
+
+    class DefaultOptionsForSerializerScopeTest < ActionController::TestCase
+      class MyController < ActionController::Base
+        def default_serializer_options
+          { scope: current_admin }
+        end
+
+        def render_using_scope_set_in_default_serializer_options
+          render json: Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+        end
+
+        private
+
+        def current_user
+          'current_user'
+        end
+
+        def current_admin
+          'current_admin'
+        end
+      end
+
+      tests MyController
+
+      def test_render_using_scope_set_in_default_serializer_options
+        get :render_using_scope_set_in_default_serializer_options
+        assert_equal 'application/json', @response.content_type
+        assert_equal '{"name":"Name 1","description":"Description 1 - current_admin"}', @response.body
+      end
+    end
   end
 end
-
-

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -31,6 +31,11 @@ end
 
 class ProfileSerializer < ActiveModel::Serializer
   attributes :name, :description
+
+  def description
+    description = object.read_attribute_for_serialization(:description)
+    scope ? "#{description} - #{scope}" : description
+  end
 end
 
 Post = Class.new(Model)


### PR DESCRIPTION
Added in serialization_scope and default_serializer_options. Right now this is just a like for like addition from 0.8 but this should open up the ability for adapter to modify this. 

For example the JsonApi adapter will probably want the default_serializer_options to include the values of the page, sort, include and fields parameters. The adapter could define this list and we would use the currently configured adapter to define what the default serializer_options are.

Thoughts?
