### PR TITLE
Fix nested include attributes

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -68,8 +68,8 @@ module ActiveModel
 
           resource_path = [parent, resource_name].compact.join('.')
 
-          if include_assoc?(resource_path)
-            plural_name = serialized_object_type(serializers).pluralize.to_sym
+          if include_assoc?(resource_path) && resource_type = serialized_object_type(serializers)
+            plural_name = resource_type.pluralize.to_sym
             @top[:linked] ||= {}
             @top[:linked][plural_name] ||= []
 


### PR DESCRIPTION
When the requests asked for a nested attribute in the `include` and it's missing or empty, don't break because the type of the object can't be determined.

If the request is for a collection and none of the elements has the attribute, it will not be added to the `linked` key, similar to what happens with simple includes.