### PR TITLE
Use association value for determining serializer used

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -181,9 +181,9 @@ module ActiveModel
       self.class._associations.dup.each do |name, association_options|
         next unless object
 
-        association = object.send(name)
         association_value = send(name)
-        serializer_class = ActiveModel::Serializer.serializer_for(association, association_options)
+
+        serializer_class = ActiveModel::Serializer.serializer_for(association_value, association_options)
 
         serializer = serializer_class.new(
           association_value,

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -159,7 +159,10 @@ module ActionController
               id: 1,
               body: 'ZOMG A COMMENT' }
           ],
-          blog: nil,
+          blog: {
+            id: 999,
+            name: 'Custom blog'
+          },
           author: {
             id: 1,
             name: 'Joao Moura.'
@@ -190,7 +193,10 @@ module ActionController
               id: 1,
               body: 'ZOMG A COMMENT' }
           ],
-          blog: nil,
+          blog: {
+            id: 999,
+            name: 'Custom blog'
+          },
           author: {
             id: 1,
             name: 'Joao Moura.'

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -32,7 +32,7 @@ module ActiveModel
             serializer = PostSerializer.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
-            assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], blog: nil, author: nil}, adapter.serializable_hash)
+            assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], blog: {id: 999, name: "Custom blog"}, author: nil}, adapter.serializable_hash)
           end
         end
       end

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -45,7 +45,10 @@ module ActiveModel
                 id: 1,
                 name: "Steve K."
               },
-              blog: nil
+              blog: {
+                id: 999,
+                name: "Custom blog"
+              }
             }]
             assert_equal expected, @adapter.serializable_hash
           end

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -67,7 +67,7 @@ module ActiveModel
             serializer = PostSerializer.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
 
-            assert_equal({comments: [], blog: nil, author: nil}, adapter.serializable_hash[:posts][:links])
+            assert_equal({comments: [], blog: "999", author: nil}, adapter.serializable_hash[:posts][:links])
           end
 
           def test_include_type_for_association_when_different_than_name
@@ -116,7 +116,7 @@ module ActiveModel
                 id: "43",
                 links: {
                   comments: [],
-                  blog: nil,
+                  blog: "999",
                   author: nil
                 }
               }]

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -27,7 +27,7 @@ module ActiveModel
           def test_include_multiple_posts
             assert_equal([
                            { title: "Hello!!", body: "Hello, world!!", id: "1", links: { comments: [], blog: "999", author: "1" } },
-                           { title: "New Post", body: "Body", id: "2", links: { comments: [], blog: nil, author: "1" } }
+                           { title: "New Post", body: "Body", id: "2", links: { comments: [], blog: "999", author: "1" } }
                          ], @adapter.serializable_hash[:posts])
           end
 
@@ -35,7 +35,7 @@ module ActiveModel
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, fields: ['title'])
             assert_equal([
               { title: "Hello!!", links: { comments: [], blog: "999", author: "1" } },
-              { title: "New Post", links: { comments: [], blog: nil, author: "1" } }
+              { title: "New Post", links: { comments: [], blog: "999", author: "1" } }
             ], @adapter.serializable_hash[:posts])
           end
 

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -170,7 +170,7 @@ module ActiveModel
                   body: "Body",
                   links: {
                     comments: [],
-                    blog: nil,
+                    blog: "999",
                     author: "1"
                   }
                 }


### PR DESCRIPTION
Ensures overridden association value works when orignal association does not return a result.