### PR TITLE
Handle correctly null associations

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -133,7 +133,7 @@ module ActiveModel
       self.class._associations.dup.each do |name, options|
         association = object.send(name)
         serializer_class = ActiveModel::Serializer.serializer_for(association)
-        serializer = serializer_class.new(association)
+        serializer = serializer_class.new(association) if serializer_class
 
         if block_given?
           block.call(name, serializer, options[:options])

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -13,7 +13,11 @@ module ActiveModel
                 array_serializer = association
                 @result[name] = array_serializer.map { |item| item.attributes(opts) }
               else
-                @result[name] = association.attributes(options)
+                if association
+                  @result[name] = association.attributes(options)
+                else
+                  @result[name] = nil
+                end
               end
             end
           end

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -44,13 +44,17 @@ module ActiveModel
         end
 
         def add_link(name, serializer, options)
-          @hash[@root][:links][name] = serializer.id.to_s
+          if serializer
+            @hash[@root][:links][name] = serializer.id.to_s
 
-          unless options[:embed] == :ids
-            plural_name = name.to_s.pluralize.to_sym
+            unless options[:embed] == :ids
+              plural_name = name.to_s.pluralize.to_sym
 
-            @hash[:linked][plural_name] ||= []
-            @hash[:linked][plural_name].push attributes_for_serializer(serializer, options)
+              @hash[:linked][plural_name] ||= []
+              @hash[:linked][plural_name].push attributes_for_serializer(serializer, options)
+            end
+          else
+            @hash[@root][:links][name] = nil
           end
         end
 

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -7,9 +7,13 @@ module ActiveModel
         class BelongsToTest < Minitest::Test
           def setup
             @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @anonymous_post = Post.new(id: 43, title: 'Hello!!', body: 'Hello, world!!')
             @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
             @post.comments = [@comment]
+            @anonymous_post.comments = []
             @comment.post = @post
+            @post.author = @author
+            @anonymous_post.author = nil
 
             @serializer = CommentSerializer.new(@comment)
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
@@ -17,6 +21,13 @@ module ActiveModel
 
           def test_includes_post
             assert_equal({id: 42, title: 'New Post', body: 'Body'}, @adapter.serializable_hash[:post])
+          end
+
+          def test_include_nil_author
+            serializer = PostSerializer.new(@anonymous_post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], author: nil}, adapter.serializable_hash)
           end
         end
       end

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -6,10 +6,13 @@ module ActiveModel
       class Json
         class Collection < Minitest::Test
           def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
             @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
             @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
             @first_post.comments = []
             @second_post.comments = []
+            @first_post.author = @author
+            @second_post.author = @author
 
             @serializer = ArraySerializer.new([@first_post, @second_post])
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
@@ -17,8 +20,8 @@ module ActiveModel
 
           def test_include_multiple_posts
             assert_equal([
-                           {title: "Hello!!", body: "Hello, world!!", id: 1, comments: []},
-                           {title: "New Post", body: "Body", id: 2, comments: []}
+                           {title: "Hello!!", body: "Hello, world!!", id: 1, comments: [], author: {id: 1, name: "Steve K."}},
+                           {title: "New Post", body: "Body", id: 2, comments: [], author: {id: 1, name: "Steve K."}}
                          ], @adapter.serializable_hash)
           end
         end

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -6,10 +6,12 @@ module ActiveModel
       class Json
         class HasManyTestTest < Minitest::Test
           def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
             @post = Post.new(title: 'New Post', body: 'Body')
             @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
             @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
             @post.comments = [@first_comment, @second_comment]
+            @post.author = @author
             @first_comment.post = @post
             @second_comment.post = @post
 

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -6,10 +6,15 @@ module ActiveModel
       class JsonApi
         class BelongsToTest < Minitest::Test
           def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
             @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @anonymous_post = Post.new(id: 43, title: 'Hello!!', body: 'Hello, world!!')
             @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
             @post.comments = [@comment]
+            @anonymous_post.comments = []
             @comment.post = @post
