### PR TITLE
Fixed `ids` typo with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ to `comments` underneath a `links` key:
 class PostSerializer < ActiveModel::Serializer
   attributes :id, :title, :body
 
-  has_many :comments, embed: ids, embed_namespace: :links
+  has_many :comments, embed: :ids, embed_namespace: :links
 end
 ```
 
@@ -615,7 +615,7 @@ the root document (say, `linked`), you can specify an `embed_in_root_key`:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
-  embed: ids, include: true, embed_in_root_key: :linked
+  embed :ids, include: true, embed_in_root_key: :linked
 
   attributes: :id, :title, :body
   has_many :comments, :tags


### PR DESCRIPTION
A small typo in README that is confusing for some young Rails developers