### PR TITLE
Make linked resource type names consistent with root names

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -126,7 +126,7 @@ module ActiveModel
 
         def serialized_object_type(serializer)
           return false unless Array(serializer).first
-          type_name = Array(serializer).first.object.class.to_s.underscore
+          type_name = Array(serializer).first.object.class.to_s.demodulize.underscore
           if serializer.respond_to?(:first)
             type_name.pluralize
           else

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -64,7 +64,7 @@ module ActiveModel
             assert_equal({comments: [], author: nil}, adapter.serializable_hash[:posts][:links])
           end
 
-          def test_include_type_for_association_when_is_different_than_name
+          def test_include_type_for_association_when_different_than_name
             serializer = BlogSerializer.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
             links = adapter.serializable_hash[:blogs][:links]

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -78,10 +78,15 @@ module ActiveModel
             assert_nil adapter.serializable_hash[:linked]
           end
 
-          def test_include_type_for_association_when_is_different_than_name
+          def test_include_type_for_association_when_different_than_name
             serializer = BlogSerializer.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
-            assert_equal({type: "posts", ids: ["1"]}, adapter.serializable_hash[:blogs][:links][:articles])
+            actual = adapter.serializable_hash[:blogs][:links][:articles]
+            expected = {
+              type: "posts",
+              ids: ["1"]
+            }
+            assert_equal(expected, actual)
           end
         end
       end

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -138,6 +138,21 @@ module ActiveModel
             }
             assert_equal expected, @adapter.serializable_hash[:linked]
           end
+
+          def test_ignore_model_namespace_for_linked_resource_type
+            spammy_post = Post.new(id: 123)
+            spammy_post.related = [Spam::UnrelatedLink.new(id: 456)]
+            serializer = SpammyPostSerializer.new(spammy_post)
+            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
+            links = adapter.serializable_hash[:posts][:links]
+            expected = {
+              related: {
+                type: 'unrelated_links',
+                ids: ['456']
+              }
+            }
+            assert_equal expected, links
+          end
         end
       end
     end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -47,6 +47,8 @@ Author = Class.new(Model)
 Bio = Class.new(Model)
 Blog = Class.new(Model)
 Role = Class.new(Model)
+module Spam; end
+Spam::UnrelatedLink = Class.new(Model)
 
 PostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :title, :body, :id
@@ -54,6 +56,15 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   has_many :comments
   belongs_to :author
   url :comments
+end
+
+SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id
+  has_many :related
+
+  def self.root_name
+    'posts'
+  end
 end
 
 CommentSerializer = Class.new(ActiveModel::Serializer) do
@@ -122,4 +133,8 @@ PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
 
   has_many :comments, serializer: CommentPreviewSerializer
   belongs_to :author, serializer: AuthorPreviewSerializer
+end
+
+Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id
 end


### PR DESCRIPTION
Using the JSON API adapter, when models are coming from a Rails engine and are namespaced, the namespace was reflected in linked resource types but not in the root type, leading to inconsistent resource names. This PR removes the namespace from linked resources. For example:

Given models like this:

```ruby
module Pizza

  class Dough < ActiveRecord::Base
    belongs_to :pie
  end

  class Pie < ActiveRecord::Base
    has_one :crust, class_name: 'Pizza::Dough'
  end

end
```

Serialization could end up looking like this:

```javascript
{
  linked: {
    'pizza/doughs': [{
      id: 456
    }]
  },
  pies: {
    id: 123,
    links: {
      crust: {
        id: 456,
        type: 'pizza/dough'
      }
    }
  }
}
```

But should look like this:

```javascript
{
  linked: {
    'doughs': [{
      id: 456
    }]
  },
  pies: {
    id: 123,
    links: {
      crust: {
        id: 456,
        type: 'dough'
      }
    }
  }
}
```