### PR TITLE
Bugfix: include nested has_many associations

### DIFF
--- a/test/adapter/json_api/has_many_embed_ids_test.rb
+++ b/test/adapter/json_api/has_many_embed_ids_test.rb
@@ -8,6 +8,7 @@ module ActiveModel
           def setup
             @author = Author.new(name: 'Steve K.')
             @author.bio = nil
+            @author.roles = nil
             @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
             @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
             @author.posts = [@first_post, @second_post]

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -16,6 +16,7 @@ module ActiveModel
             @second_post.author = @author
             @author.posts = [@first_post, @second_post]
             @author.bio = @bio
+            @author.roles = []
             @bio.author = @author
 
             @serializer = ArraySerializer.new([@first_post, @second_post])

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -40,6 +40,7 @@ Comment = Class.new(Model)
 Author = Class.new(Model)
 Bio = Class.new(Model)
 Blog = Class.new(Model)
+Role = Class.new(Model)
 
 PostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :title, :body, :id
@@ -60,7 +61,14 @@ AuthorSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :name
 
   has_many :posts, embed: :ids
+  has_many :roles, embed: :ids
   belongs_to :bio
+end
+
+RoleSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id, :name
+
+  belongs_to :author
 end
 
 BioSerializer = Class.new(ActiveModel::Serializer) do

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -27,6 +27,7 @@ module ActiveModel
       def setup
         @author = Author.new(name: 'Steve K.')
         @author.bio = nil
+        @author.roles = []
         @post = Post.new({ title: 'New Post', body: 'Body' })
         @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
         @post.comments = [@comment]
@@ -42,6 +43,7 @@ module ActiveModel
       def test_has_many
         assert_equal(
           { posts: { type: :has_many, options: { embed: :ids } },
+            roles: { type: :has_many, options: { embed: :ids } },
             bio: { type: :belongs_to, options: {} } },
           @author_serializer.class._associations
         )
@@ -52,6 +54,9 @@ module ActiveModel
           elsif name == :bio
             assert_equal({}, options)
             assert_nil serializer
+          elsif name == :roles
+            assert_equal({embed: :ids}, options)
+            assert_kind_of(ActiveModel::Serializer.config.array_serializer, serializer)
           else
             flunk "Unknown association: #{name}"
           end


### PR DESCRIPTION
Currently, doing `include: author.bio` would work correctly, but not for
has_many associations such as `include: author.roles`. This fixes it.

The problem was basically that we were not handling arrays for has_many linked,
as happens for ArraySerializers.
