### PR TITLE
pass serializable_options to associations

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -197,6 +197,7 @@ end
     def embedded_in_root_associations
       associations = self.class._associations
       included_associations = filter(associations.keys)
+      options = Array.wrap(serialization_options.presence)
       associations.each_with_object({}) do |(name, association), hash|
         if included_associations.include? name
           association_serializer = build_serializer(association)
@@ -209,7 +210,7 @@ end
               hash = hash[association.embed_in_root_key] ||= {}
             end
 
-            serialized_data = association_serializer.serializable_object
+            serialized_data = association_serializer.serializable_object(*options) # always sending options may break some tests/serializers
             key = association.root_key
             if hash.has_key?(key)
               hash[key].concat(serialized_data).uniq!
@@ -237,7 +238,8 @@ end
     end
 
     def serialize(association)
-      build_serializer(association).serializable_object
+      options = Array.wrap(serialization_options.presence)
+      build_serializer(association).serializable_object(*options) # always sending options may break some tests/serializers
     end
 
     def serialize_ids(association)

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -177,4 +177,19 @@ ActiveModel::Serializer.setup do |config|
   config.default_key_type = nil
 end
 
+class PrefixCommentSerializer < ActiveModel::Serializer
+  attributes :comment
+
+  def comment
+    "#{serialization_options[:prefix]}#{object.read_attribute_for_serialization(:content)}"
+  end
+end
+
+class PrefixUserProfileSerializer < ActiveModel::Serializer
+  attributes :description
+
+  def description
+    "#{serialization_options[:prefix]}#{object.read_attribute_for_serialization(:description)}"
+  end
+end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,13 @@ require 'fixtures/poro'
 # Ensure backward compatibility with Minitest 4
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
+module DefineTestSerializerClass
+  def define_test_serializer_class(name = "TestSerializer#{SecureRandom.hex(32)}", base = ActiveModel::Serializer, &block)
+    serializer = Class.new(base, &block)
+    Object.const_set(name, serializer)
+  end
+end
+
 module TestHelper
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
@@ -15,6 +22,7 @@ module TestHelper
 
   ActionController::Base.send :include, Routes.url_helpers
   ActionController::Base.send :include, ActionController::Serialization
+  Minitest::Test.send :include, DefineTestSerializerClass
 end
 
 ActionController::TestCase.class_eval do

--- a/test/unit/active_model/serializer/has_one_test.rb
+++ b/test/unit/active_model/serializer/has_one_test.rb
@@ -234,6 +234,30 @@ module ActiveModel
           'name_key_user' => { name: 'Name 1', email: 'mail@server.com', 'profile' => @user.profile.object_id }
         }, NameKeyUserSerializer.new(@user).as_json)
       end
+
+      def test_associations_serialization_options
+        serializer = define_test_serializer_class do
+          has_one :profile, serializer: PrefixUserProfileSerializer, embed: :object
+        end
+        assert_equal({
+         'user' => {
+           profile: { description: "PREFIX:#{@user.profile.read_attribute_for_serialization(:description)}" }
+         }
+       }, serializer.new(@user, root: 'user').as_json(prefix: 'PREFIX:'))
+      end
+
+      def test_associations_serialization_options_with_embed_in_root
+        serializer = define_test_serializer_class do
+          has_one :profile, serializer: PrefixUserProfileSerializer, embed: :id, embed_in_root: true
+        end
+
+        assert_equal({
+          'user' => {
+            'profile_id' => @user.profile.read_attribute_for_serialization(:id)
+          },
+          'profiles' => [{ description: "PREFIX:#{@user.profile.read_attribute_for_serialization(:description)}" }]
+        }, serializer.new(@user, root: 'user').as_json(prefix: 'PREFIX:'))
+      end
     end
   end
 end


### PR DESCRIPTION
@RobinDaugherty had committed some changes included in 0.9.1 to forward options passed to `as_json` to serialize_object, bringing back the behavior from 0.8.  I definitely welcomed these changes, as I had been stuffing options into `scope` to get around this, but these options, however, are still not available to associations.  I believe they should be passed to serialize_object for associations and these changes do just that.

I was afraid of breaking stuff so the code goes out of it's way continue to support serialize_object methods that cannot accept options.

I've included some tests and some helpers as well to help create serializer classes so that I don't need to define all my serializers in the poro file.