### PR TITLE
Snake case attributes #507

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ActiveModel::Serializers 
- 
+# ActiveModel::Serializers
+
 [![Build Status](https://travis-ci.org/rails-api/active_model_serializers.svg)](https://travis-ci.org/rails-api/active_model_serializers)
 
-ActiveModel::Serializers brings convention over configuration to your JSON generation. 
+ActiveModel::Serializers brings convention over configuration to your JSON generation.
 
 AMS does this through two components: **serializers** and **adapters**. Serializers describe which attributes and relationships should be serialized. Adapters describe how attributes and relationships should be serialized.
 
@@ -32,7 +32,7 @@ serializers:
 ```ruby
 class PostSerializer < ActiveModel::Serializer
   attributes :title, :body
- 
+
   has_many :comments
 
   url :post
@@ -61,7 +61,7 @@ ActiveModel::Serializer.config.adapter = ActiveModel::Serializer::Adapter::HalAd
 ```
 
 or
- 
+
 ```ruby
 ActiveModel::Serializer.config.adapter = :hal
 ```
@@ -85,18 +85,18 @@ end
 In this case, Rails will look for a serializer named `PostSerializer`, and if
 it exists, use it to serialize the `Post`.
 
-## Installation 
- 
-Add this line to your application's Gemfile: 
+## Installation
 
-``` 
-gem 'active_model_serializers' 
+Add this line to your application's Gemfile:
+
 ```
- 
-And then execute: 
+gem 'active_model_serializers'
+```
 
-``` 
-$ bundle 
+And then execute:
+
+```
+$ bundle
 ```
 
 ## Creating a Serializer
@@ -141,8 +141,26 @@ class CommentSerializer < ActiveModel::Serializer
 end
 ```
 
-The attribute names are a **whitelist** of attributes to be serialized. 
- 
+The attribute names are a **whitelist** of attributes to be serialized.
+
+**CamelCased** attributes will be converted to **snake_case** to ensure a AMS
+approach consistence. It will be done be automaticly creating a method in the
+generated serializer. For example:
+
+```ruby
+class PostSerializer < ActiveModel::Serializer
+  attributes :full_title, :body
+
+  has_many :comments
+
+  url :post
+
+  def full_title
+    obejct.fullTitle
+  end
+end
+```
+
 The `has_many` and `belongs_to` declarations describe relationships between
 resources. By default, when you serialize a `Post`, you will
 get its `Comment`s as well.
@@ -159,11 +177,11 @@ If you have a question, please [post to Stack
 Overflow](http://stackoverflow.com/questions/tagged/active-model-serializers).
 
 Thanks!
- 
-## Contributing 
- 
-1. Fork it ( https://github.com/rails-api/active_model_serializers/fork ) 
-2. Create your feature branch (`git checkout -b my-new-feature`) 
-3. Commit your changes (`git commit -am 'Add some feature'`) 
-4. Push to the branch (`git push origin my-new-feature`) 
-5. Create a new Pull Request 
+
+## Contributing
+
+1. Fork it ( https://github.com/rails-api/active_model_serializers/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/lib/generators/serializer/serializer_generator.rb
+++ b/lib/generators/serializer/serializer_generator.rb
@@ -15,11 +15,15 @@ module Rails
       private
 
       def attributes_names
-        [:id] + attributes.select { |attr| !attr.reference? }.map { |a| a.name.to_sym }
+        [:id] + attributes.select { |attr| !attr.reference? }.map { |a| a.name.underscore.to_sym }
       end
 
       def association_names
         attributes.select { |attr| attr.reference? }.map { |a| a.name.to_sym }
+      end
+
+      def attributes_transformation
+        attributes.select { |attr| !attr.reference? }.select { |a| a.name.match(/([A-Z][a-z0-9]+)+/) }.map { |a| a.name.to_s }
       end
 
       def parent_class_name

--- a/lib/generators/serializer/templates/serializer.rb
+++ b/lib/generators/serializer/templates/serializer.rb
@@ -5,4 +5,9 @@ end
 <% association_names.each do |attribute| -%>
   has_one :<%= attribute %>
 <% end -%>
+<% attributes_transformation.each do |attribute| -%>
+  def <%= attribute.underscore %>
+    object.<%= attribute %>
+  end
+<% end -%>
 <% end -%>

--- a/test/serializers/generators_test.rb
+++ b/test/serializers/generators_test.rb
@@ -55,6 +55,7 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
     assert_file "app/serializers/account_serializer.rb" do |serializer|
       assert_match(/^  def full_name\n    object.fullName\n  end\n/, serializer)
       assert_match(/^  def full_description\n    object.fullDescription\n  end\n/, serializer)
+      refute_match(/^  def account_number/, serializer)
     end
   end
 

--- a/test/serializers/generators_test.rb
+++ b/test/serializers/generators_test.rb
@@ -14,7 +14,7 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
   setup :prepare_destination
 
   tests Rails::Generators::SerializerGenerator
-  arguments %w(account name:string description:text business:references)
+  arguments %w(account account_number:integer fullName:string fullDescription:text business:references)
 
   def test_generates_a_serializer
     run_generator
@@ -45,8 +45,16 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
   def test_generates_attributes_and_associations
     run_generator
     assert_file "app/serializers/account_serializer.rb" do |serializer|
-      assert_match(/^  attributes :id, :name, :description$/, serializer)
+      assert_match(/^  attributes :id, :account_number, :full_name, :full_description$/, serializer)
       assert_match(/^  has_one :business$/, serializer)
+    end
+  end
+
+  def test_generates_attributes_transformation_methods
+    run_generator
+    assert_file "app/serializers/account_serializer.rb" do |serializer|
+      assert_match(/^  def full_name\n    object.fullName\n  end\n/, serializer)
+      assert_match(/^  def full_description\n    object.fullDescription\n  end\n/, serializer)
     end
   end
 


### PR DESCRIPTION
Adding automatically treat to **CamelCased** attributes when using AMS Serializer gerenator.
It replaces the **CamelCased** attribute by a **snake_cased** one and defining a method to access the original attribute inside the serializer. For example:

```ruby
class PostSerializer < ActiveModel::Serializer
  attributes :full_title, :body

  has_many :comments

  url :post

  def full_title
    object.fullTitle
  end
end
```

As I wrote on README:
> **CamelCased** attributes will be converted to **snake_case** to ensure a AMS
> approach consistence. It will be done be automaticly creating a method in the
> generated serializer.

It is related to feature proposal #507 and other projects as [Ember APIKit Rails](dockyard/ember-appkit-rails#183)