### PR TITLE
Fix use of `super` in `define_method`

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -47,7 +47,7 @@ module ActionController
         if json
           super(json, options)
         else
-          super
+          super(resource, options)
         end
       end
     end


### PR DESCRIPTION
We need to explicitly specify arguments when using `super` in `define_method`.
I messed this up in #655.
