### PR TITLE
Use type as key for linked resources

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -62,7 +62,7 @@ module ActiveModel
           resource_path = [parent, resource_name].compact.join('.')
 
           if include_assoc?(resource_path)
-            plural_name = resource_name.to_s.pluralize.to_sym
+            plural_name = serialized_object_type(serializer).pluralize.to_sym
             attrs = [attributes_for_serializer(serializer, @options)].flatten
             @top[:linked] ||= {}
             @top[:linked][plural_name] ||= []


### PR DESCRIPTION
If type is `author` but the association is called `writer`, the linked
resource key should be called `authors`, e.g

```
{
  ...
  linked: {
    authors: [{
      ...
    }]
  }
  ...
}
```
