### PR TITLE
Make json api adapter 'include' option accept an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ resources in the `"linked"` member when the resource names are included in the
 `include` option.
 
 ```ruby
+  render @posts, include: ['authors', 'comments']
+  # or
   render @posts, include: 'authors,comments'
 ```
 

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -121,7 +121,9 @@ module ActiveModel
         end
 
         def check_assoc(assoc)
-          @options[:include].split(',').any? do |s|
+          include_opt = @options[:include]
+          include_opt = include_opt.split(',') if include_opt.is_a?(String)
+          include_opt.any? do |s|
             s.match(/^#{assoc.gsub('.', '\.')}/)
           end
         end

--- a/test/action_controller/json_api_linked_test.rb
+++ b/test/action_controller/json_api_linked_test.rb
@@ -52,7 +52,7 @@ module ActionController
 
         def render_resource_with_nested_has_many_include
           setup_post
-          render json: @post, include: 'author,author.roles', adapter: :json_api
+          render json: @post, include: ['author', 'author.roles'], adapter: :json_api
         end
 
         def render_resource_with_missing_nested_has_many_include
@@ -74,7 +74,7 @@ module ActionController
 
         def render_collection_with_include
           setup_post
-          render json: [@post], include: 'author,comments', adapter: :json_api
+          render json: [@post], include: ['author', 'comments'], adapter: :json_api
         end
       end
 

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -89,7 +89,7 @@ module ActiveModel
 
           def test_include_linked_resources_with_type_name
             serializer = BlogSerializer.new(@blog)
-            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer, include: "writer,articles")
+            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer, include: ['writer', 'articles'])
             linked = adapter.serializable_hash[:linked]
             expected = {
               authors: [{

--- a/test/adapter/json_api/has_many_explicit_serializer_test.rb
+++ b/test/adapter/json_api/has_many_explicit_serializer_test.rb
@@ -24,7 +24,7 @@ module ActiveModel
             @serializer = PostPreviewSerializer.new(@post)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(
               @serializer,
-              include: 'comments,author'
+              include: ['comments', 'author']
             )
           end
 


### PR DESCRIPTION
I'm proposing this change because it just makes more sense (to me). I'm not sure why we're accepting a comma-delimited string and then splitting it into an array instead of just accepting an array in the first place. This still allows a comma-delimited string for legacy reasons. I did not include a test for this on purpose but can add it if you'd like.

I have updated the readme to reflect the usage change. It's pretty straight-forward.