### PR TITLE
add a failing spec for 746 hash.to_a is happening

### DIFF
--- a/test/integration/action_controller/serialization_test.rb
+++ b/test/integration/action_controller/serialization_test.rb
@@ -299,5 +299,21 @@ module ActionController
         assert_equal '{"my":[{"name":"Name 1"}]}', @response.body
       end
     end
+
+    class HashSerializationTest < ActionController::TestCase
+      class MyController < ActionController::Base
+        def render_hash
+          h = {a: 'b', c: 'd'}
+          render json: h, root: false
+        end
+      end
+
+      tests MyController
+
+      def test_render_hash
+        get :render_hash
+        assert_equal '{"a":"b","c":"d"}', @response.body
+      end
+    end
   end
 end


### PR DESCRIPTION
Here's a failing spec for https://github.com/rails-api/active_model_serializers/issues/746.  Anyone want to help fix?