### PR TITLE
Support has_one to be compatible with 0.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
   * adds support for `meta` and `meta_key` [@kurko]
   * adds method to override association [adcb99e, @kurko]
+  * add `has_one` attribute for backwards compatibility [@ggordon]

--- a/README.md
+++ b/README.md
@@ -224,13 +224,14 @@ $ rails g serializer post
 ```
 
 The generated seralizer will contain basic `attributes` and
-`has_many`/`belongs_to` declarations, based on the model. For example:
+`has_many`/`has_one`/`belongs_to` declarations, based on the model. For example:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
   attributes :title, :body
 
   has_many :comments
+  has_one :author
 
   url :post
 end
@@ -250,7 +251,7 @@ end
 
 The attribute names are a **whitelist** of attributes to be serialized.
 
-The `has_many` and `belongs_to` declarations describe relationships between
+The `has_many`, `has_one`, and `belongs_to` declarations describe relationships between
 resources. By default, when you serialize a `Post`, you will get its `Comment`s
 as well.
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -66,6 +66,16 @@ module ActiveModel
       associate(:belongs_to, attrs)
     end
 
+    # Defines an association in the object should be rendered.
+    #
+    # The serializer object should implement the association name
+    # as a method which should return an object when invoked. If a method
+    # with the association name does not exist, the association name is
+    # dispatched to the serialized object.
+    def self.has_one(*attrs)
+      associate(:has_one, attrs)
+    end
+
     def self.associate(type, attrs) #:nodoc:
       options = attrs.extract_options!
       self._associations = _associations.dup

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi
+        class HasOneTest < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
+            @bio = Bio.new(id: 43, content: 'AMS Contributor')
+            @author.bio = @bio
+            @bio.author = @author
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @anonymous_post = Post.new(id: 43, title: 'Hello!!', body: 'Hello, world!!')
+            @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @post.comments = [@comment]
+            @anonymous_post.comments = []
+            @comment.post = @post
+            @comment.author = nil
+            @post.author = @author
+            @anonymous_post.author = nil
+            @blog = Blog.new(id: 1, name: "My Blog!!")
+            @blog.writer = @author
+            @blog.articles = [@post, @anonymous_post]
+            @author.posts = []
+            @author.roles = []
+
+            @serializer = AuthorSerializer.new(@author)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio,posts')
+          end
+
+          def test_includes_bio_id
+            assert_equal("43", @adapter.serializable_hash[:authors][:links][:bio])
+          end
+
+          def test_includes_linked_bio
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio')
+            assert_equal([{id: "43", :content=>"AMS Contributor", :links=>{:author=>"1"}}], @adapter.serializable_hash[:linked][:bios])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -10,9 +10,9 @@ module ActiveModel
             @author2 = Author.new(id: 2, name: 'Tenderlove')
             @bio1 = Bio.new(id: 1, content: 'AMS Contributor')
             @bio2 = Bio.new(id: 2, content: 'Rails Contributor')
-            @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
-            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
-            @third_post = Post.new(id: 3, title: 'Yet Another Post', body: 'Body')
+            @first_post = Post.new(id: 10, title: 'Hello!!', body: 'Hello, world!!')
+            @second_post = Post.new(id: 20, title: 'New Post', body: 'Body')
+            @third_post = Post.new(id: 30, title: 'Yet Another Post', body: 'Body')
             @blog = Blog.new({ name: 'AMS Blog' })
             @first_post.blog = @blog
             @second_post.blog = @blog
@@ -44,8 +44,8 @@ module ActiveModel
             @second_comment.post = @first_post
             @second_comment.author = nil
             assert_equal([
-                           { title: "Hello!!", body: "Hello, world!!", id: "1", links: { comments: ['1', '2'], blog: "999", author: "1" } },
-                           { title: "New Post", body: "Body", id: "2", links: { comments: [], blog: "999", author: "2" } }
+                           { title: "Hello!!", body: "Hello, world!!", id: "10", links: { comments: ['1', '2'], blog: "999", author: "1" } },
+                           { title: "New Post", body: "Body", id: "20", links: { comments: [], blog: "999", author: "2" } }
                          ], @adapter.serializable_hash[:posts])
 
 
@@ -54,14 +54,14 @@ module ActiveModel
                 id: "1",
                 body: "ZOMG A COMMENT",
                 links: {
-                  post: "1",
+                  post: "10",
                   author: nil
                 }
               }, {
                 id: "2",
                 body: "ZOMG ANOTHER COMMENT",
                 links: {
-                  post: "1",
+                  post: "10",
                   author: nil
                 }
               }],
@@ -69,7 +69,7 @@ module ActiveModel
                 id: "1",
                 name: "Steve K.",
                 links: {
-                  posts: ["1", "3"],
+                  posts: ["10", "30"],
                   roles: [],
                   bio: "1"
                 }
@@ -77,7 +77,7 @@ module ActiveModel
                 id: "2",
                 name: "Tenderlove",
                 links: {
-                  posts: ["2"],
+                  posts: ["20"],
                   roles: [],
                   bio: "2"
                 }
@@ -117,7 +117,7 @@ module ActiveModel
                 id: "1",
                 name: "Steve K.",
                 links: {
-                  posts: ["1", "3"],
+                  posts: ["10", "30"],
                   roles: [],
                   bio: "1"
                 }
@@ -125,7 +125,7 @@ module ActiveModel
               posts: [{
                 title: "Hello!!",
                 body: "Hello, world!!",
-                id: "1",
+                id: "10",
                 links: {
                   comments: ["1", "2"],
                   blog: "999",
@@ -134,7 +134,7 @@ module ActiveModel
               }, {
                 title: "Yet Another Post",
                 body: "Body",
-                id: "3",
+                id: "30",
                 links: {
                   comments: [],
                   blog: nil,

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -99,7 +99,7 @@ AuthorSerializer = Class.new(ActiveModel::Serializer) do
 
   has_many :posts, embed: :ids
   has_many :roles, embed: :ids
-  belongs_to :bio
+  has_one :bio
 end
 
 RoleSerializer = Class.new(ActiveModel::Serializer) do

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -23,7 +23,6 @@ module ActiveModel
         end
       end
 
-
       def setup
         @author = Author.new(name: 'Steve K.')
         @author.bio = nil
@@ -43,11 +42,11 @@ module ActiveModel
         @comment_serializer = CommentSerializer.new(@comment)
       end
 
-      def test_has_many
+      def test_has_many_and_has_one
         assert_equal(
           { posts: { type: :has_many, association_options: { embed: :ids } },
             roles: { type: :has_many, association_options: { embed: :ids } },
-            bio: { type: :belongs_to, association_options: {} } },
+            bio: { type: :has_one, association_options: {} } },
           @author_serializer.class._associations
         )
         @author_serializer.each_association do |name, serializer, options|
@@ -67,7 +66,11 @@ module ActiveModel
       end
 
       def test_belongs_to
-        assert_equal({post: {type: :belongs_to, association_options: {}}, :author=>{:type=>:belongs_to, :association_options=>{}}}, @comment_serializer.class._associations)
+        assert_equal(
+          { post: { type: :belongs_to, association_options: {} },
+            author: { type: :belongs_to, association_options: {} } },
+          @comment_serializer.class._associations
+        )
         @comment_serializer.each_association do |name, serializer, options|
           if name == :post
             assert_equal({}, options)


### PR DESCRIPTION
The 0.8.x branch used ```has_one``` for associations, it looks like this was changed to ```belongs_to``` in 0.10.x. This patch adds support for ```has_one``` in addition to ```belongs_to``` for backwards compatibility.