### PR TITLE
Don't automatically include ActionController::Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ class PostSerializer < ActiveModel::Serializer
 end
 ```
 
-In your controllers, when you use `render :json`, Rails will now first search
-for a serializer for the object and use it if available.
+In your controllers, include the serialization module and when you use `render :json`, Rails will now first search for a serializer for the object and use it if available.
 
 ```ruby
 class PostsController < ApplicationController
+  include ActionController::Serialization
+
   def show
     @post = Post.find(params[:id])
 

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -5,10 +5,6 @@ require "active_model/serializer"
 begin
   require 'action_controller'
   require 'action_controller/serialization'
-
-  ActiveSupport.on_load(:action_controller) do
-    include ::ActionController::Serialization
-  end
 rescue LoadError
   # rails not installed, continuing
 end

--- a/test/action_controller/adapter_selector_test.rb
+++ b/test/action_controller/adapter_selector_test.rb
@@ -4,6 +4,7 @@ module ActionController
   module Serialization
     class AdapterSelectorTest < ActionController::TestCase
       class MyController < ActionController::Base
+        include ActionController::Serialization
         def render_using_default_adapter
           @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           render json: @profile

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -4,6 +4,8 @@ module ActionController
   module Serialization
     class ExplicitSerializerTest < ActionController::TestCase
       class MyController < ActionController::Base
+        include ActionController::Serialization
+
         def render_using_explicit_serializer
           @profile = Profile.new(name: 'Name 1',
                                  description: 'Description 1',

--- a/test/action_controller/json_api_linked_test.rb
+++ b/test/action_controller/json_api_linked_test.rb
@@ -4,6 +4,8 @@ module ActionController
   module Serialization
     class JsonApiLinkedTest < ActionController::TestCase
       class MyController < ActionController::Base
+        include ActionController::Serialization
+
         def setup_post
           @role1 = Role.new(id: 1, name: 'admin')
           @role2 = Role.new(id: 2, name: 'colab')

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -4,6 +4,8 @@ module ActionController
   module Serialization
     class ImplicitSerializerTest < ActionController::TestCase
       class MyController < ActionController::Base
+        include ActionController::Serialization
+
         def render_using_implicit_serializer
           @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           render json: @profile


### PR DESCRIPTION
This PR removes some magic I was having a difficult time working around. My legacy app has issues with automatically including ActionController::Serialization in ActionController. Some of my controllers use other methods to render json and the methods defined in this module intercept my calls. 

Since it would be explicitly included if this PR is accepted, we'd probably want a better name for the module. I just left it as ActionController::Serialization for now, but I'm open to suggestions.
