### PR TITLE
Fix and test for #490

### DIFF
--- a/lib/active_model/serializer/association/has_one.rb
+++ b/lib/active_model/serializer/association/has_one.rb
@@ -12,7 +12,7 @@ module ActiveModel
         end
 
         def serializer_class(object, options = {})
-          serializer_from_options || serializer_from_object(object, options) || default_serializer
+          (serializer_from_options unless object.nil?) || serializer_from_object(object, options) || default_serializer
         end
 
         def build_serializer(object, options = {})

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -88,7 +88,7 @@ class UserSerializer < ActiveModel::Serializer
 end
 
 class UserInfoSerializer < ActiveModel::Serializer
-  has_one :user
+  has_one :user, serializer: UserSerializer
 end
 
 class ProfileSerializer < ActiveModel::Serializer

--- a/test/unit/active_model/serializer/has_one_test.rb
+++ b/test/unit/active_model/serializer/has_one_test.rb
@@ -176,6 +176,20 @@ module ActiveModel
         }, @user_serializer.as_json)
       end
 
+      def test_associations_embedding_objects_with_nil_values
+        user_info = UserInfo.new
+        user_info.instance_eval do
+          def user
+            nil
+          end
+        end
+        user_info_serializer = UserInfoSerializer.new(user_info)
+
+        assert_equal({
+          'user_info' => { user: nil }
+        }, user_info_serializer.as_json)
+      end
+
       def test_associations_embedding_ids_using_embed_namespace
         @association.embed_namespace = :links
         @association.embed = :ids


### PR DESCRIPTION
Without the fix, this new test was failing with:

```
ActiveModel::Serializer::HasOneTest#test_associations_embedding_objects_with_nil_values:
NoMethodError: undefined method `profile' for nil:NilClass
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:124:in `block (2 levels) in associate'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:225:in `build_serializer'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:202:in `block in embedded_in_root_associations'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:200:in `each'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:200:in `each_with_object'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:200:in `embedded_in_root_associations'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:205:in `block in embedded_in_root_associations'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:200:in `each'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:200:in `each_with_object'
    /Users/afn/active_model_serializers/lib/active_model/serializer.rb:200:in `embedded_in_root_associations'
    /Users/afn/active_model_serializers/lib/active_model/serializable.rb:28:in `serializable_data'
    /Users/afn/active_model_serializers/lib/active_model/serializable.rb:13:in `block in as_json'
    /Users/afn/.rvm/gems/ruby-2.1.1/gems/activesupport-4.0.13/lib/active_support/notifications.rb:161:in `instrument'
    /Users/afn/active_model_serializers/lib/active_model/serializable.rb:55:in `instrument'
    /Users/afn/active_model_serializers/lib/active_model/serializable.rb:10:in `as_json'
    /Users/afn/active_model_serializers/test/unit/active_model/serializer/has_one_test.rb:190:in `test_associations_embedding_objects_with_nil_values'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:1265:in `run'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:940:in `block in _run_suite'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:933:in `map'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:933:in `_run_suite'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/parallel_each.rb:78:in `block in _run_suites'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/parallel_each.rb:78:in `map'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/parallel_each.rb:78:in `_run_suites'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:884:in `_run_anything'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:1092:in `run_tests'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:1079:in `block in _run'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:1078:in `each'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:1078:in `_run'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:1066:in `run'
    /Users/afn/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/minitest/unit.rb:802:in `block in autorun'
```
