### PR TITLE
Check superclasses for Serializers

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -66,8 +66,7 @@ module ActiveModel
       if resource.respond_to?(:to_ary)
         config.array_serializer
       else
-        serializer_class = "#{resource.class.name}Serializer"
-        serializer_class.safe_constantize
+        get_serializer_for(resource.class)
       end
     end
 
@@ -110,5 +109,19 @@ module ActiveModel
         end
       end
     end
+
+    private
+
+    def self.get_serializer_for(klass)
+      serializer_class_name = "#{klass.name}Serializer"
+      serializer_class = serializer_class_name.safe_constantize
+
+      if serializer_class
+        serializer_class
+      elsif klass.superclass
+        get_serializer_for(klass.superclass)
+      end
+    end
+
   end
 end

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -27,8 +27,12 @@ module ActiveModel
       end
 
       class SerializerTest <  Minitest::Test
+        class MyProfile < Profile
+        end
+
         def setup
           @profile = Profile.new
+          @my_profile = MyProfile.new
           @model = ::Model.new
         end
 
@@ -40,6 +44,11 @@ module ActiveModel
         def test_serializer_for_not_existing_serializer
           serializer = ActiveModel::Serializer.serializer_for(@model)
           assert_equal nil, serializer
+        end
+
+        def test_serializer_inherited_serializer
+          serializer = ActiveModel::Serializer.serializer_for(@my_profile)
+          assert_equal ProfileSerializer, serializer
         end
       end
     end


### PR DESCRIPTION
This may be related to #525 

If a serializer is defined for a base class, but not the subclass, no serializer is currently used on the subclass object.
