### PR TITLE
Serialize polymorphic, embed-in-root relationships by class name instead of association name

### DIFF
--- a/lib/active_model/default_serializer.rb
+++ b/lib/active_model/default_serializer.rb
@@ -12,12 +12,17 @@ module ActiveModel
     def initialize(object, options={})
       @object = object
       @wrap_in_array = options[:_wrap_in_array]
+      @polymorphic = options[:polymorphic]
     end
 
     def as_json(options={})
       instrument('!serialize') do
         return [] if @object.nil? && @wrap_in_array
         hash = @object.as_json
+
+        hash = {:type => type_name(@object), type_name(@object) => hash} \
+          if @polymorphic && !@object.nil?
+
         @wrap_in_array ? [hash] : hash
       end
     end
@@ -27,6 +32,10 @@ module ActiveModel
     private
     def instrumentation_keys
       [:object, :wrap_in_array]
+    end
+
+    def type_name(elem)
+      elem.class.to_s.demodulize.underscore.to_sym
     end
   end
 end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -202,7 +202,9 @@ end
           association_serializer = build_serializer(association)
           # we must do this always because even if the current association is not
           # embeded in root, it might have its own associations that are embeded in root
-          hash.merge!(association_serializer.embedded_in_root_associations) {|key, oldval, newval| [newval, oldval].flatten }
+          hash.merge!(association_serializer.embedded_in_root_associations) do |key, oldval, newval|
+            [newval, oldval].flatten.uniq
+          end
 
           if association.embed_in_root?
             if association.embed_in_root_key?
@@ -210,11 +212,27 @@ end
             end
 
             serialized_data = association_serializer.serializable_object
-            key = association.root_key
-            if hash.has_key?(key)
-              hash[key].concat(serialized_data).uniq!
+
+            if !association.polymorphic?
+              key = association.root_key
+
+              if hash.has_key?(key)
+                hash[key].concat(serialized_data).uniq!
+              else
+                hash[key] = serialized_data
+              end
             else
-              hash[key] = serialized_data
+              serialized_data.each do |datum|
+                type = datum[:type]
+                key = type.to_s.pluralize
+                datum = datum[type]
+
+                if hash.has_key?(key)
+                  hash[key].push(datum).uniq!
+                else
+                  hash[key] = [datum]
+                end
+              end
             end
           end
         end

--- a/test/unit/active_model/serializer/has_many_polymorphic_test.rb
+++ b/test/unit/active_model/serializer/has_many_polymorphic_test.rb
@@ -140,10 +140,8 @@ module ActiveModel
               { id: c.object_id, type: model_name(c) }
             end,
           },
-          'attachments' => [
-            { type: :image, image: { url: 'U1' }},
-            { type: :video, video: { html: 'H1' }}
-          ]
+          'images' => [{ url: 'U1' }],
+          'videos' => [{ html: 'H1' }]
         }, @mail_serializer.as_json)
       end
 
@@ -153,10 +151,8 @@ module ActiveModel
 
         assert_equal({
           'mail' => { body: 'Body 1' },
-          'attachments' => [
-            { type: :image, image: { url: 'U1' }},
-            { type: :video, video: { html: 'H1' }}
-          ]
+          'images' => [{ url: 'U1' }],
+          'videos' => [{ html: 'H1' }]
         }, @mail_serializer.as_json)
       end
 
@@ -178,10 +174,8 @@ module ActiveModel
               { id: c.object_id, type: model_name(c) }
             end
           },
-          'attachments' => [
-            { type: :image, image: { fake: 'fake' }},
-            { type: :video, video: { fake: 'fake' }}
-          ]
+          'images' => [{ fake: 'fake' }],
+          'videos' => [{ fake: 'fake' }]
         }, @mail_serializer.as_json)
       end
     end

--- a/test/unit/active_model/serializer/has_one_polymorphic_test.rb
+++ b/test/unit/active_model/serializer/has_one_polymorphic_test.rb
@@ -155,12 +155,7 @@ module ActiveModel
               id: @interview.attachment.object_id
             }
           },
-          "attachments" => [{
-            type: model_name(@interview.attachment),
-            model_name(@interview.attachment) => {
-              url: 'U1'
-            }
-          }]
+          model_name(@interview.attachment).to_s.pluralize => [{url: 'U1'}]
         }, @interview_serializer.as_json)
       end
 
@@ -183,12 +178,7 @@ module ActiveModel
               id: @interview.attachment.object_id
             }
           },
-          "attachments" => [{
-            type: model_name(@interview.attachment),
-            model_name(@interview.attachment) => {
-              name: 'fake'
-            }
-          }]
+          model_name(@interview.attachment).to_s.pluralize => [{name: 'fake'}]
         }, @interview_serializer.as_json)
       end
     end


### PR DESCRIPTION
Since entities are embedded at the root level, polymorphic associations should use the class name under polymorphism instead of the association name. `has_one` and `has_many` relationships have been updated to reflect this, and `DefaultSerializer` now represents polymorphic types just as `Serializer` would.

This change brings active_model_serializers much closer to supporting Ember Data sideloading with polymorphism and the [`ActiveModelAdapter`](http://emberjs.com/api/data/classes/DS.ActiveModelAdapter.html). On the Rails side, you need an initializer of the form:

    ActiveModel::Serializer.setup do |config|
      config.embed = :ids
      config.embed_in_root = true
    end

... and a `key` option in associations to ensure that `key_name` gets serialized as `key_name` instead of `key_name_id`:

    has_one :content, polymorphic: true, key: "content"

Admittedly, I made this PR to bring an end to monkey patching of our active_model_serializer / Ember Data transport layer, but I do believe that people would want this type of embed-in-root behavior regardless of what consumes the JSON. Also, getting an API server and JavaScript MVC framework to play well together would be a nice showpiece for complex serialization done right, i.e., with polymorphism *and* sideloading.