### PR TITLE
include? does not exclude if declared

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -369,8 +369,8 @@ module ActiveModel
     end
 
     def include?(name)
-      return false if @options.key?(:only) && !Array(@options[:only]).include?(name)
-      return false if @options.key?(:except) && Array(@options[:except]).include?(name)
+      return false if @options.key?(:only) && !Array(@options[:only]).include?(:#{name.to_sym})
+      return false if @options.key?(:except) && Array(@options[:except]).include?(:#{name.to_sym})
       send INCLUDE_METHODS[name]
     end
 


### PR DESCRIPTION
options[:include] is missing/empty or attr included and not in exclude if declared
