### PR TITLE
Define as_json instead of to_json

### DIFF
--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -16,8 +16,8 @@ module ActiveModel
         raise NotImplementedError, 'This is an abstract method. Should be implemented at the concrete adapter.'
       end
 
-      def to_json(options = {})
-        serializable_hash(options).to_json
+      def as_json(options = {})
+        serializable_hash(options)
       end
     end
   end


### PR DESCRIPTION
As @chancancode mentioned in https://github.com/ohler55/oj/issues/199#issuecomment-61465250, we should define as_json, no to_json, the latter should be called by ActiveSupport, no defined here directly

/cc @chancancode 
