### PR TITLE
Capsulate serializers and enable identifier instead of default id.to_s

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -142,7 +142,9 @@ module ActiveModel
     def each_association(&block)
       self.class._associations.dup.each do |name, options|
         association = object.send(name)
-        serializer_class = ActiveModel::Serializer.serializer_for(association)
+        serializer_class = options[:options][:serializer] if association
+        serializer_class ||= ActiveModel::Serializer.serializer_for(association)
+
         serializer = serializer_class.new(association) if serializer_class
 
         if block_given?

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -121,6 +121,10 @@ module ActiveModel
       @root   = options[:root] || (self.class._root ? self.class.root_name : false)
     end
 
+    def identifier
+      object.id.to_s
+    end
+
     def json_key
       if root == true || root.nil?
         self.class.root_name
@@ -150,8 +154,12 @@ module ActiveModel
     private
 
     def self.get_serializer_for(klass)
-      serializer_class_name = "#{klass.name}Serializer"
-      serializer_class = serializer_class_name.safe_constantize
+      serializer_class = if klass.respond_to?(:serializer_class)
+        klass.serializer_class
+      else
+        serializer_class_name = "#{klass.name}Serializer"
+        serializer_class_name.safe_constantize
+      end
 
       if serializer_class
         serializer_class

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -156,11 +156,21 @@ module ActiveModel
     private
 
     def self.get_serializer_for(klass)
+#      serializer_class = if klass.respond_to?(:serializer_class)
+#        klass.serializer_class
+#      else
+#        serializer_class_name = "#{klass.name}Serializer"
+#        serializer_class_name.safe_constantize
+#      end
+      #serializer_class = if klass.to_s.starts_with?("Samples") #.split("::").first == "Samples" # klass != NilClass && klass != Object && klass != BasicObject
+      #  klass.serializer_class
+      #else
+      #  serializer_class_name = "#{klass.name}Serializer"
+      #  serializer_class_name.safe_constantize
+      #end
+
       serializer_class = if klass.respond_to?(:serializer_class)
         klass.serializer_class
-      else
-        serializer_class_name = "#{klass.name}Serializer"
-        serializer_class_name.safe_constantize
       end
 
       if serializer_class

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -33,12 +33,12 @@ module ActiveModel
 
           if name.to_s == type || !type
             resource[:links][name] ||= []
-            resource[:links][name] += serializers.map{|serializer| serializer.id.to_s }
+            resource[:links][name] += serializers.map{|serializer| serializer.identifier }
           else
             resource[:links][name] ||= {}
             resource[:links][name][:type] = type
             resource[:links][name][:ids] ||= []
-            resource[:links][name][:ids] += serializers.map{|serializer| serializer.id.to_s }
+            resource[:links][name][:ids] += serializers.map{|serializer| serializer.identifier }
           end
         end
 
@@ -49,11 +49,11 @@ module ActiveModel
           if serializer
             type = serialized_object_type(serializer)
             if name.to_s == type || !type
-              resource[:links][name] = serializer.id.to_s
+              resource[:links][name] = serializer.identifier
             else
               resource[:links][name] ||= {}
               resource[:links][name][:type] = type
-              resource[:links][name][:id] = serializer.id.to_s
+              resource[:links][name][:id] = serializer.identifier
             end
           end
         end
@@ -118,7 +118,13 @@ module ActiveModel
 
         def serialized_object_type(serializer)
           return false unless Array(serializer).first
-          type_name = Array(serializer).first.object.class.to_s.underscore
+          klass = Array(serializer).first.object.class
+          type_name = if klass.respond_to?(:object_type)
+            klass.object_type.to_s.underscore
+          else
+            klass.name.to_s.underscore
+          end
+
           if serializer.respond_to?(:first)
             type_name.pluralize
           else

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -122,7 +122,7 @@ module ActiveModel
           type_name = if klass.respond_to?(:object_type)
             klass.object_type.to_s.underscore
           else
-            klass.name.to_s.underscore
+            klass.to_s.underscore
           end
 
           if serializer.respond_to?(:first)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -120,7 +120,8 @@ module ActiveModel
 
         def serialized_object_href(serializer)
           return false unless Array(serializer).first                 
-          Array(serializer).first.object.href 
+          obj = Array(serializer).first.object 
+          obj.respond_to?(:href) ? obj.href : nil 
         end
 
         def serialized_object_type(serializer)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -29,13 +29,15 @@ module ActiveModel
 
         def add_links(resource, name, serializers, opts = {})
           type = serialized_object_type(serializers)
+          href = serialized_object_href(serializers)  
           resource[:links] ||= {}
 
-          if opts[:skip_type_check] || name.to_s == type || !type
+          if opts[:skip_type_check] || ((name.to_s == type || !type) && !href )
             resource[:links][name] ||= []
             resource[:links][name] += serializers.map{|serializer| serializer.identifier }
           else
             resource[:links][name] ||= {}
+            resource[:links][name][:href] = href if href
             resource[:links][name][:type] = type
             resource[:links][name][:ids] ||= []
             resource[:links][name][:ids] += serializers.map{|serializer| serializer.identifier }
@@ -114,6 +116,11 @@ module ActiveModel
           @options[:include].split(',').any? do |s|
             s.match(/^#{assoc.gsub('.', '\.')}/)
           end
+        end
+
+        def serialized_object_href(serializer)
+          return false unless Array(serializer).first                 
+          Array(serializer).first.object.href 
         end
 
         def serialized_object_type(serializer)

--- a/lib/active_model/serializer/version.rb
+++ b/lib/active_model/serializer/version.rb
@@ -1,5 +1,5 @@
 module ActiveModel
   class Serializer
-    VERSION = "0.10.0.pre"
+    VERSION = "0.10.1.pre"
   end
 end

--- a/lib/active_model/serializer/version.rb
+++ b/lib/active_model/serializer/version.rb
@@ -1,5 +1,5 @@
 module ActiveModel
   class Serializer
-    VERSION = "0.10.1.pre"
+    VERSION = "0.10.2.pre"
   end
 end


### PR DESCRIPTION
This PR contains:
a) Enable use of identifier to override default id.to_s
b) Enable use of own serializer capsulated in modules
c) Enable use of object_type to override default name (including modules)

According a: We need the possibility to define an own identifier, because the nested models are mainly identified by its type and not it's id. With this change the default behaviour is not changed and it is possible to use another content in the links section. ( e.g. { id: xxx, type: yyy } )

According b): We do not  have a rails/rails-api structure and the Serializers are inside <Application>::Serializer, and the models are inside <Application>::Model. The original code would expect the serializer to be defined in <Application>::Model::<model>Serializer. This would mix serializer and models.

According c) Because of the modules the type_name would look like "<application>/model/<model>" which looks ugly and does represent the internal structure of the classes, not the content. 

We are not really happy with the current solution, because the model has to define the serializer it is used by, but we can't add the "to-use-serializer" to the call, because of the implicit nesting. The object_type method may be moved to the serializer instead of the model.