### PR TITLE
fixed issue with rendering Hash which appears in rails 4.2.0.beta4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ rvm:
   - ruby-head
   - jruby-19mode
   - rbx-2
+  - ruby-head
 
 sudo: false
+
+install:
+  - bundle install --retry=3
 
 env:
   - "RAILS_VERSION=3.2.17"

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -56,7 +56,7 @@ end
       attr_reader :key_format
 
       def serializer_for(resource, options = {})
-        if resource.respond_to?(:each)
+        if resource.respond_to?(:each) && !resource.is_a?(Hash)
           if Object.constants.include?(:ArraySerializer)
             ::ArraySerializer
           else

--- a/test/integration/action_controller/namespaced_serialization_test.rb
+++ b/test/integration/action_controller/namespaced_serialization_test.rb
@@ -19,6 +19,10 @@ module ActionController
         def render_comments
           render json: [Comment.new(content: 'Comment 1')]
         end
+
+        def render_hash
+          render json: {message: 'not found'}, status: 404
+        end
       end
 
       tests TestNamespace::MyController
@@ -41,6 +45,11 @@ module ActionController
       def test_array_fallback_to_a_version_without_namespace
         get :render_comments
         assert_serializer CommentSerializer
+      end
+
+      def test_render_hash_regression
+        get :render_hash
+        assert_equal JSON.parse(response.body), {'message' => 'not found'}
       end
     end
 


### PR DESCRIPTION
Unfortunately it fails in example application:

`Gemfile`:

```ruby
source 'https://rubygems.org'

gem 'rails', '4.2.0.beta4'
gem 'pg'
gem 'sass-rails', '5.0.0.beta1'
gem 'uglifier', '>= 1.3.0'
gem 'coffee-rails', '~> 4.0.0'
gem 'jquery-rails'
gem 'turbolinks'
gem 'jbuilder', '~> 2.0'

gem 'sdoc', '~> 0.4.0',          group: :doc
gem 'active_model_serializers', github: 'rails-api/active_model_serializers', branch: '0-9-stable'

group :development, :test do
  gem 'rspec-rails', '~> 2.14.0'
  gem 'factory_girl_rails', '~> 4.2.1'
end
```

`app/controllers/application_controller.rb`:

```ruby
class ApplicationController < ActionController::Base
  # skipped...
  rescue_from ActiveRecord::RecordNotFound do |exception|
    respond_to do |f|
      f.json { render json: {message: I18n.t('not_found')}, status: 404 }
    end
  end
  # skipped....
end
```

`app/controllers/articles_controller.rb`:

```ruby
class ArticlesController < ApplicationController
   # skipped...
   def show
     @article = Article.find params[:id]
      render status: 200, json: @article
    end 
    # skipped...
end
```

`spec/requests/articles_spec.rb`

```ruby
require 'spec_helper'

describe 'Articles API' do
  describe 'GET /articles/:id.json' do
      it 'returns proper json (status 404)' do
        get article_path(id: 100500, format: :json)
         json = JSON.parse response.body
        expect(response).to_not be_success
        expect(json['message']).to eq I18n.t('not_found')
      end
  end
end
```