### PR TITLE
Add plural_default_root config option

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -72,7 +72,10 @@ end
       alias root= _root=
 
       def root_name
-        name.demodulize.underscore.sub(/_serializer$/, '') if name
+        if name
+          root_name = name.demodulize.underscore.sub(/_serializer$/, '')
+          CONFIG.plural_default_root ? root_name.pluralize : root_name
+        end
       end
 
       def attributes(*attrs)

--- a/test/unit/active_model/serializer/config_test.rb
+++ b/test/unit/active_model/serializer/config_test.rb
@@ -78,6 +78,9 @@ module ActiveModel
           assert !association.embed_objects?
           assert association.embed_in_root
           assert_equal :lower_camel, association.key_format
+          assert_equal 'post', PostSerializer.root_name
+          CONFIG.plural_default_root = true
+          assert_equal 'posts', PostSerializer.root_name
         ensure
           PostSerializer._associations[:comments] = old_association
           CONFIG.clear


### PR DESCRIPTION
This PR adds a `plural_default_root` config options which will take the pluralized name by default as root key to match JSON-API specs (https://github.com/json-api/json-api/blob/gh-pages/format/index.md#individual-resource-representations-)

The default behavior keeps using singular root name for individual resources, but by setting `config.plural_default_root = true` in an initializer, all serializers will take pluralized root keys by default, avoiding the need to set it in each serializer.
