### PR TITLE
Add url option to assocation for jsonapi

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -42,7 +42,7 @@ module ActionController
 
           @_serializer_opts[:scope] ||= serialization_scope
           @_serializer_opts[:scope_name] = _serialization_scope
-
+          @_adapter_opts[:url_helper] = self
           # omg hax
           object = serializer.new(resource, @_serializer_opts)
           adapter = ActiveModel::Serializer::Adapter.create(object, @_adapter_opts)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -6,7 +6,7 @@ module ActiveModel
           super
           serializer.root = true
           @hash = {}
-          @url_helper = options.delete(:url_helper)
+          @url_helper = options[:url_helper]
           @top = @options.fetch(:top) { @hash }
 
           if fields = options.delete(:fields)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -6,6 +6,7 @@ module ActiveModel
           super
           serializer.root = true
           @hash = {}
+          @url_helper = options.delete(:url_helper)
           @top = @options.fetch(:top) { @hash }
 
           if fields = options.delete(:fields)
@@ -138,21 +139,27 @@ module ActiveModel
           end
         end
 
+        attr_reader :url_helper
+
         def add_resource_links(attrs, serializer, options = {})
           options[:add_linked] = options.fetch(:add_linked, true)
 
           serializer.each_association do |name, association, opts|
             attrs[:links] ||= {}
 
-            if association.respond_to?(:each)
-              add_links(attrs, name, association)
+            if opts[:url]
+              attrs[:links][name] = url_helper.url_for([serializer.object, name])
             else
-              add_link(attrs, name, association)
-            end
+              if association.respond_to?(:each)
+                add_links(attrs, name, association)
+              else
+                add_link(attrs, name, association)
+              end
 
-            if @options[:embed] != :ids && options[:add_linked]
-              Array(association).each do |association|
-                add_linked(name, association)
+              if @options[:embed] != :ids && options[:add_linked]
+                Array(association).each do |association|
+                  add_linked(name, association)
+                end
               end
             end
           end

--- a/test/adapter/json_api/has_many_url_test.rb
+++ b/test/adapter/json_api/has_many_url_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module ActionController
+  module Serialization
+    class JsonApiHasManyUrlTest < ActionController::TestCase
+      class MyController < ActionController::Base
+
+        def render_resource_with_url_association
+          @tag = Tag.new(id: 1)
+          @tag.posts = []
+          render json: @tag, adapter: :json_api
+        end
+      end
+
+      tests MyController
+
+      def test_render_resource_with_url_association
+        get :render_resource_with_url_association
+        response = JSON.parse(@response.body)
+        assert response.key? 'tags'
+        assert response['tags'].key? 'links'
+        assert response['tags']['links'].key? 'posts'
+        assert_equal 'http://test.host/tags/1/posts', response['tags']['links']['posts']
+      end
+    end
+  end
+end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,4 +1,5 @@
 class Model
+  extend ActiveModel::Naming
   def initialize(hash={})
     @attributes = hash
   end
@@ -24,7 +25,7 @@ class Model
   end
 
   def to_param
-    id
+    id.to_s
   end
 
   def method_missing(meth, *args)
@@ -63,6 +64,8 @@ Author = Class.new(Model)
 Bio = Class.new(Model)
 Blog = Class.new(Model)
 Role = Class.new(Model)
+Tag = Class.new(Model)
+
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
 
@@ -165,6 +168,10 @@ PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
 
   has_many :comments, serializer: CommentPreviewSerializer
   belongs_to :author, serializer: AuthorPreviewSerializer
+end
+
+TagSerializer = Class.new(ActiveModel::Serializer) do
+  has_many :posts, url: true
 end
 
 Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ require 'fixtures/poro'
 module TestHelper
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
+    get 'tags/:tag_id/posts', to: 'application#index', as: 'tag_posts'
     get ':controller(/:action(/:id))'
     get ':controller(/:action)'
   end


### PR DESCRIPTION
This adds the url option to associations to tell the jsonapi adapter to use a url instead of a link object. 

The adapter assumes that the correct url can be generated using `named_routes`.

In order to generate the urls, the adapter is given the controller instance to use to generate the urls. Let me know if I should be exposing url generation abilities is some other way.

Fixes #834 