### PR TITLE
Fix meta_key/meta documentation for v0.9.x series

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ The above usage of `:meta` will produce the following:
 If you would like to change the meta key name you can use the `:meta_key` option:
 
 ```ruby
-render json: @posts, serializer: CustomArraySerializer, meta: {total: 10}, meta_key: 'meta_object'
+render json: @posts, serializer: CustomArraySerializer, meta_object: {total: 10}, meta_key: 'meta_object'
 ```
 
 The above usage of `:meta_key` will produce the following:


### PR DESCRIPTION
This updates the documentation to reflect the [behavior implemented by the `v0.9.x` series](https://github.com/rails-api/active_model_serializers/commit/93baaa96b19e69098579b51db2f36809cfa28522). Note that this behavior differs from [that of the `v0.8.x` series](https://github.com/rails-api/active_model_serializers/commit/a71698d5bbb630262487abe3eca99c9598df04d9), which is reflected by the current documentation. Interestingly, the implementations were made months apart by different developers.

Consideration should be given to patching the `v0.9.x` series to revert back to the `v0.8.x` behavior since I'm not entirely sure if this slight change was intentional, but for the time being, this at least documents the existing behavior correctly.
