### PR TITLE
Fixes undefined method `pluralize' for false:FalseClass

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -69,7 +69,9 @@ module ActiveModel
           resource_path = [parent, resource_name].compact.join('.')
 
           if include_assoc?(resource_path) && resource_type = serialized_object_type(serializers)
-            plural_name = resource_type.pluralize.to_sym
+            object_type = serialized_object_type(serializers)
+            return unless object_type
+            plural_name = object_type.pluralize.to_sym
             @top[:linked] ||= {}
             @top[:linked][plural_name] ||= []
 


### PR DESCRIPTION
Had some errors where the `serialized_object_type` method was returning `false` and the `add_linked()` method didn't seem to care. This might not be the best solution, but it works for me.