### PR TITLE
Fixed a bug that appears when a nil association is included

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -53,10 +53,11 @@ module ActiveModel
         end
 
         def add_included(resource_name, serializers, parent = nil)
-          serializers = Array(serializers) unless serializers.respond_to?(:each)
-
+          unless serializers.respond_to?(:each)
+            return unless serializers.object
+            serializers = Array(serializers)
+          end
           resource_path = [parent, resource_name].compact.join('.')
-
           if include_assoc?(resource_path)
             @hash[:included] ||= []
 

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -6,6 +6,7 @@ module ActiveModel
       class JsonApi
         class LinkedTest < Minitest::Test
           def setup
+            ActionController::Base.cache_store.clear
             @author1 = Author.new(id: 1, name: 'Steve K.')
             @author2 = Author.new(id: 2, name: 'Tenderlove')
             @bio1 = Bio.new(id: 1, content: 'AMS Contributor')
@@ -224,6 +225,29 @@ module ActiveModel
             ]
 
             assert_equal expected, adapter.serializable_hash[:included]
+          end
+
+          def test_nil_link_with_specified_serializer
+            @first_post.author = nil
+            serializer = PostPreviewSerializer.new(@first_post)
+            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(
+              serializer,
+              include: ['author']
+            )
+
+            expected = {
+              data: {
+                id: "10",
+                title: "Hello!!",
+                body: "Hello, world!!",
+                type: "posts",
+                links: {
+                  comments: { linkage: [ { type: "comments", id: '1' }, { type: "comments", id: '2' } ] },
+                  author: { linkage: nil }
+                }
+              }
+            }
+            assert_equal expected, adapter.serializable_hash
           end
         end
       end


### PR DESCRIPTION
Take a serializer that has an association with a serializer specified for this association, e.g.:

    PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
      attributes :title, :body, :id
      belongs_to :author, serializer: AuthorPreviewSerializer
    end

When serialized with JsonApi adapter, if this association is included and the value associated is `nil` then `included` would look like this: `"included":[{"id":"", type:"nil_classes"}]`.

I changed the behaviour so that it only non nil values are added to `included`. 