### PR TITLE
Added spec to show array serialization doesn't work in integration specs

### DIFF
--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -7,6 +7,14 @@ module ActionController
         def render_using_implicit_serializer
           render json: Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
         end
+
+        def render_array_using_implicit_serializer
+          array = [
+            Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+            Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })
+          ]
+          render json: array
+        end
       end
 
       tests MyController
@@ -18,8 +26,24 @@ module ActionController
         assert_equal 'application/json', @response.content_type
         assert_equal '{"name":"Name 1","description":"Description 1"}', @response.body
       end
+
+      def test_render_array_using_implicit_serializer
+        get :render_array_using_implicit_serializer
+        assert_equal 'application/json', @response.content_type
+
+        expected = [
+          {
+            name: 'Name 1',
+            description: 'Description 1',
+          },
+          {
+            name: 'Name 2',
+            description: 'Description 2',
+          }
+        ]
+
+        assert_equal expected.to_json, @response.body
+      end
     end
   end
 end
-
-


### PR DESCRIPTION
I have yet to find a solution to this, but I wanted to bring it up. 

This is the error:

```
ActionController::Serialization::ImplicitSerializerTest#test_render_array_using_implicit_serializer:
NoMethodError: undefined method `attributes' for #<ActiveModel::Serializer::ArraySerializer:0x00000002968c58>
    active_model_serializers/lib/active_model/serializer/adapter/json.rb:6:in `serializable_hash'
    active_model_serializers/lib/active_model/serializer/adapter.rb:20:in `to_json'
    .rvm/gems/ruby-2.1.2/gems/actionpack-4.1.6/lib/action_controller/metal/renderers.rb:96:in `block in <module:Renderers>'
    active_model_serializers/lib/action_controller/serialization.rb:18:in `block (2 levels) in <module:Serialization>'
```

I'm still investigating. I'll post a solution as soon as I find one. 
