### PR TITLE
add to_param for correct URL generation

### DIFF
--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -15,6 +15,10 @@ class Model
     @attributes[:id] || @attributes['id'] || object_id
   end
 
+  def to_param
+    id
+  end
+
   def method_missing(meth, *args)
     if meth.to_s =~ /^(.*)=$/
       @attributes[$1.to_sym] = args[0]


### PR DESCRIPTION
I don't think that this needs tests, but I can write them if necessary. Just make sure that the correct URL is generated when using Rails' `url_helpers` in tests.