### PR TITLE
Cache serializers for class

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activemodel", ">= 4.0"
-  spec.add_dependency 'thread_safe','~> 0.3', '>= 0.3.4'
+
   spec.add_development_dependency "rails", ">= 4.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activemodel", ">= 4.0"
-
+  spec.add_dependency 'thread_safe','~> 0.3', '>= 0.3.4'
   spec.add_development_dependency "rails", ">= 4.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -199,11 +199,11 @@ module ActiveModel
       opts
     end
 
-    private
-
     def self.serializers_cache
-      @serializers_cache ||= Threadsafe::Cache.new
+      @serializers_cache ||= ThreadSafe::Cache.new
     end
+
+    private
 
     def self.get_serializer_for(klass)
       serializers_cache.fetch_or_store(klass) do

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -1,3 +1,5 @@
+require 'thread_safe'
+
 module ActiveModel
   class Serializer
     extend ActiveSupport::Autoload

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -201,14 +201,20 @@ module ActiveModel
 
     private
 
-    def self.get_serializer_for(klass)
-      serializer_class_name = "#{klass.name}Serializer"
-      serializer_class = serializer_class_name.safe_constantize
+    def self.serializers_cache
+      @serializers_cache ||= Threadsafe::Cache.new
+    end
 
-      if serializer_class
-        serializer_class
-      elsif klass.superclass
-        get_serializer_for(klass.superclass)
+    def self.get_serializer_for(klass)
+      serializers_cache.fetch_or_store(klass) do
+        serializer_class_name = "#{klass.name}Serializer"
+        serializer_class = serializer_class_name.safe_constantize
+
+        if serializer_class
+          serializer_class
+        elsif klass.superclass
+          get_serializer_for(klass.superclass)
+        end
       end
     end
 

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -9,6 +9,9 @@ begin
 
   ActiveSupport.on_load(:action_controller) do
     include ::ActionController::Serialization
+    ActionDispatch::Reloader.to_prepare do
+      ActiveModel::Serializer.serializers_cache.clear
+    end
   end
 rescue LoadError
   # rails not installed, continuing


### PR DESCRIPTION
Currently, each time a model is serializer is tries to look up the Serializer class using `safe_constantize`. This can be slow when serializing a large number of models.

This adds a cache to return the serializer class for each class, which reduced the amount of time looking up the serializer classes.