### PR TITLE
Makes passed in options accessible inside serializers

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -140,6 +140,7 @@ module ActiveModel
 
     def initialize(object, options = {})
       @object   = object
+      @options  = options
       @root     = options[:root] || (self.class._root ? self.class.root_name : false)
       @meta     = options[:meta]
       @meta_key = options[:meta_key]
@@ -200,6 +201,8 @@ module ActiveModel
     end
 
     private
+
+    attr_reader :options
 
     def self.get_serializer_for(klass)
       serializer_class_name = "#{klass.name}Serializer"

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -45,6 +45,10 @@ class ProfileSerializer < ActiveModel::Serializer
   attributes :name, :description
 
   urls :posts, :comments
+
+  def arguments_passed_in?
+    options[:my_options] == :accessible
+  end
 end
 
 class ProfilePreviewSerializer < ActiveModel::Serializer

--- a/test/serializers/options_test.rb
+++ b/test/serializers/options_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class OptionsTest < Minitest::Test
+      def setup
+        @profile = Profile.new(name: 'Name 1', description: 'Description 1')
+      end
+
+      def test_options_are_accessible
+        @profile_serializer = ProfileSerializer.new(@profile, my_options: :accessible)
+        assert @profile_serializer.arguments_passed_in?
+      end
+
+      def test_no_option_is_passed_in
+        @profile_serializer = ProfileSerializer.new(@profile)
+        refute @profile_serializer.arguments_passed_in?
+      end
+    end
+  end
+end


### PR DESCRIPTION
In some cases, we want to pass arguments from the controller and we want
to serializer a resource according to that. This allows serializers to
use the `options` method to retrieve whatever was passed in via
arguments.