### PR TITLE
Properly formatting passed in serializer namespace

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -110,7 +110,7 @@ end
 
       def build_serializer_class(resource, options)
         "".tap do |klass_name|
-          klass_name << "#{options[:namespace]}::" if options[:namespace]
+          klass_name << "#{options[:namespace].to_s.classify}::" if options[:namespace]
           klass_name << options[:prefix].to_s.classify if options[:prefix]
           klass_name << "#{resource.class.name}Serializer"
         end

--- a/test/unit/active_model/serializer/associations/build_serializer_test.rb
+++ b/test/unit/active_model/serializer/associations/build_serializer_test.rb
@@ -24,6 +24,13 @@ module ActiveModel
           assert_instance_of(TestNamespace::ProfileSerializer, serializer)
         end
 
+        def test_build_serializer_with_a_namespace
+          assoc      = Association::HasOne.new('profile', namespace: :test_namespace)
+          serializer = UserSerializer.new(@user).build_serializer(assoc)
+
+          assert_instance_of(TestNamespace::ProfileSerializer, serializer)
+        end
+
         def test_build_serializer_with_prefix
           assoc      = Association::HasOne.new('profile', prefix: :short)
           serializer = UserSerializer.new(@user).build_serializer(assoc)


### PR DESCRIPTION
This fix allows to pass `namespace: :api`, with a lowercase `:api`. Old format, of course, is still supported.