### PR TITLE
Add support for embed: :ids option for in associations

### DIFF
--- a/test/adapter/json_api/has_many_embed_ids.rb
+++ b/test/adapter/json_api/has_many_embed_ids.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi
+        class HasManyEmbedIdsTest < Minitest::Test
+          def setup
+            @author = Author.new(name: 'Steve K.')
+            @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
+            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+            @author.posts = [@first_post, @second_post]
+            @first_post.author = @author
+            @second_post.author = @author
+
+            @serializer = AuthorSerializer.new(@author)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
+          end
+
+          def test_includes_comment_ids
+            assert_equal([1, 2], @adapter.serializable_hash[:links][:posts])
+          end
+
+          def test_no_includes_linked_comments
+            assert_nil @adapter.serializable_hash[:linked]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -35,6 +35,7 @@ end
 
 Post = Class.new(Model)
 Comment = Class.new(Model)
+Author = Class.new(Model)
 
 PostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :title, :body, :id
@@ -46,4 +47,10 @@ CommentSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :body
 
   belongs_to :post
+end
+
+AuthorSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id, :name
+
+  has_many :posts, embed: :ids
 end


### PR DESCRIPTION
Hey!!

We would like to add an option to associations to allow the inclusion of only associated object ids instead of full objects, for this I'm proposing the `embed: :ids` option, example:

``` ruby
class AuthorSerializer < ActiveModel::Serializer
  attributes :id, :name

  has_many :posts, embed: :ids
end
```

in JSON API adapter this will not include the posts within the `linked` hash.

I'm not convinced by the option name, let me know if you have other suggestions.
