### PR TITLE
Tiny improvement of README 0-9-stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,18 +755,18 @@ end
     "title": "New post",
     "attachments": [
       {
-        "type": "image"
+        "type": "image",
         "image": {
-          "id": 3
-          "name": "logo"
+          "id": 3,
+          "name": "logo",
           "url": "http://images.com/logo.jpg"
         }
       },
       {
-        "type": "video"
+        "type": "video",
         "video": {
-          "id": 12
-          "uid": "XCSSMDFWW"
+          "id": 12,
+          "uid": "XCSSMDFWW",
           "source": "youtube"
         }
       }
@@ -793,11 +793,11 @@ end
     "title": "New post",
     "attachment_ids": [
       {
-        "type": "image"
+        "type": "image",
         "id": 12
       },
       {
-        "type": "video"
+        "type": "video",
         "id": 3
       }
     ]


### PR DESCRIPTION
Really small thing, but due to lack of commas github is adding extra red backgrounds in "Embedding Polymorphic Associations" examples, making it look like some kind of errors.
![screen shot 2014-12-09 at 16 09 08](https://cloud.githubusercontent.com/assets/68907/5359475/fa7e0b58-7fbd-11e4-8d3a-e5ad6267c2a3.png)
