### PR TITLE
Fix issue with embedding multiple associations under the same root key

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -204,7 +204,9 @@ end
           association_serializer = build_serializer(association)
           # we must do this always because even if the current association is not
           # embeded in root, it might have its own associations that are embeded in root
-          hash.merge!(association_serializer.embedded_in_root_associations) {|key, oldval, newval| [newval, oldval].flatten }
+          hash.merge!(association_serializer.embedded_in_root_associations) do |key, oldval, newval|
+            oldval.merge(newval) { |_, oldval, newval| [oldval, newval].flatten.uniq }
+          end
 
           if association.embed_in_root?
             if association.embed_in_root_key?

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -74,6 +74,10 @@ class ARSectionSerializer < ActiveModel::Serializer
   attributes 'name'
 end
 
+class AREmbeddedSerializer < ActiveModel::Serializer
+  has_many :ar_tags, :ar_comments
+end
+
 ARPost.create(title: 'New post',
               body:  'A body!!!',
               ar_section: ARSection.create(name: 'ruby')).tap do |post|


### PR DESCRIPTION
When trying to embed multiple associations under the same root key AMS will crash trying to call `has_key?` on `Array`, because current merge conflict resolving strategy will return an `Array` instead of `Hash`.

Unfortunately can not use `deep_merge` here, because of rails 3.x and it's old `deep_merge` implementation (doesn't accept block).

A test reproducing the issue is included.

I'm also successfully using this solution on a project that relies heavily on JSON API and is properly covered with tests.