### PR TITLE
not serialize keys with nil value

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -142,7 +142,7 @@ module ActiveModel
         end
 
       attributes.each_with_object({}) do |name, hash|
-        hash[name] = send(name)
+        hash[name] = send(name) unless send(name).nil?
       end
     end
 

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -59,8 +59,7 @@ module ActiveModel
           },
           articles: [{
             id: 3,
-            title: "AMS",
-            body: nil
+            title: "AMS"
           }]
         }]
         assert_equal expected, adapter.as_json


### PR DESCRIPTION
Most clients IOS / Android crashing if the key value nil.