### PR TITLE
Make sure `render json: ..., each_serializer: ...` is working with Enumerables

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -84,7 +84,7 @@ module ActionController
       if serializer = options.fetch(:serializer, default_serializer(resource))
         options[:scope] = serialization_scope unless options.has_key?(:scope)
 
-        if resource.respond_to?(:to_ary)
+        if resource.respond_to?(:each)
           options[:resource_name] = controller_name 
           options[:namespace] = namespace_for_serializer if namespace_for_serializer
         end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -56,7 +56,7 @@ end
       attr_reader :key_format
 
       def serializer_for(resource, options = {})
-        if resource.respond_to?(:to_ary)
+        if resource.respond_to?(:each)
           if Object.constants.include?(:ArraySerializer)
             ::ArraySerializer
           else

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -92,6 +92,10 @@ class ProfileSerializer < ActiveModel::Serializer
   attributes :name, :description
 end
 
+class DifferentProfileSerializer < ActiveModel::Serializer
+  attributes :name
+end
+
 class CategorySerializer < ActiveModel::Serializer
   attributes :name
 

--- a/test/integration/action_controller/serialization_test.rb
+++ b/test/integration/action_controller/serialization_test.rb
@@ -283,5 +283,21 @@ module ActionController
         assert_equal("{\"my\":[{\"name\":\"Name 1\",\"email\":\"mail@server.com\",\"profile_id\":#{@controller.user.profile.object_id}}],\"profiles\":[{\"name\":\"N1\",\"description\":\"D1\"}]}", @response.body)
       end
     end
+  
+    class ExplicitEachSerializerWithEnumarableObjectTest < ActionController::TestCase
+      class MyController < ActionController::Base
+        def render_array
+          render json: [Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })].to_enum, each_serializer: DifferentProfileSerializer
+        end
+      end
+
+      tests MyController
+
+      def test_render_array
+        get :render_array
+        assert_equal 'application/json', @response.content_type
+        assert_equal '{"my":[{"name":"Name 1"}]}', @response.body
+      end
+    end
   end
 end


### PR DESCRIPTION
If you try to render Enumerable with custom `each_serializer` then it will render with default serializer instead:

``` ruby
render json: sequel_scope, each_serializer: CustomSerializer
```

This commit fixes this behaviour. Most likely fixes https://github.com/rails-api/active_model_serializers/issues/664 as well
