### PR TITLE
Cache Support at AMS 0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ coverage
 doc/
 lib/bundler/man
 pkg
+Vagrantfile
+.vagrant
 rdoc
 spec/reports
 test/tmp

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ serializers:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
+  cache key: 'posts', expires_in: 3.hours
   attributes :title, :body
 
   has_many :comments
@@ -245,6 +246,37 @@ You may also use the `:serializer` option to specify a custom serializer class, 
 
 The `url` declaration describes which named routes to use while generating URLs
 for your JSON. Not every adapter will require URLs.
+
+## Caching
+
+To cache a serializer, call ```cache``` and pass its options.
+The options are the same options of ```ActiveSupport::Cache::Store```, plus
+a ```key``` option that will be the prefix of the object cache
+on a pattern ```"#{key}/#{object.id}-#{object.updated_at}"```.
+
+**[NOTE] Every object is individually cached.**
+**[NOTE] The cache is automatically expired after update an object but it's not deleted.**
+
+```ruby
+cache(options = nil) # options: ```{key, expires_in, compress, force, race_condition_ttl}```
+```
+
+Take the example bellow:
+
+```ruby
+class PostSerializer < ActiveModel::Serializer
+  cache key: 'post', expires_in: 3.hours
+  attributes :title, :body
+
+  has_many :comments
+
+  url :post
+end
+```
+
+On this example every ```Post``` object will be cached with
+the key ```"post/#{post.id}-#{post.updated_at}"```. You can use this key to expire it as you want,
+but in this case it will be automatically expired after 3 hours.
 
 ## Getting Help
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -10,6 +10,9 @@ module ActiveModel
       attr_accessor :_attributes
       attr_accessor :_associations
       attr_accessor :_urls
+      attr_accessor :_cache
+      attr_accessor :_cache_key
+      attr_accessor :_cache_options
     end
 
     def self.inherited(base)
@@ -36,7 +39,14 @@ module ActiveModel
       end unless method_defined?(key)
     end
 
-    # Defines an association in the object that should be rendered.
+    # Enables a serializer to be automatically cached
+    def self.cache(options = {})
+      @_cache = ActionController::Base.cache_store if Rails.configuration.action_controller.perform_caching
+      @_cache_key = options.delete(:key)
+      @_cache_options = (options.empty?) ? nil : options
+    end
+
+    # Defines an association in the object should be rendered.
     #
     # The serializer object should implement the association name
     # as a method which should return an array when invoked. If a method

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -50,6 +50,20 @@ module ActiveModel
         json[meta_key] = meta if meta && root
         json
       end
+
+      private
+
+      def cached_object
+        klass = serializer.class
+        if klass._cache
+          _cache_key = (klass._cache_key) ? "#{klass._cache_key}/#{serializer.object.id}-#{serializer.object.updated_at}" : serializer.object.cache_key
+          klass._cache.fetch(_cache_key, klass._cache_options) do
+            yield
+          end
+        else
+          yield
+        end
+      end
     end
   end
 end

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -6,19 +6,21 @@ module ActiveModel
           if serializer.respond_to?(:each)
             @result = serializer.map{|s| self.class.new(s).serializable_hash }
           else
-            @result = serializer.attributes(options)
-
-            serializer.each_association do |name, association, opts|
-              if association.respond_to?(:each)
-                array_serializer = association
-                @result[name] = array_serializer.map { |item| item.attributes(opts) }
-              else
-                if association
-                  @result[name] = association.attributes(options)
+            @result = cached_object do
+              @hash = serializer.attributes(options)
+              serializer.each_association do |name, association, opts|
+                if association.respond_to?(:each)
+                  array_serializer = association
+                  @hash[name] = array_serializer.map { |item| item.attributes(opts) }
                 else
-                  @result[name] = nil
+                  if association
+                    @hash[name] = association.attributes(options)
+                  else
+                    @hash[name] = nil
+                  end
                 end
               end
