### PR TITLE
Fix explicit serializer for associations

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -176,7 +176,7 @@ module ActiveModel
 
     def serializer_from_options(options)
       opts = {}
-      serializer = options.fetch(:options, {}).fetch(:serializer, nil)
+      serializer = options.fetch(:association_options, {}).fetch(:serializer, nil)
       opts[:serializer] = serializer if serializer
       opts
     end

--- a/test/adapter/json_api/has_many_explicit_serializer_test.rb
+++ b/test/adapter/json_api/has_many_explicit_serializer_test.rb
@@ -34,8 +34,9 @@ module ActiveModel
           end
 
           def test_includes_linked_comments
-            assert_equal([{ id: '1', body: "ZOMG A COMMENT", links: { post: @post.id.to_s, author: nil }},
-                          { id: '2', body: "ZOMG ANOTHER COMMENT", links: { post: @post.id.to_s, author: nil }}],
+            # If CommentPreviewSerializer is applied correctly the body text will not be present in the output
+            assert_equal([{ id: '1', links: { post: @post.id.to_s}},
+                          { id: '2', links: { post: @post.id.to_s}}],
                          @adapter.serializable_hash[:linked][:comments])
           end
 


### PR DESCRIPTION
I needed to apply this patch in order to get the explicit association serializers feature to work as expected with the `has_many` association. Looked like a probable typo (the feature PR #696 renamed :options to :association_options, and forgot to update this one to match).

I've updated the `test_includes_linked_comments` test with the proper expected result (the old test was not invoking the explicit `has_many` association serializer functionality at all).