### PR TITLE
Add contributing readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Issue Labeling
+
+AMS uses [StandardIssueLabels](https://github.com/wagenet/StandardIssueLabels) for Github Issues.
+
+## Contributing
+
+1. Fork it ( https://github.com/rails-api/active_model_serializers/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Issue Labeling
 
-AMS uses [StandardIssueLabels](https://github.com/wagenet/StandardIssueLabels) for Github Issues.
+AMS uses a subset of [StandardIssueLabels](https://github.com/wagenet/StandardIssueLabels) for Github Issues. You can [see our labels here](https://github.com/rails-api/active_model_serializers/labels).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -303,10 +303,6 @@ If you have a question, please [post to Stack Overflow](http://stackoverflow.com
 
 Thanks!
 
-## Contributing
+# Contributing
 
-1. Fork it ( https://github.com/rails-api/active_model_serializers/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+See [CONTRIBUTING.md](https://github.com/rails-api/active_model_serializers/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
This is the start of pulling out our Contributing section into a separate markdown file so we can clarify and improve process. The first step is linking to our new set of labels, using a large subset of [StandardIssueLabels](https://github.com/wagenet/StandardIssueLabels).