+            @post.author = @author
+            @anonymous_post.author = nil
 
             @serializer = CommentSerializer.new(@comment)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
@@ -21,6 +26,13 @@ module ActiveModel
 
           def test_includes_linked_post
             assert_equal([{id: "42", title: 'New Post', body: 'Body'}], @adapter.serializable_hash[:linked][:posts])
+          end
+
+          def test_include_nil_author
+            serializer = PostSerializer.new(@anonymous_post)
+            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
+
+            assert_equal({comments: [], author: nil}, adapter.serializable_hash[:posts][:links])
           end
         end
       end

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -6,10 +6,13 @@ module ActiveModel
       class JsonApi
         class Collection < Minitest::Test
           def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
             @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
             @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
             @first_post.comments = []
             @second_post.comments = []
+            @first_post.author = @author
+            @second_post.author = @author
 
             @serializer = ArraySerializer.new([@first_post, @second_post])
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
@@ -17,8 +20,8 @@ module ActiveModel
 
           def test_include_multiple_posts
             assert_equal([
-                           {title: "Hello!!", body: "Hello, world!!", id: "1", links: {comments: []}},
-                           {title: "New Post", body: "Body", id: "2", links: {comments: []}}
+                           {title: "Hello!!", body: "Hello, world!!", id: "1", links: {comments: [], author: "1"}},
+                           {title: "New Post", body: "Body", id: "2", links: {comments: [], author: "1"}}
                          ], @adapter.serializable_hash[:posts])
           end
         end

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -6,12 +6,14 @@ module ActiveModel
       class JsonApi
         class HasManyTest < Minitest::Test
           def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
             @post = Post.new(title: 'New Post', body: 'Body')
             @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
             @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
             @post.comments = [@first_comment, @second_comment]
             @first_comment.post = @post
             @second_comment.post = @post
+            @post.author = @author
 
             @serializer = PostSerializer.new(@post)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)

--- a/test/adapter/json_test.rb
+++ b/test/adapter/json_test.rb
@@ -5,12 +5,14 @@ module ActiveModel
     class Adapter
       class JsonTest < Minitest::Test
         def setup
+          @author = Author.new(id: 1, name: 'Steve K.')
           @post = Post.new(title: 'New Post', body: 'Body')
           @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
           @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
           @post.comments = [@first_comment, @second_comment]
           @first_comment.post = @post
           @second_comment.post = @post
+          @post.author = @author
 
           @serializer = PostSerializer.new(@post)
           @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -43,6 +43,7 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :title, :body, :id
 
   has_many :comments
+  belongs_to :author
   url :comments
 end
 

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class AssocationsTest < Minitest::Test
+    class AssociationsTest < Minitest::Test
       class Model
         def initialize(hash={})
           @attributes = hash
@@ -25,20 +25,23 @@ module ActiveModel
 
 
       def setup
+        @author = Author.new(name: 'Steve K.')
         @post = Post.new({ title: 'New Post', body: 'Body' })
         @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
         @post.comments = [@comment]
         @comment.post = @post
+        @post.author = @author
+        @author.posts = [@post]
 
-        @post_serializer = PostSerializer.new(@post)
+        @author_serializer = AuthorSerializer.new(@author)
         @comment_serializer = CommentSerializer.new(@comment)
       end
 
       def test_has_many
-        assert_equal({comments: {type: :has_many, options: {}}}, @post_serializer.class._associations)
-        @post_serializer.each_association do |name, serializer, options|
-          assert_equal(:comments, name)
-          assert_equal({}, options)
+        assert_equal({posts: {type: :has_many, options: {embed: :ids}}}, @author_serializer.class._associations)
+        @author_serializer.each_association do |name, serializer, options|
+          assert_equal(:posts, name)
+          assert_equal({embed: :ids}, options)
           assert_kind_of(ActiveModel::Serializer.config.array_serializer, serializer)
         end
       end


### PR DESCRIPTION
null belongs_to associations are now serialized as nil instead
of raise an error during serialization.
