### PR TITLE
Regression Fix: Don't use array serializer when rendering a hash

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -87,8 +87,8 @@ module ActionController
       if serializer = options.fetch(:serializer, default_serializer(resource))
         options[:scope] = serialization_scope unless options.has_key?(:scope)
 
-        if resource.respond_to?(:each)
-          options[:resource_name] = controller_name 
+        if resource.respond_to?(:each) && !resource.is_a?(Hash)
+          options[:resource_name] = controller_name
           options[:namespace] = namespace_for_serializer if namespace_for_serializer
         end
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -56,7 +56,7 @@ end
       attr_reader :key_format
 
       def serializer_for(resource, options = {})
-        if resource.respond_to?(:each)
+        if resource.respond_to?(:each) && !resource.is_a?(Hash)
           if Object.constants.include?(:ArraySerializer)
             ::ArraySerializer
           else

--- a/test/integration/action_controller/serialization_test.rb
+++ b/test/integration/action_controller/serialization_test.rb
@@ -299,5 +299,21 @@ module ActionController
         assert_equal '{"my":[{"name":"Name 1"}]}', @response.body
       end
     end
+
+    class SimpleHashObjectTest < ActionController::TestCase
+      class MyController < ActionController::Base
+        def render_hash
+          render json: { name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }
+        end
+      end
+
+      tests MyController
+
+      def test_render_hash
+        get :render_hash
+        assert_equal 'application/json', @response.content_type
+        assert_equal '{"name":"Name 1","description":"Description 1","comments":"Comments 1"}', @response.body
+      end
+    end
   end
 end


### PR DESCRIPTION
90343ce introduced a bug when rendering basic hashes. Since hashes respond to `each` they were being incorrectly rendered as multi-level arrays after that commit.

This PR simply checks if the resource is not a hash before using the array serializer. I'm not entirely convinced using `each` is the right approach here in the first place, and I dislike checking for a hash explicitly, but this restores the previous functionality without removing the functionality introduced in the above commit.