### PR TITLE
Fix Rails Master

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -40,7 +40,7 @@ module ActionController
     def default_serializer_options
     end
 
-    %i(_render_option_json _render_with_renderer_json).each do |renderer_method|
+    [:_render_option_json, :_render_with_renderer_json].each do |renderer_method|
       define_method renderer_method do |resource, options|
         json = ActiveModel::Serializer.build_json(self, resource, options)
 


### PR DESCRIPTION
Looks like rails master is now calling `_render_with_renderer_json` instead of `_render_option_json` as of
https://github.com/rails/rails/commit/4dfe140ef3fbed34e6ae8af3b32402630a4690a1
