### PR TITLE
Fixing tests on JRuby

### DIFF
--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -319,13 +319,13 @@ module ActionController
         response = JSON.parse(@response.body)
 
         expected_return = {
+          "id"=>1,
+          "time"=>DateTime.now.to_s,
           "post" => {
             "id"=>1,
             "title"=>"New Post",
             "body"=>"Body"
-          },
-          "id"=>1,
-          "time"=>DateTime.now.to_s
+          }
         }
 
         assert_equal 'application/json', @response.content_type

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,8 @@ Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 class Foo < Rails::Application
   if Rails.version.to_s.start_with? '4'
     config.action_controller.perform_caching = true
-    ActionController::Base.cache_store = :memory_store
+    config.active_support.test_order         = :random
+    ActionController::Base.cache_store       = :memory_store
   end
 end
 


### PR DESCRIPTION
Adding ```test_order``` flag following Rails 5 conventions.
Fixing JRuby tests.