### PR TITLE
Define custom serializer for a resource

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -82,6 +82,8 @@ module ActiveModel
     def self.serializer_for(resource)
       if resource.respond_to?(:to_ary)
         config.array_serializer
+      elsif resource.respond_to?(:serializer_class)
+        resource.serializer_class
       else
         get_serializer_for(resource.class)
       end


### PR DESCRIPTION
This PR is resurrection of #515. Please read conversation there first.

I think this feature is useful for STI models where all descendants can be serialized with same serializer - you would specify it once in base class and then it wouldn't be needed to create serializer class for each descendant and specify serializer again.