+              @hash
             end
           end
 

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -23,10 +23,12 @@ module ActiveModel
               self.class.new(s, @options.merge(top: @top, fieldset: @fieldset)).serializable_hash[@root]
             end
           else
-            @hash[@root] = attributes_for_serializer(serializer, @options)
-            add_resource_links(@hash[@root], serializer)
+            @hash = cached_object do
+              @hash[@root] = attributes_for_serializer(serializer, @options)
+              add_resource_links(@hash[@root], serializer)
+              @hash
+            end
           end
-
           @hash
         end
 

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -1,7 +1,7 @@
-require "active_model"
-require "active_model/serializer/version"
-require "active_model/serializer"
-require "active_model/serializer/fieldset"
+require 'active_model'
+require 'active_model/serializer/version'
+require 'active_model/serializer'
+require 'active_model/serializer/fieldset'
 
 begin
   require 'action_controller'

--- a/test/action_controller/json_api_linked_test.rb
+++ b/test/action_controller/json_api_linked_test.rb
@@ -5,6 +5,7 @@ module ActionController
     class JsonApiLinkedTest < ActionController::TestCase
       class MyController < ActionController::Base
         def setup_post
+          ActionController::Base.cache_store.clear
           @role1 = Role.new(id: 1, name: 'admin')
           @role2 = Role.new(id: 2, name: 'colab')
           @author = Author.new(id: 1, name: 'Steve K.')

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -21,6 +21,7 @@ module ActiveModel
 
             @serializer = CommentSerializer.new(@comment)
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
+            ActionController::Base.cache_store.clear
           end
 
           def test_includes_post

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -19,6 +19,7 @@ module ActiveModel
 
             @serializer = ArraySerializer.new([@first_post, @second_post])
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
+            ActionController::Base.cache_store.clear
           end
 
           def test_include_multiple_posts

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -28,6 +28,7 @@ module ActiveModel
 
             @serializer = CommentSerializer.new(@comment)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
+            ActionController::Base.cache_store.clear
           end
 
           def test_includes_post_id

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -21,6 +21,7 @@ module ActiveModel
 
             @serializer = ArraySerializer.new([@first_post, @second_post])
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
+            ActionController::Base.cache_store.clear
           end
 
           def test_include_multiple_posts

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -6,6 +6,7 @@ module ActiveModel
       class JsonApi
         class HasManyTest < Minitest::Test
           def setup
+            ActionController::Base.cache_store.clear
             @author = Author.new(id: 1, name: 'Steve K.')
             @author.posts = []
             @author.bio = nil

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -3,6 +3,14 @@ class Model
     @attributes = hash
   end
 
+  def cache_key
+    "#{self.class.name.downcase}/#{self.id}-#{self.updated_at}"
+  end
+
+  def updated_at
+    @attributes[:updated_at] ||= DateTime.now.to_time.to_i
+  end
+
   def read_attribute_for_serialization(name)
     if name == :id || name == 'id'
       id
@@ -55,7 +63,8 @@ module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
 
 PostSerializer = Class.new(ActiveModel::Serializer) do
-  attributes :title, :body, :id
+  cache key:'post', expires_in: 0.05
+  attributes :id, :title, :body
 
   has_many :comments
   belongs_to :blog
@@ -77,6 +86,7 @@ SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
 end
 
 CommentSerializer = Class.new(ActiveModel::Serializer) do
+  cache expires_in: 1.day
   attributes :id, :body
 
   belongs_to :post
@@ -84,6 +94,7 @@ CommentSerializer = Class.new(ActiveModel::Serializer) do
 end
 
 AuthorSerializer = Class.new(ActiveModel::Serializer) do
+  cache key:'writer'
   attributes :id, :name
 
   has_many :posts, embed: :ids

