### PR TITLE
Returning DefaultSerializer when nil is passed to serializer_for

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -56,7 +56,9 @@ end
       attr_reader :key_format
 
       def serializer_for(resource, options = {})
-        if resource.respond_to?(:to_ary)
+        if resource.nil?
+          DefaultSerializer
+        elsif resource.respond_to?(:to_ary)
           if Object.constants.include?(:ArraySerializer)
             ::ArraySerializer
           else

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -24,6 +24,11 @@ class User < Model
   end
 end
 
+class NilProfileUser < User
+  def profile
+  end
+end
+
 class UserInfo < Model
   def user
     @user ||= User.new(name: 'N1', email: 'E1')

--- a/test/unit/active_model/serializer/associations/build_serializer_test.rb
+++ b/test/unit/active_model/serializer/associations/build_serializer_test.rb
@@ -8,6 +8,7 @@ module ActiveModel
           @association = Association::HasOne.new('post', serializer: PostSerializer)
           @post = Post.new({ title: 'Title 1', body: 'Body 1', date: '1/1/2000' })
           @user = User.new
+          @nil_profile_user = NilProfileUser.new
         end
 
         def test_build_serializer_for_array_called_twice
@@ -29,6 +30,13 @@ module ActiveModel
           serializer = UserSerializer.new(@user).build_serializer(assoc)
 
           assert_instance_of(ShortProfileSerializer, serializer)
+        end
+        
+        def test_build_serializer_when_association_nil
+          assoc      = Association::HasOne.new('profile')
+          serializer = UserSerializer.new(@nil_profile_user).build_serializer(assoc)
+          
+          assert_instance_of(DefaultSerializer, serializer)
         end
       end
     end


### PR DESCRIPTION
This avoids a costly `_const_get` search for a non-existent `NilClassSerializer`. We hit a performance issue when serializing thousands of records that had a `has_one` association that could potentially be nil--the `_const_get` search was responsible for about 26 seconds of a 28 second `to_json` call. It can be fixed by adding an empty `NilClassSerializer`, but this seems like the better fix.