### PR TITLE
Updates rails versions for test and dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,12 @@ install:
   - bundle install --retry=3
 
 env:
-  - "RAILS_VERSION=3.2"
   - "RAILS_VERSION=4.0"
   - "RAILS_VERSION=4.1"
+  - "RAILS_VERSION=4.2"
   - "RAILS_VERSION=master"
 
 matrix:
   allow_failures:
     - rvm: ruby-head
     - env: "RAILS_VERSION=master"
-    - env: "RAILS_VERSION=3.2"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem "minitest"
 
-version = ENV["RAILS_VERSION"] || "4.1"
+version = ENV["RAILS_VERSION"] || "4.2"
 
 if version == "master"
   gem "rails", github: "rails/rails"


### PR DESCRIPTION
While looking to contribute, I saw that `.travis.yml` and `Gemfile` were outdated for **AMS** `v0.10.0rc`:

**Changes:**
- Removes test env using **Rails 3.2** (**AMS10** depends on `>=4.0`)
- Adds test env for **Rails 4.2** and sets it as default `RAILS_VERSION`
- Removes explicit requirement for **arel** `master` since `v6.0.0` was released

Hope this is helpful! :smile_cat: 