### PR TITLE
add column_names method

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -36,6 +36,10 @@ module ActiveModel
       end unless method_defined?(key)
     end
 
+    def self.column_names
+      to_s.sub("Serializer", "").constantize.column_names
+    end
+
     # Defines an association in the object that should be rendered.
     #
     # The serializer object should implement the association name
@@ -167,10 +171,6 @@ module ActiveModel
       serializer = options.fetch(:options, {}).fetch(:serializer, nil)
       opts[:serializer] = serializer if serializer
       opts
-    end
-
-    def column_names
-      to_s.sub("Serializer", "").constantize.column_names
     end
 
     private

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -169,6 +169,10 @@ module ActiveModel
       opts
     end
 
+    def column_names
+      to_s.sub("Serializer", "").constantize.column_names
+    end
+
     private
 
     def self.get_serializer_for(klass)


### PR DESCRIPTION
If you are using a large Rails application and you can't keep track of the columns names to whitelist, sometimes its easier just to use a method to white list all the column names for you and use a black list instead. This would be true for a Rails engine such as [Spree](https://github.com/spree/spree).

This method currently has no tests. Not sure how testing should be done in this app.

Usage:

```ruby
class ArticleSerializer < ActiveModel::Serializer
  attributes *column_names
end
```

Result is all columns in the `Article` class are now available to be serialized for the `ArticleSerializer`.