### PR TITLE
Allow to define custom serializer for given class

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -56,7 +56,9 @@ end
       attr_reader :key_format
 
       def serializer_for(resource, options = {})
-        if resource.respond_to?(:to_ary)
+        if resource.respond_to?(:serializer_class)
+          resource.serializer_class
+        elsif resource.respond_to?(:to_ary)
           if Object.constants.include?(:ArraySerializer)
             ::ArraySerializer
           else

--- a/test/unit/active_model/array_serializer/serialization_test.rb
+++ b/test/unit/active_model/array_serializer/serialization_test.rb
@@ -35,6 +35,23 @@ module ActiveModel
       end
     end
 
+    class CustomSerializerClassTest < Minitest::Test
+      def setup
+        Object.const_set(:CustomSerializer, Class.new)
+      end
+
+      def teardown
+        Object.send(:remove_const, :CustomSerializer)
+      end
+
+      def test_serializer_for_array_returns_appropriate_type
+        object = {}
+        def object.serializer_class; CustomSerializer; end
+
+        assert_equal CustomSerializer, Serializer.serializer_for(object)
+      end
+    end
+
     class ModelSerializationTest < Minitest::Test
       def test_array_serializer_serializes_models
         array = [Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),


### PR DESCRIPTION
.. by defining #serializer_class method in serialized object's class. Resolves #515.

This is a really small fix and has a test - so I don't see any reasons why it shouldn't be merged.