### PR TITLE
`:serializer` option now can take a symbol as a method to call.

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -48,7 +48,13 @@ module ActiveModel
 
         def target_serializer
           serializer = option(:serializer)
-          serializer.is_a?(String) ? serializer.constantize : serializer
+          if serializer.is_a?(String)
+            serializer.constantize
+          elsif serializer.is_a?(Symbol)
+            source_serializer.send(serializer)
+          else
+            serializer
+          end
         end
 
         def source_serializer

--- a/test/association_test.rb
+++ b/test/association_test.rb
@@ -589,4 +589,30 @@ class AssociationTest < ActiveModel::TestCase
       assert_equal({}, @root_hash)
     end
   end
+
+  class SymbolSerializerOption < AssociationTest
+    class SymbolSerializer < ActiveModel::Serializer
+      attributes :id
+    end
+
+    def test_specifying_serializer_class_as_a_symbol
+      @post_serializer_class.class_eval do
+        has_many :comments, :embed => :objects
+
+        def conditional_searializer
+          AssociationTest::SymbolSerializerOption::SymbolSerializer
+        end
+      end
+
+      include_bare! :comments, :serializer => :conditional_searializer
+
+      assert_equal({
+        :comments => [
+          { :id => 1 }
+        ]
+      }, @hash)
+
+      assert_equal({}, @root_hash)
+    end
+  end
 end


### PR DESCRIPTION
Fix suggestion for #825

This is handy for specifying a custom serializer class based on
conditionals.