--- a/test/serializers/cache_test.rb
+++ b/test/serializers/cache_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+module ActiveModel
+  class Serializer
+    class CacheTest < Minitest::Test
+      def setup
+        @post            = Post.new({ title: 'New Post', body: 'Body' })
+        @comment         = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
+        @author          = Author.new(name: 'Joao M. D. Moura')
+        @role            = Role.new(name: 'Great Author')
+        @author.posts    = [@post]
+        @author.roles    = [@role]
+        @author.bio      = nil
+        @post.comments   = [@comment]
+        @post.author     = @author
+        @comment.post    = @post
+        @comment.author  = @author
+
+        @post_serializer    = PostSerializer.new(@post)
+        @author_serializer  = AuthorSerializer.new(@author)
+        @comment_serializer = CommentSerializer.new(@comment)
+      end
+
+      def test_cache_definition
+        assert_equal(ActionController::Base.cache_store, @post_serializer.class._cache)
+        assert_equal(ActionController::Base.cache_store, @author_serializer.class._cache)
+        assert_equal(ActionController::Base.cache_store, @comment_serializer.class._cache)
+      end
+
+      def test_cache_key_definition
+        assert_equal('post', @post_serializer.class._cache_key)
+        assert_equal('writer', @author_serializer.class._cache_key)
+        assert_equal(nil, @comment_serializer.class._cache_key)
+      end
+
+      def test_cache_key_interpolation_with_updated_at
+        author = render_object_with_cache_without_cache_key(@author)
+        assert_equal(nil, ActionController::Base.cache_store.fetch(@author.cache_key))
+        assert_equal(author, ActionController::Base.cache_store.fetch("#{@author_serializer.class._cache_key}/#{@author_serializer.object.id}-#{@author_serializer.object.updated_at}").to_json)
+      end
+
+      def test_default_cache_key_fallback
+        comment = render_object_with_cache_without_cache_key(@comment)
+        assert_equal(comment, ActionController::Base.cache_store.fetch(@comment.cache_key).to_json)
+      end
+
+      def test_cache_options_definition
+        assert_equal({expires_in: 0.05}, @post_serializer.class._cache_options)
+        assert_equal(nil, @author_serializer.class._cache_options)
+        assert_equal({expires_in: 1.day}, @comment_serializer.class._cache_options)
+      end
+
+      private
+      def render_object_with_cache_without_cache_key(obj)
+        serializer_class = ActiveModel::Serializer.serializer_for(obj)
+        serializer = serializer_class.new(obj)
+        adapter = ActiveModel::Serializer.adapter.new(serializer)
+        adapter.to_json
+      end
+    end
+  end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,20 @@
-require "bundler/setup"
+require 'bundler/setup'
 
 require 'rails'
 require 'action_controller'
 require 'action_controller/test_case'
-require "active_support/json"
+require 'action_controller/railtie'
+require 'active_support/json'
 require 'minitest/autorun'
 # Ensure backward compatibility with Minitest 4
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+
+class Foo < Rails::Application
+  if Rails.version.to_s.start_with? '4'
+    config.action_controller.perform_caching = true
+    ActionController::Base.cache_store = :memory_store
+  end
+end
 
 require "active_model_serializers"
 


### PR DESCRIPTION
This is a implementation of cache support to the new version of AMS.

It started originally at the mailing list:
[AMS: Caching](https://groups.google.com/forum/#!topic/rails-api-core/FRy7GMbGEMI) with *Matthijs Langenberg*.
[New Cache Support on AMS](https://groups.google.com/forum/#!topic/rails-api-core/kxP0WxWzFEg). with me

This implementation proposes x different approaches of the old versions of AMS.

- A different syntax. (no longer need the cache_key method)
- An options argument that have the same arguments of ```ActiveSupport::Cache::Store```, plus a ```key``` option that will be the prefix of the object cache on a pattern ```"#{key}-#{object.id}"```.
- It cache the objects individually and not the whole Serializer return, re-using it in different requests (as a show and a index method for example.)

There are many benefits on this approach:

- You can easily know which will be your final cache key, so you can expire it with any custom code.
- You can use all options of ```ActiveSupport::Cache::Store``` (:expires_in for example)
- All objects will be cached individually and re-used on any other return needed
- It keeps you Serializer clean by not depending on old ```cache_key``` method. 
