### PR TITLE
Support Rails 4.2.0 with AMS 0.9

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -45,13 +45,15 @@ module ActionController
       end
     end
 
-    def _render_option_json(resource, options)
-      serializer = build_json_serializer(resource, options)
+    [:_render_option_json, :_render_with_renderer_json].each do |renderer_method|
+      define_method renderer_method do |resource, options|
+        serializer = build_json_serializer(resource, options)
 
-      if serializer
-        super(serializer, options)
-      else
-        super
+        if serializer
+          super(serializer, options)
+        else
+          super(resource, options)
+        end
       end
     end
 


### PR DESCRIPTION
This patch is the same fixes as #655 and #663 for 0-9-stable branch.
