### PR TITLE
Fix namespaced serializers reloading

### DIFF
--- a/lib/active_model/serializable/utils.rb
+++ b/lib/active_model/serializable/utils.rb
@@ -4,8 +4,12 @@ module ActiveModel
       extend self
 
       def _const_get(const)
-        method = RUBY_VERSION >= '2.0' ? :const_get : :qualified_const_get
-        Object.send method, const
+        begin
+          method = RUBY_VERSION >= '2.0' ? :const_get : :qualified_const_get
+          Object.send method, const
+        rescue NameError
+          const.safe_constantize
+        end
       end
     end
   end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -63,11 +63,7 @@ end
             ArraySerializer
           end
         else
-          begin
-            _const_get build_serializer_class(resource, options)
-          rescue NameError
-            nil
-          end
+          _const_get build_serializer_class(resource, options)
         end
       end
 


### PR DESCRIPTION
As discussed (https://github.com/rails-api/active_model_serializers/pull/617#issuecomment-54798433) with @konukhov, some namespaced serializers aren't found anymore after a reload in development mode.

Note sure if it's Rails related but this PR adds a fallback `safe_constantize` when `#const_get` doesn't find a matching serializer in the parent tree. This is more like a workaround but it actually works fine.

As `safe_constantize` returns nil if the class is not found, I've moved the `begin...rescue NameError` in `_const_get` so it's not necessary anymore to add it in methods depending on it.
