### PR TITLE
Store options in array serializers

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -176,19 +176,20 @@ module ActiveModel
     end
 
     def each_association(&block)
-      self.class._associations.dup.each do |name, options|
+      self.class._associations.dup.each do |name, association_options|
         next unless object
 
         association = object.send(name)
         association_value = send(name)
-        serializer_class = ActiveModel::Serializer.serializer_for(association, options)
+        serializer_class = ActiveModel::Serializer.serializer_for(association, association_options)
+
         serializer = serializer_class.new(
           association_value,
-          serializer_from_options(options)
+          serializer_from_options(association_options).merge(options)
         ) if serializer_class
 
         if block_given?
-          block.call(name, serializer, options[:association_options])
+          block.call(name, serializer, association_options[:association_options])
         end
       end
     end

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -7,12 +7,14 @@ module ActiveModel
       attr_reader :meta, :meta_key
 
       def initialize(objects, options = {})
+        options.merge!(root: nil)
+
         @objects = objects.map do |object|
           serializer_class = options.fetch(
             :serializer,
             ActiveModel::Serializer.serializer_for(object)
           )
-          serializer_class.new(object)
+          serializer_class.new(object, options)
         end
         @meta     = options[:meta]
         @meta_key = options[:meta_key]

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -6,7 +6,7 @@ module ActiveModel
       def setup
         @comment = Comment.new
         @post = Post.new
-        @serializer = ArraySerializer.new([@comment, @post])
+        @serializer = ArraySerializer.new([@comment, @post], {some: :options})
       end
 
       def test_respond_to_each
@@ -21,6 +21,8 @@ module ActiveModel
 
         assert_kind_of PostSerializer, serializers.last
         assert_kind_of Post, serializers.last.object
+
+        assert_equal serializers.last.custom_options[:some], :options
       end
     end
   end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -78,6 +78,10 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   def blog
     Blog.new(id: 999, name: "Custom blog")
   end
+
+  def custom_options
+    options
+  end
 end
 
 SpammyPostSerializer = Class.new(ActiveModel::Serializer) do

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -99,6 +99,10 @@ CommentSerializer = Class.new(ActiveModel::Serializer) do
 
   belongs_to :post
   belongs_to :author
+
+  def custom_options
+    options
+  end
 end
 
 AuthorSerializer = Class.new(ActiveModel::Serializer) do

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -37,7 +37,7 @@ module ActiveModel
         @post.author = @author
         @author.posts = [@post]
 
-        @post_serializer = PostSerializer.new(@post)
+        @post_serializer = PostSerializer.new(@post, {custom_options: true})
         @author_serializer = AuthorSerializer.new(@author)
         @comment_serializer = CommentSerializer.new(@comment)
       end
@@ -61,6 +61,14 @@ module ActiveModel
             assert_kind_of(ActiveModel::Serializer.config.array_serializer, serializer)
           else
             flunk "Unknown association: #{name}"
+          end
+        end
+      end
+
+      def test_serializer_options_are_passed_into_associations_serializers
+        @post_serializer.each_association do |name, association|
+          if name == :comments
+            assert association.first.custom_options[:custom_options]
           end
         end
       end


### PR DESCRIPTION
1. In my previous PR, I forgot to cover `ArraySerializer`. This fixes it.

2. Options need to be passed down into the associations as well. Eg. in a PostsController you want to pass in some arguments that will make comments be presented in a different way. This accomplishes that. https://github.com/rails-api/active_model_serializers/pull/837/files#diff-a97213928a042d41b4d8d56281b7049eR68 is an example of how it'd work.