### PR TITLE
Readme typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ the root document (say, `linked`), you can specify an `embed_in_root_key`:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
-  embed: ids, include: true, embed_in_root_key: :linked
+  embed :ids, include: true, embed_in_root_key: :linked
 
   attributes: :id, :title, :body
   has_many :comments, :tags


### PR DESCRIPTION
The current README has two examples of code that did not work for me. The following commits change these examples to working code.
