### PR TITLE
Serailize plain arrays

### DIFF
--- a/lib/active_model/serializer/primitive_serializer.rb
+++ b/lib/active_model/serializer/primitive_serializer.rb
@@ -1,0 +1,15 @@
+module ActiveModel
+  class Serializer
+    class PrimitiveSerializer < Serializer
+      def self.can_serialize?(value)
+        [:to_str, :to_int, :to_hash].detect { |meth|
+          value.respond_to?(meth)
+        } || value.is_a?(Symbol)
+      end
+
+      def attributes(*)
+        object
+      end
+    end
+  end
+end

--- a/test/action_controller/primitive_serializer_test.rb
+++ b/test/action_controller/primitive_serializer_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+module ActionController
+  module Serialization
+    class PrimitiveSerializationTest < ActionController::TestCase
+      class MyController < ActionController::Base
+        def render_array_of_primitives
+          render json: ['value1', 1, {some: 'hash'}]
+        end
+      end
+
+      tests MyController
+
+      def test_render_array_of_primitives
+        get :render_array_of_primitives
+
+        assert_equal 'application/json', @response.content_type
+        assert_equal %{["value1",1,{"some":"hash"}]}, @response.body
+      end
+    end
+  end
+end

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -51,6 +51,15 @@ module ActiveModel
           assert_equal ProfileSerializer, serializer
         end
       end
+
+      class PrimitiveSerializerTest < Minitest::Test
+        def test_serializer_for_primitives
+          ['hi', 1, {}, :symbol].each do |primitive|
+            serializer = ActiveModel::Serializer.serializer_for(primitive)
+            assert_equal PrimitiveSerializer, serializer
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is in response to https://github.com/rails-api/active_model_serializers/issues/772

I wanted to learn about ActiveModelSerializers so I thought I'd try to tackle a bug. Unfortunately the one I picked lead me to some pretty big design questions. 

Specifically:

Is there a way to avoid invoking all the guts of AMS on a "plain" array?

```ruby
class PostsController < ApplicationController
  def show
    # Would be nice to avoid AMS altogether
    render json: ['one', 'two', 'three']
  end
end
```

and what does it even mean to have primitive values in an array with serializable objects?

```ruby
class PostsController < ApplicationController
  def show
    post = Post.find(params[:id])
    render json: ['look at this post', post, 3]
  end
end
```

I'm sending this PR because it at least provides a failing test for the issue. If you have some helpful insights or If you think this PR might be usable let me know and I can work on any needed adjustments. Otherwise, feel no remorse about closing :)