### PR TITLE
Added serializer namespacing option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
   * updates JSON API support to RC3 [@mateomurphy]
   * adds fragment cache support [@joaomdmoura]
   * adds cache support to attributes and associations [@joaomdmoura]
+  * adds a `:namespace` option to association and array serializer [@groyoh]

--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ The `has_many`, `has_one`, and `belongs_to` declarations describe relationships 
 resources. By default, when you serialize a `Post`, you will get its `Comment`s
 as well.
 
+You may use the `:namespace` options to specify the `module` where the serializer(s) of an
+association may be found, for example:
+
+```ruby
+  has_many :comments, namespace: Blogging::Serializers
+```
+The serializer used then depends on the class of the object to be serialized e.g. if a
+comment is an instance of class `AdminComment`, the serializer would use
+`Blogging::Serializers::AdminComment` to serializer this comment.
+
 You may also use the `:serializer` option to specify a custom serializer class, for example:
 
 ```ruby
@@ -257,6 +267,20 @@ You may also use the `:serializer` option to specify a custom serializer class, 
 
 The `url` declaration describes which named routes to use while generating URLs
 for your JSON. Not every adapter will require URLs.
+
+## Array serializer
+When calling the `ActiveModel::Serializer::ArraySerializer#new`, you may pass the `:namespace`
+to specify the module in which the objects serializers may be found. The serializers used then
+depend on the objects class.
+
+Take the example below:
+
+```ruby
+a = [Post.new,AdminComment.new]
+ActiveRecord::Serializer.ArraySerializer.new(a, namespace: Blogging::Serializers)
+```
+Here the objects of `a` would respectively be serialized using `Blogging::Serializers::Post`
+and `Blogging::Serializers::AdminComment.`
 
 ## Caching
 

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -8,11 +8,10 @@ module ActiveModel
 
       def initialize(objects, options = {})
         options.merge!(root: nil)
-
         @objects = objects.map do |object|
           serializer_class = options.fetch(
             :serializer,
-            ActiveModel::Serializer.serializer_for(object)
+            ActiveModel::Serializer.serializer_for(object, options)
           )
           serializer_class.new(object, options)
         end

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -24,6 +24,18 @@ module ActiveModel
 
         assert_equal serializers.last.custom_options[:some], :options
       end
+
+      def test_each_object_should_be_serialized_with_appropriate_serializer
+        @comment = BasicComment.new
+        @serializer = ArraySerializer.new([@comment, @post], {namespace: Test::Serializer})
+        serializers =  @serializer.to_a
+
+        assert_kind_of Test::Serializer::BasicComment, serializers.first
+        assert_kind_of Comment, serializers.first.object
+
+        assert_kind_of Test::Serializer::Post, serializers.last
+        assert_kind_of Post, serializers.last.object
+      end
     end
   end
 end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -57,16 +57,18 @@ class ProfilePreviewSerializer < ActiveModel::Serializer
   urls :posts, :comments
 end
 
-Post     = Class.new(Model)
-Like     = Class.new(Model)
-Comment  = Class.new(Model)
-Author   = Class.new(Model)
-Bio      = Class.new(Model)
-Blog     = Class.new(Model)
-Role     = Class.new(Model)
-User = Class.new(Model)
-Location = Class.new(Model)
-Place    = Class.new(Model)
+Post           = Class.new(Model)
+Like           = Class.new(Model)
+Comment        = Class.new(Model)
+BasicComment   = Class.new(Comment)
+SpecialComment = Class.new(Comment)
+Author         = Class.new(Model)
+Bio            = Class.new(Model)
+Blog           = Class.new(Model)
+Role           = Class.new(Model)
+User           = Class.new(Model)
+Location       = Class.new(Model)
+Place          = Class.new(Model)
 
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
@@ -203,4 +205,30 @@ end
 
 Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
+end
+
+module Test
+  module Serializer
+    Post = Class.new(ActiveModel::Serializer) do
+      attributes :id, :title
+
+      has_many :comments, namespace: Test::Serializer
+    end
+
+    BasicComment = Class.new(ActiveModel::Serializer) do
+      attribute :id
+
+      belongs_to :post, namespace: Test::Serializer
+    end
+
+    SpecialComment = Class.new(ActiveModel::Serializer) do
+      attributes :id, :special
+
+      belongs_to :post, namespace: Test::Serializer
+
+      def special
+        "I'm so special!"
+      end
+    end
+  end
 end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -73,6 +73,15 @@ module ActiveModel
         end
       end
 
+      def test_association_with_namespace_options_uses_namespace_serializer
+        @post.comments = [BasicComment.new, SpecialComment.new]
+        @post_serializer = Test::Serializer::Post.new(@post)
+        @post_serializer.each_association do |name, serializer, options|
+          assert_kind_of Test::Serializer::BasicComment, serializer.to_a.first
+          assert_kind_of Test::Serializer::SpecialComment, serializer.to_a.last
+        end
+      end
+
       def test_belongs_to
         assert_equal(
           { post: { type: :belongs_to, association_options: {} },

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -30,6 +30,9 @@ module ActiveModel
         class MyProfile < Profile
         end
 
+        class TopComment < BasicComment
+        end
+
         def setup
           @profile = Profile.new
           @my_profile = MyProfile.new
@@ -49,6 +52,18 @@ module ActiveModel
         def test_serializer_inherited_serializer
           serializer = ActiveModel::Serializer.serializer_for(@my_profile)
           assert_equal ProfileSerializer, serializer
+        end
+
+        def test_serializer_in_module
+          post = Post.new
+          serializer = ActiveModel::Serializer.serializer_for(post, { namespace: Test::Serializer })
+          assert_equal Test::Serializer::Post, serializer
+        end
+
+        def test_serializer_inherited_serializer_in_module
+          comment = TopComment.new
+          serializer = ActiveModel::Serializer.serializer_for(comment, { namespace: Test::Serializer })
+          assert_equal Test::Serializer::BasicComment, serializer
         end
       end
     end


### PR DESCRIPTION
I added an `namespace` option to the serializer associations and array serializer. This option can be used to define in which `module` the correct serializer may be found.  This option is pretty useful when dealing with versionized serializer and polymorphic associations. I added some information on how to use it in the README, e.g. :

> You may use the `:namespace` options to specify the `module` where the serializer(s) of an
association may be found, for example:
```ruby
has_many :comments, namespace: Blogging::Serializers
```
The serializer used then depends on the class of the object to be serialized e.g. if a
comment is an instance of class `AdminComment`, the serializer would use
`Blogging::Serializers::AdminComment` to serializer this comment.

To make it clear, I do not use rails so I don't know if this would fit well with rails. I'm opened to any kind of discussions and changes. And of course, serializers here are used without `Serializer` suffix because that's the way we use it in our team but this behavior may as well be changed (adding a `suffix` option for example). 