### PR TITLE
AMS Benchmark tests #832

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,15 @@ install:
   - bundle install --retry=3
 
 env:
-  - "RAILS_VERSION=4.0"
-  - "RAILS_VERSION=4.1"
-  - "RAILS_VERSION=4.2"
-  - "RAILS_VERSION=master"
+  global:
+    - JRUBY_OPTS=-Xcext.enabled=true
+  matrix:
+    - "RAILS_VERSION=4.0"
+    - "RAILS_VERSION=4.1"
+    - "RAILS_VERSION=4.2"
+    - "RAILS_VERSION=master"
 
 matrix:
-  include:
-    - rvm: jruby-19mode
-      gemfile: gemfiles/Gemfile.rails-3.2.x
-      env: "JRUBY_OPTS=-Xcext.enabled=true"
   allow_failures:
     - rvm: ruby-head
     - env: "RAILS_VERSION=master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ env:
   - "RAILS_VERSION=master"
 
 matrix:
+  include:
+    - rvm: jruby-19mode
+      gemfile: gemfiles/Gemfile.rails-3.2.x
+      env: "JRUBY_OPTS=-Xcext.enabled=true"
   allow_failures:
     - rvm: ruby-head
     - env: "RAILS_VERSION=master"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in active_model_serializers.gemspec
 gemspec
 
-gem "minitest"
+gem 'minitest'
+gem 'rugged'
 
 version = ENV["RAILS_VERSION"] || "4.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'minitest'
-gem 'rugged'
+gem 'git'
 
 version = ENV["RAILS_VERSION"] || "4.2"
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
-require "bundler/gem_tasks"
-
+require 'bundler/gem_tasks'
+require 'rugged'
+require 'benchmark'
 require 'rake/testtask'
+
+task :default => :test
 
 Rake::TestTask.new do |t|
   t.libs << "test"
@@ -9,4 +12,35 @@ Rake::TestTask.new do |t|
   t.verbose = true
 end
 
-task :default => :test
+Rake::TestTask.new :benchmark_tests do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/**/*_benchmark.rb']
+  t.ruby_opts = ['-r./test/test_helper.rb']
+  t.verbose = true
+end
+
+task :benchmark do
+  @repo = Rugged::Repository.new('.')
+  ref   = @repo.head
+
+  actual_branch = ref.name
+
+  set_commit('master')
+  old_bench = Benchmark.realtime { Rake::Task['benchmark_tests'].execute }
+
+  set_commit(actual_branch)
+  new_bench = Benchmark.realtime { Rake::Task['benchmark_tests'].execute }
+
+  puts 'Results ============================'
+  puts "------------------------------------~> (Branch) MASTER"
+  puts old_bench
+  puts "------------------------------------"
+
+  puts "------------------------------------~> (Actual Branch) #{actual_branch}"
+  puts new_bench
+  puts "------------------------------------"
+end
+
+def set_commit(ref)
+  @repo.checkout ref
+end

--- a/test/benchmark/serialization_benchmark.rb
+++ b/test/benchmark/serialization_benchmark.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+module ActionController
+  module Serialization
+    class SerializerTest < ActionController::TestCase
+      class PostController < ActionController::Base
+
+        def render_with_cache_enable
+          comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
+          author  = Author.new(id: 1, name: 'Joao Moura.')
+          post    = Post.new({ id: 1, title: 'New Post', blog:nil, body: 'Body', comments: [comment], author: author })
+
+          render json: post
+        end
+      end
+
+      tests PostController
+
+      def test_render_with_cache_enable
+        ActionController::Base.cache_store.clear
+        get :render_with_cache_enable
+
+        expected = {
+          id: 1,
+          title: 'New Post',
+          body: 'Body',
+          comments: [
+            {
+              id: 1,
+              body: 'ZOMG A COMMENT' }
+          ],
+          blog: {
+            id: 999,
+            name: 'Custom blog'
+          },
+          author: {
+            id: 1,
+            name: 'Joao Moura.'
+          }
+        }
+
+        assert_equal 'application/json', @response.content_type
+        assert_equal expected.to_json, @response.body
+
+        get :render_with_cache_enable
+        assert_equal expected.to_json, @response.body
+      end
+    end
+  end
+end

--- a/test/serializers/generators_test.rb
+++ b/test/serializers/generators_test.rb
@@ -1,10 +1,3 @@
-class Foo < Rails::Application
-  if Rails.version.to_s.start_with? '4'
-    config.eager_load = false
-    config.secret_key_base = 'abc123'
-  end
-end
-
 Rails.application.load_generators
 
 require 'generators/serializer/serializer_generator'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,8 @@ class Foo < Rails::Application
     config.action_controller.perform_caching = true
     config.active_support.test_order         = :random
     ActionController::Base.cache_store       = :memory_store
+    config.eager_load = false
+    config.secret_key_base = 'abc123'
   end
 end
 


### PR DESCRIPTION
Adding a benchmak test structure to help contributors to keep track
of how their PR will impact overall performance.

It enables developers to create test inside of tests/benchmark.

This implementation adds a rake task: ```rake benchmark``` that checkout
one commit before, run the test of  tests/benchmark, then mover back to
the last commit and run it again. By comparing the benchmark results between
both commits the contributor will notice if and how much  his contribution
will impact overall performance.