### PR TITLE
Allows providing a `module_namespace` option

### DIFF
--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -80,7 +80,7 @@ module ActiveModel
         if @options.has_key? :each_serializer
           serializer = @options[:each_serializer]
         elsif item.respond_to?(:active_model_serializer)
-          serializer = item.active_model_serializer
+          serializer = item.active_model_serializer(@options[:module_namespace])
         end
 
         serializable = serializer ? serializer.new(item, @options) : DefaultSerializer.new(item, @options.merge(:root => false))

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -263,7 +263,7 @@ module ActiveModel
 
         serializer = options.delete(:serializer) ||
           (resource.respond_to?(:active_model_serializer) &&
-           resource.active_model_serializer)
+           resource.active_model_serializer(options[:module_namespace]))
 
         return serializer unless serializer
 

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -40,13 +40,13 @@ module ActiveModel::SerializerSupport
 
   module ClassMethods #:nodoc:
     if "".respond_to?(:safe_constantize)
-      def active_model_serializer
-        "#{self.name}Serializer".safe_constantize
+      def active_model_serializer(namespace = nil)
+        "#{namespace}::#{self.name}Serializer".safe_constantize
       end
     else
-      def active_model_serializer
+      def active_model_serializer(namespace = nil)
         begin
-          "#{self.name}Serializer".constantize
+          "#{namespace}::#{self.name}Serializer".constantize
         rescue NameError => e
           raise unless e.message =~ /uninitialized constant/
         end
@@ -55,15 +55,15 @@ module ActiveModel::SerializerSupport
   end
 
   # Returns a model serializer for this object considering its namespace.
-  def active_model_serializer
-    self.class.active_model_serializer
+  def active_model_serializer(namespace = nil)
+    self.class.active_model_serializer(namespace)
   end
 
   alias :read_attribute_for_serialization :send
 end
 
 module ActiveModel::ArraySerializerSupport
-  def active_model_serializer
+  def active_model_serializer(namespace = nil)
     ActiveModel::ArraySerializer
   end
 end

--- a/test/association_test.rb
+++ b/test/association_test.rb
@@ -443,11 +443,11 @@ class AssociationTest < ActiveModel::TestCase
     end
 
     class Foo < Model
-      def active_model_serializer; FooSerializer; end
+      def active_model_serializer(*args); FooSerializer; end
     end
 
     class Bar < Model
-      def active_model_serializer; BarSerializer; end
+      def active_model_serializer(*args); BarSerializer; end
     end
 
     def setup

--- a/test/no_serialization_scope_test.rb
+++ b/test/no_serialization_scope_test.rb
@@ -12,7 +12,7 @@ class NoSerializationScopeTest < ActionController::TestCase
   end
 
   class ScopeSerializable
-    def active_model_serializer
+    def active_model_serializer(*args)
       ScopeSerializer
     end
   end

--- a/test/serialization_test.rb
+++ b/test/serialization_test.rb
@@ -36,7 +36,7 @@ class RenderJsonTest < ActionController::TestCase
       @skip = skip
     end
 
-    def active_model_serializer
+    def active_model_serializer(*args)
       JsonSerializer unless @skip
     end
 
@@ -68,7 +68,7 @@ class RenderJsonTest < ActionController::TestCase
   end
 
   class HypermediaSerializable
-    def active_model_serializer
+    def active_model_serializer(*args)
       HypermediaSerializer
     end
   end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -872,7 +872,7 @@ class SerializerTest < ActiveModel::TestCase
     post_class = Class.new(Model) do
       attr_accessor :comments
 
-      define_method :active_model_serializer do
+      define_method :active_model_serializer do |*args|
         post_serializer
       end
     end
@@ -1324,7 +1324,7 @@ class SerializerTest < ActiveModel::TestCase
         @attributes[:name]
       end
 
-      define_method :active_model_serializer do
+      define_method :active_model_serializer do |*args|
         tag_serializer
       end
     end

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -66,7 +66,7 @@ class Post < Model
 end
 
 class Comment < Model
-  def active_model_serializer; CommentSerializer; end
+  def active_model_serializer(*args); CommentSerializer; end
 end
 
 class UserSerializer < ActiveModel::Serializer


### PR DESCRIPTION
This is passed through to the active record object, so that it can prepend the module namespace to the serializer name before constantizing it.

:white_check_mark: Allows easy versioning for serializers!
If you want to version your serializers, your controller can now do so easily.

:white_check_mark: Allows creating a better controller/view pattern!

application_controller.rb

``` ruby
  def default_serializer_options
    {module_namespace: self.class.name.deconstantize}
  end
```

path structure

```
|- controllers
|  |- api
|     |- v1
|         posts_controller.rb
|- serializers
   |- api
      |- v1
          posts_serializer.rb
```
