### PR TITLE
add basic support for collection+json

### DIFF
--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -7,6 +7,7 @@ module ActiveModel
       autoload :Json
       autoload :Null
       autoload :JsonApi
+      autoload :CollectionJson
 
       attr_reader :serializer
 

--- a/lib/active_model/serializer/adapter/collection_json.rb
+++ b/lib/active_model/serializer/adapter/collection_json.rb
@@ -1,0 +1,74 @@
+module ActiveModel
+  class Serializer
+    class Adapter
+      class CollectionJson < Adapter
+        def initialize(serializer, options = {})
+          super
+          @hash = {}
+        end
+
+        def serializable_hash(options = {})
+          @hash[:version] = "1.0"
+          @hash[:href] = add_href(:collection)
+
+          add_items
+
+          { collection: @hash }
+        end
+
+        private
+
+        def add_items
+          if serializer.respond_to?(:each)
+            serializer.map do |serializer|
+              add_item(serializer)
+            end
+          else
+            add_item(serializer)
+          end
+        end
+
+        def add_item(serializer)
+          @hash.store :items, [] unless @hash.key?(:items)
+          item = Hash.new
+
+          item[:href] = add_href(:item, serializer.object)
+
+          serializer.attributes.each do |k,v|
+            item[:data] = [] unless item.key?(:data)
+
+            c = { name: k.to_s, value: v }
+            item[:data] << c
+          end if serializer.attributes.present?
+
+          @hash[:items] << item
+        end
+
+        def add_href(target = :collection, object = nil)
+          case target
+          when :collection
+            Rails.application.routes.url_helpers.send("#{type.pluralize}_url")
+          when :item
+            Rails.application.routes.url_helpers.send("#{type}_url", object)
+          end
+        end
+
+        # This is copy&paste from the JsonApi adapter
+        # Should it be moved to AMS::Adapter?
+        def serialized_object_type(serializer)
+          return false unless Array(serializer).first
+          type_name = Array(serializer).first.object.class.to_s.underscore
+          if serializer.respond_to?(:first)
+            type_name.pluralize
+          else
+            type_name
+          end
+        end
+
+        def type
+          serialized_object_type(serializer).singularize
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/collection_json/attributes_test.rb
+++ b/test/adapter/collection_json/attributes_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class CollectionJson
+        class Attributes < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Carles J.')
+            @first_post = Post.new(id: 1, title: 'Hello!', body: 'Hello, world!!')
+            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+
+            @single_serializer = PostSerializer.new(@first_post)
+            @multiple_serializer = ArraySerializer.new([@first_post, @second_post])
+
+            Rails.application.routes.default_url_options[:host] = 'localhost'
+            Rails.application.routes.draw do
+              resources :posts
+            end
+          end
+
+          def test_a_single_post_is_included
+            adapter = ActiveModel::Serializer::Adapter::CollectionJson.
+              new(@single_serializer)
+            expected = [
+              { name: "id", value: 1 },
+              { name: "title", value: "Hello!" },
+              { name: "body", value: "Hello, world!!" }
+            ]
+
+            assert_equal expected,
+                         adapter.serializable_hash[:collection][:items][0][:data]
+          end
+
+          def test_multiple_posts_are_included
+            adapter = ActiveModel::Serializer::Adapter::CollectionJson.
+              new(@multiple_serializer)
+            expected_1 = [
+              { name: "id", value: 1 },
+              { name: "title", value: "Hello!" },
+              { name: "body", value: "Hello, world!!" }
+            ]
+            expected_2 = [
+              { name: "id", value: 2 },
+              { name: "title", value: "New Post" },
+              { name: "body", value: "Body" }
+            ]
+
+
+            assert_equal expected_1,
+                         adapter.serializable_hash[:collection][:items][0][:data]
+            assert_equal expected_2,
+                         adapter.serializable_hash[:collection][:items][1][:data]
+
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/collection_json/collection_json_test.rb
+++ b/test/adapter/collection_json/collection_json_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class CollectionJson
+        class CollectionJsonAdapterTest < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Carles J.')
+            @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')
+            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+
+            @single_serializer = PostSerializer.new(@first_post)
+            @multiple_serializer = ArraySerializer.new([@first_post, @second_post])
+
+            Rails.application.routes.default_url_options[:host] = "localhost"
+            Rails.application.routes.draw do
+              resources :posts
+            end
+          end
+
+          def test_response_with_a_single_resource
+            adapter = ActiveModel::Serializer::Adapter::CollectionJson.new(@single_serializer)
+            expected = {
+              collection: {
+                version: "1.0",
+                href: "http://localhost/posts",
+                items: [
+                  {
+                    href: "http://localhost/posts/1",
+                    data: [{
+                      name: "id", value: 1
+                    },{
+                      name: "title", value: "Hello!!"
+                    },{
+                      name: "body", value: "Hello, world!!"
+                    }]
+                  }
+                ]
+              }
+            }
+
+            assert_equal expected, adapter.serializable_hash
+          end
+
+          def test_response_with_multiple_resources
+            adapter = ActiveModel::Serializer::Adapter::CollectionJson.new(@multiple_serializer)
+            expected = {
+              collection: {
+                version: "1.0",
+                href: "http://localhost/posts",
+                items: [
+                  {
+                    href: "http://localhost/posts/1",
+                    data: [{
+                      name: "id", value: 1
+                    },{
+                      name: "title", value: "Hello!!"
+                    },{
+                      name: "body", value: "Hello, world!!"
+                    }]
+                  },
+                  {
+                    href: "http://localhost/posts/2",
+                    data: [{
+                      name: "id", value: 2
+                    },{
+                      name: "title", value: "New Post"
+                    },{
+                      name: "body", value: "Body"
+                    }]
+                  }
+                ]
+              }
+            }
+
+            assert_equal expected, adapter.serializable_hash
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/collection_json/href_test.rb
+++ b/test/adapter/collection_json/href_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class CollectionJson
+        class Href< Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Carles J.')
+            @first_post = Post.new(
+              id: 1,
+              title: 'Hello!!',
+              body: 'Hello, world!!'
+            )
+            @second_post = Post.new(id: 2, title: 'New Post', body: 'Body')
+
+            @single_serializer = PostSerializer.new(@first_post)
+
+            @multiple_serializer = ArraySerializer.
+              new([@first_post, @second_post])
+
+            Rails.application.routes.default_url_options[:host] = 'localhost'
+            Rails.application.routes.draw do
+              resources :posts
+            end
+          end
+
+          def test_top_level_and_items_href_is_included_for_single_items
+            adapter = ActiveModel::Serializer::Adapter::CollectionJson.
+              new(@single_serializer)
+
+            assert_equal "http://localhost/posts",
+              adapter.serializable_hash[:collection][:href],
+              "top-level href does not match"
+            assert_equal "http://localhost/posts/1",
+              adapter.serializable_hash[:collection][:items][0][:href],
+              "item href does not match"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This introduces really basic support for Collection+JSON. Some parts of CJ can't be implemented with the current AMS DSL, and some others (urls, associations) need a thought, since CJ does not have nested resources. 

Two things here:

1. This would need a massive rebase before being merge, I know ;-)
2. Here I'm introducing `to_param` to `Model` for tests. I already submitted [a PR for this](https://github.com/rails-api/active_model_serializers/pull/794), but I needed it for tests to pass, so I couldn't avoid it. I leave it up to you to decide whether it's best to have it a separate PR or have it here mixed up. I think it's better to have a separate PR and I'll fix it when I rebase.