### PR TITLE
Fixes nested has_many links in JSONAPI

### DIFF
--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -6,24 +6,32 @@ module ActiveModel
       class JsonApi
         class LinkedTest < Minitest::Test
           def setup
-            @author = Author.new(id: 1, name: 'Steve K.')
-            @bio = Bio.new(id: 1, content: 'AMS Contributor')
+            @author1 = Author.new(id: 1, name: 'Steve K.')
+            @author2 = Author.new(id: 2, name: 'Tenderlove')
+            @bio1 = Bio.new(id: 1, content: 'AMS Contributor')
+            @bio2 = Bio.new(id: 2, content: 'Rails Contributor')
             @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
             @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+            @third_post = Post.new(id: 3, title: 'Yet Another Post', body: 'Body')
             @first_post.comments = []
             @second_post.comments = []
-            @first_post.author = @author
-            @second_post.author = @author
-            @author.posts = [@first_post, @second_post]
-            @author.bio = @bio
-            @author.roles = []
-            @bio.author = @author
-
-            @serializer = ArraySerializer.new([@first_post, @second_post])
-            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'author,author.bio,comments')
+            @first_post.author = @author1
+            @second_post.author = @author2
+            @third_post.author = @author1
+            @author1.posts = [@first_post, @third_post]
+            @author1.bio = @bio1
+            @author1.roles = []
+            @author2.posts = [@second_post]
+            @author2.bio = @bio2
+            @author2.roles = []
+            @bio1.author = @author1
+            @bio2.author = @author2
           end
 
           def test_include_multiple_posts_and_linked
+            @serializer = ArraySerializer.new([@first_post, @second_post])
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'author,author.bio,comments')
+
             @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
             @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
             @first_post.comments = [@first_comment, @second_comment]
@@ -33,7 +41,7 @@ module ActiveModel
             @second_comment.author = nil
             assert_equal([
                            { title: "Hello!!", body: "Hello, world!!", id: "1", links: { comments: ['1', '2'], author: "1" } },
-                           { title: "New Post", body: "Body", id: "2", links: { comments: [], :author => "1" } }
+                           { title: "New Post", body: "Body", id: "2", links: { comments: [], :author => "2" } }
                          ], @adapter.serializable_hash[:posts])
 
 
@@ -57,15 +65,73 @@ module ActiveModel
                 id: "1",
                 name: "Steve K.",
                 links: {
-                  posts: ["1", "2"],
+                  posts: ["1"],
                   roles: [],
                   bio: "1"
+                }
+              }, {
+                id: "2",
+                name: "Tenderlove",
+                links: {
+                  posts: ["2"],
+                  roles: [],
+                  bio: "2"
                 }
               }],
               bios: [{
                 id: "1",
                 content: "AMS Contributor",
                 links: {
+                  author: "1"
+                }
+              }, {
+                id: "2",
+                content: "Rails Contributor",
+                links: {
+                  author: "2"
+                }
+              }]
+            }
+            assert_equal expected, @adapter.serializable_hash[:linked]
+          end
+
+          def test_include_multiple_posts_and_linked
+            @serializer = BioSerializer.new(@bio1)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'author,author.posts')
+
+            @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+            @first_post.comments = [@first_comment, @second_comment]
+            @third_post.comments = []
+            @first_comment.post = @first_post
+            @first_comment.author = nil
+            @second_comment.post = @first_post
+            @second_comment.author = nil
+
+            expected = {
+              authors: [{
+                id: "1",
+                name: "Steve K.",
+                links: {
+                  posts: ["1", "3"],
+                  roles: [],
+                  bio: "1"
+                }
+              }],
+              posts: [{
+                title: "Hello!!",
+                body: "Hello, world!!",
+                id: "1",
+                links: {
+                  comments: ["1", "2"],
+                  author: "1"
+                }
+              }, {
+                title: "Yet Another Post",
+                body: "Body",
+                id: "3",
+                links: {
+                  comments: [],
                   author: "1"
                 }
               }]


### PR DESCRIPTION
When linked resource had has_many links, all of them would use the
association from the first resource, causing all of the items to build
`links` with the same associations.

This fixes it by iterating over the serializers, not just the
attributes array.
