### PR TITLE
Serialize ids as strings in JSON-API adapter

### DIFF
--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -16,11 +16,11 @@ module ActiveModel
           end
 
           def test_includes_post_id
-            assert_equal(42, @adapter.serializable_hash[:comments][:links][:post])
+            assert_equal("42", @adapter.serializable_hash[:comments][:links][:post])
           end
 
           def test_includes_linked_post
-            assert_equal([{id: 42, title: 'New Post', body: 'Body'}], @adapter.serializable_hash[:linked][:posts])
+            assert_equal([{id: "42", title: 'New Post', body: 'Body'}], @adapter.serializable_hash[:linked][:posts])
           end
         end
       end

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -17,8 +17,8 @@ module ActiveModel
 
           def test_include_multiple_posts
             assert_equal([
-                           {title: "Hello!!", body: "Hello, world!!", id: 1, links: {comments: []}},
-                           {title: "New Post", body: "Body", id: 2, links: {comments: []}}
+                           {title: "Hello!!", body: "Hello, world!!", id: "1", links: {comments: []}},
+                           {title: "New Post", body: "Body", id: "2", links: {comments: []}}
                          ], @adapter.serializable_hash[:posts])
           end
         end

--- a/test/adapter/json_api/has_many_embed_ids.rb
+++ b/test/adapter/json_api/has_many_embed_ids.rb
@@ -18,7 +18,7 @@ module ActiveModel
           end
 
           def test_includes_comment_ids
-            assert_equal([1, 2], @adapter.serializable_hash[:authors][:links][:posts])
+            assert_equal(["1", "2"], @adapter.serializable_hash[:authors][:links][:posts])
           end
 
           def test_no_includes_linked_comments

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -18,13 +18,13 @@ module ActiveModel
           end
 
           def test_includes_comment_ids
-            assert_equal([1, 2], @adapter.serializable_hash[:posts][:links][:comments])
+            assert_equal(["1", "2"], @adapter.serializable_hash[:posts][:links][:comments])
           end
 
           def test_includes_linked_comments
             assert_equal([
-                           {id: 1, body: 'ZOMG A COMMENT'},
-                           {id: 2, body: 'ZOMG ANOTHER COMMENT'}
+                           {id: "1", body: 'ZOMG A COMMENT'},
+                           {id: "2", body: 'ZOMG ANOTHER COMMENT'}
                          ], @adapter.serializable_hash[:linked][:comments])
           end
         end


### PR DESCRIPTION
Serialize ids as strings in JSON-API adapter.

Same as #683 but updated
