### PR TITLE
fix: issue 772 by adding StringSerializer

### DIFF
--- a/lib/active_model/serializers.rb
+++ b/lib/active_model/serializers.rb
@@ -1,0 +1,9 @@
+module ActiveModel
+  module Serializers
+    class StringSerializer < ActiveModel::Serializer
+      def attributes(obj)
+        @object.to_s
+      end
+    end
+  end
+end

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -2,7 +2,9 @@ require "active_model"
 require "active_model/serializer/version"
 require "active_model/serializer"
 require "active_model/serializer/fieldset"
+require "active_model/serializers"
 
+include ActiveModel::Serializers
 begin
   require 'action_controller'
   require 'action_controller/serialization'

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -38,6 +38,13 @@ module ActionController
           render json: array
         end
 
+        def render_array_using_generic_array_serializer
+          array = [
+          'No session found for the current user.'
+          ]
+          render json: array
+        end
+
         def render_array_using_implicit_serializer_and_meta
           old_adapter = ActiveModel::Serializer.config.adapter
 
@@ -95,6 +102,17 @@ module ActionController
             name: 'Name 2',
             description: 'Description 2',
           }
+        ]
+
+        assert_equal expected.to_json, @response.body
+      end
+
+      def test_render_array_using_generic_array_serializer
+        get :render_array_using_generic_array_serializer
+        assert_equal 'application/json', @response.content_type
+
+        expected = [
+          'No session found for the current user.'
         ]
 
         assert_equal expected.to_json, @response.body


### PR DESCRIPTION
fix: Add String Serializer

Issue #772 seemed to be caused by it trying to look up a StringSerializer and failing. Why not add serializers for basic types if we want to use the metaprogramming-friendly logic in get_serializer_for(). I also wrote a test that failed on master, but worked after I added my code.