### PR TITLE
Propagate serialization_options across associations

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -161,7 +161,7 @@ end
       end
     end
 
-    def associations
+    def associations(options={})
       associations = self.class._associations
       included_associations = filter(associations.keys)
       associations.each_with_object({}) do |(name, association), hash|
@@ -178,7 +178,7 @@ end
             if association.embed_namespace?
               hash = hash[association.embed_namespace] ||= {}
             end
-            hash[association.embedded_key] = serialize association
+            hash[association.embedded_key] = serialize association, options
           end
         end
       end
@@ -236,8 +236,8 @@ end
       end
     end
 
-    def serialize(association)
-      build_serializer(association).serializable_object
+    def serialize(association,options={})
+      build_serializer(association).serializable_object(options)
     end
 
     def serialize_ids(association)
@@ -282,7 +282,7 @@ end
       self.serialization_options = options
       return @wrap_in_array ? [] : nil if @object.nil?
       hash = attributes
-      hash.merge! associations
+      hash.merge! associations(options)
       hash = convert_keys(hash) if key_format.present?
       hash = { :type => type_name(@object), type_name(@object) => hash } if @polymorphic
       @wrap_in_array ? [hash] : hash

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -113,6 +113,13 @@ end
 class PostSerializer < ActiveModel::Serializer
   attributes :title, :body
 
+  def title
+    keyword = serialization_options[:highlight_keyword]
+    title = object.read_attribute_for_serialization(:title)
+    title = title.gsub(keyword,"'#{keyword}'") if keyword
+    title
+  end
+
   has_many :comments
 end
 

--- a/test/unit/active_model/serializer/has_many_test.rb
+++ b/test/unit/active_model/serializer/has_many_test.rb
@@ -176,7 +176,7 @@ module ActiveModel
 
       def test_associations_embedding_objects_using_a_given_array_serializer
         @association.serializer_from_options = Class.new(ArraySerializer) do
-          def serializable_object
+          def serializable_object(options={})
             { my_content: ['fake'] }
           end
         end

--- a/test/unit/active_model/serializer/options_test.rb
+++ b/test/unit/active_model/serializer/options_test.rb
@@ -21,6 +21,9 @@ module ActiveModel
             serialization_options[:force_the_description]
           end
         end
+
+        @category = Category.new({name: 'Category 1'})
+        @category_serializer = CategorySerializer.new(@category)
       end
 
       def test_filtered_attributes_serialization
@@ -28,6 +31,11 @@ module ActiveModel
         assert_equal({
           'profile' => { name: 'Name 1', description: forced_description }
         }, @profile_serializer.as_json(force_the_description: forced_description))
+      end
+
+      def test_filtered_attributes_serialization_across_association
+        assert_equal("'T1'",
+            @category_serializer.as_json(highlight_keyword: 'T1')['category'][:posts][0][:title])
       end
     end
   end


### PR DESCRIPTION
Hi,

This patch extends https://github.com/rails-api/active_model_serializers/pull/679 to allow the usage of serialization_options across all serializer associations. 

I needed this to implement a server side text search engine that returns the search results preprocessed to highlight the text that was searched.