### PR TITLE
README: Change :embed_key to :key

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,15 +513,15 @@ Now, any associations will be supplied as an Array of IDs:
 }
 ```
 
-You may also choose to embed the IDs by the association's name underneath an
-`embed_key` for the resource. For example, say we want to change `comment_ids`
+You may also choose to embed the IDs by the association's name underneath a
+`key` for the resource. For example, say we want to change `comment_ids`
 to `comments` underneath a `links` key:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
   attributes :id, :title, :body
 
-  has_many :comments, embed: :ids, embed_namespace: :links
+  has_many :comments, embed: :ids, key: :comments, embed_namespace: :links
 end
 ```
 
@@ -683,7 +683,7 @@ class PostSerializer < ActiveModel::Serializer
   embed :ids, include: true
 
   attributes :id, :title, :body
-  has_many :comments, embed_key: :external_id
+  has_many :comments, key: :external_id
 end
 ```
 


### PR DESCRIPTION
I've never used the 0.8 version of AMS but I'm guessing `:embed_key` was changed to `:key` in 0.9 and the README wasn't updated to reflect this everywhere? When I tried using the former it didn't work. Using `:key` worked fine.
