### PR TITLE
Add auto-stripping of question mark for attributes

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -79,10 +79,12 @@ end
       end
 
       def attributes(*attrs)
-        @_attributes.concat attrs
-
         attrs.each do |attr|
-          define_method attr do
+          striped_attr = strip_attribute attr
+
+          @_attributes << striped_attr
+
+          define_method striped_attr do
             object.read_attribute_for_serialization attr
           end unless method_defined?(attr)
         end
@@ -97,6 +99,14 @@ end
       end
 
       private
+
+      def strip_attribute(attr)
+        symbolized = attr.is_a?(Symbol)
+
+        attr = attr.to_s.gsub(/\?\Z/, '')
+        attr = attr.to_sym if symbolized
+        attr
+      end
 
       def build_serializer_class(resource, options)
         "".tap do |klass_name|

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,11 +1,13 @@
 class Model
-  def initialize(hash={})
+  def initialize(hash = {})
     @attributes = hash
   end
 
   def read_attribute_for_serialization(name)
     if name == :id || name == 'id'
       object_id
+    elsif respond_to?(name)
+      send name
     else
       @attributes[name]
     end

--- a/test/unit/active_model/serializer/attributes_test.rb
+++ b/test/unit/active_model/serializer/attributes_test.rb
@@ -36,6 +36,22 @@ module ActiveModel
         assert_equal([:name, :description],
                      another_inherited_serializer_klass._attributes)
       end
+
+      def tests_query_attributes_strip_question_mark
+        model = Class.new(::Model) do
+          def strip?
+            true
+          end
+        end
+
+        serializer = Class.new(ActiveModel::Serializer) do
+          attributes :strip?
+        end
+
+        actual = serializer.new(model.new).as_json
+
+        assert_equal({ strip: true }, actual)
+      end
     end
   end
 end


### PR DESCRIPTION
This is a pull-request for issue #605. There is a little mess in this part

``` ruby
striped_attrs = attrs.map do |attr|
  symbolized = attr.is_a?(Symbol)

  attr = attr.to_s.gsub(/\?\Z/, '')
  attr = attr.to_sym if symbolized
  attr
end
```

I had to add condition of checking attribute type to make tests from this commit https://github.com/rails-api/active_model_serializers/commit/06e4c2c9d601a067124e2653ff66e0c8c5320867 pass.
As we can see if we pass string params to `attributes` method than output hash will be generated with string param as a key.

Example:

``` ruby
class UserSerializer < ActiveModel::Serializer
  attributes 'name', :gender
end
```

``` ruby
UserSerializer.new(user).as_json # => { 'name' => 'John Doe', :gender => 'male'  }
```

I think that this is a little bit strange. It would be much predictable to generate symbolized hash no matter what kind of param was passed to `attributes` method. Tell me if you agree with this and I'll fix this pull-request.
