### PR TITLE
Remove the mailing list from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ to use it. `8` was the version that was on RubyGems, so if you were using that,
 that's probably what you want.
 
 `0.10.x` will be based on the `0.8.0` code, but with a more flexible
-architecture. We'd love your help.
-
-For more, please see [the rails-api-core mailing list](https://groups.google.com/d/msg/rails-api-core/8zu1xjIOTAM/siZ0HySKgaAJ).
+architecture. We'd love your help. [Learn how you can help here.](https://github.com/rails-api/active_model_serializers/blob/master/CONTRIBUTING.md)
 
 Thanks!
 


### PR DESCRIPTION
We discussed this previously, but I think it's time for the mailing list to be removed from the README. Every day more discussion, issues, and pull requests happen here then ever before. The mailing list is not representative of this activity and only dilutes the purpose of the blossoming community we're finding here.

A related note: I think we should actively encourage folks to ask questions on StackOverflow with the AMS tag, and put some documentation in here about that. I can open a separate PR for this later, but it would require more than a few of us to actively monitor SO and help where we can. If we successfully do this, then I think we effectively cover all the use cases the mailing list originally may have had.