### PR TITLE
Fields option should filter linked associations

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -156,8 +156,16 @@ module ActiveModel
       end
     end
 
-    def each_association(&block)
-      self.class._associations.dup.each do |name, options|
+    def associations(options = {})
+      if options[:fields]
+        self.class._associations.slice(*options[:fields])
+      else
+        self.class._associations.dup
+      end
+    end
+
+    def each_association(options = {}, &block)
+      self.associations(options).each do |name, options|
         next unless object
 
         association = object.send(name)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -138,8 +138,9 @@ module ActiveModel
 
         def add_resource_links(attrs, serializer, options = {})
           options[:add_linked] = options.fetch(:add_linked, true)
+          options[:fields] = @fieldset && @fieldset.fields_for(serializer) 
 
-          serializer.each_association do |name, association, opts|
+          serializer.each_association(options) do |name, association, opts|
             attrs[:links] ||= {}
 
             if association.respond_to?(:each)

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -51,9 +51,12 @@ module ActiveModel
           end
 
           def test_limiting_linked_post_fields
-            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'post', fields: {post: [:title]})
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'post', fields: {post: [:title, :author]})
             expected = [{
-              title: 'New Post'
+              title: 'New Post',
+              links: {
+                author: "1"
+              }
             }]
             assert_equal expected, @adapter.serializable_hash[:linked][:posts]
           end

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -53,12 +53,7 @@ module ActiveModel
           def test_limiting_linked_post_fields
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'post', fields: {post: [:title]})
             expected = [{
-              title: 'New Post',
-              links: {
-                comments: ["1"],
-                blog: "999",
-                author: "1"
-              }
+              title: 'New Post'
             }]
             assert_equal expected, @adapter.serializable_hash[:linked][:posts]
           end

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -34,8 +34,8 @@ module ActiveModel
           def test_limiting_fields
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, fields: ['title'])
             assert_equal([
-              { title: "Hello!!", links: { comments: [], blog: "999", author: "1" } },
-              { title: "New Post", links: { comments: [], blog: nil, author: "1" } }
+              { title: "Hello!!" },
+              { title: "New Post" }
             ], @adapter.serializable_hash[:posts])
           end
 

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -32,10 +32,10 @@ module ActiveModel
           end
 
           def test_limiting_fields
-            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, fields: ['title'])
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, fields: ['title', 'comments'])
             assert_equal([
-              { title: "Hello!!" },
-              { title: "New Post" }
+              { title: "Hello!!", links: { comments: [] } },
+              { title: "New Post", links: { comments: [] } }
             ], @adapter.serializable_hash[:posts])
           end
 

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -59,17 +59,9 @@ module ActiveModel
           def test_limit_fields_of_linked_comments
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'comments', fields: {comment: [:id]})
             expected = [{
-              id: "1",
-              links: {
-                post: "1",
-                author: nil
-              }
+              id: "1"
             }, {
-              id: "2",
-              links: {
-                post: "1",
-                author: nil
-              }
+              id: "2"
             }]
             assert_equal expected, @adapter.serializable_hash[:linked][:comments]
           end

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -57,11 +57,17 @@ module ActiveModel
           end
 
           def test_limit_fields_of_linked_comments
-            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'comments', fields: {comment: [:id]})
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'comments', fields: {comment: [:id, :post]})
             expected = [{
-              id: "1"
+              id: "1",
+              links: {
+                post: "1"
+              }
             }, {
-              id: "2"
+              id: "2",
+              links: {
+                post: "1"
+              }
             }]
             assert_equal expected, @adapter.serializable_hash[:linked][:comments]
           end


### PR DESCRIPTION
This feature implements filtering of associations with option `fields`. 
IMHO, linked associations are like fields and they should be filtered too, when option `fields` used

Unfortunately, I found nothing about it at http://jsonapi.org/format/. What do you think about it?