### PR TITLE
Fix the failing `test_render_json_with_callback`

### DIFF
--- a/test/serialization_test.rb
+++ b/test/serialization_test.rb
@@ -242,7 +242,7 @@ class RenderJsonTest < ActionController::TestCase
 
   def test_render_json_with_callback
     get :render_json_hello_world_with_callback
-    assert_equal 'alert({"hello":"world"})', @response.body
+    assert_equal '/**/alert({"hello":"world"})', @response.body
     # For JSONP, Rails 3 uses application/json, but Rails 4 uses text/javascript
     assert_match %r(application/json|text/javascript), @response.content_type.to_s
   end


### PR DESCRIPTION
Since Rails 4.0.10, a JS comment is prepended to JSONP callbacks, to address CVE-2014-4671.
Introduced in Rails at https://github.com/rails/rails/pull/16109
The build is still :red_circle: for `0-8-stable` due to other errors (I'm taking a look)