### PR TITLE
Fixing README at 0.9.0 by removing reference to attribute method #657

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ ActiveModel::Serializer.setup do |config|
 end
 ````
 
-This will build association keys like `comments` or `author` instead of `comment_ids` or `author_id`. 
+This will build association keys like `comments` or `author` instead of `comment_ids` or `author_id`.
 
 ## Getting the old version
 
@@ -304,7 +304,7 @@ Since this shadows any attribute named `object`, you can include them through `o
 
 ```ruby
 class VersionSerializer < ActiveModel::Serializer
-  attribute :version_object, key: :object
+  attributes :version_object
 
   def version_object
     object.object


### PR DESCRIPTION
As said on issue #657 , method attribute is no longer supported at 0.9.0.
This PR remove its reference on the README
