### PR TITLE
Changed duplicated test name in action controller test

### DIFF
--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -80,7 +80,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_array_using_explicit_serializer
+      def test_render_array_using_implicit_serializer
         get :render_array_using_implicit_serializer
         assert_equal 'application/json', @response.content_type
 


### PR DESCRIPTION
I fixed a test in `test/action_controller/explicit_serializer_test.rb` which had the same name of another test declared before. This basically prevented the first test to run.