### PR TITLE
Remove unused method `def_serializer`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,7 +36,3 @@ ActionController::TestCase.class_eval do
     @routes = TestHelper::Routes
   end
 end
-
-def def_serializer(&block)
-  Class.new(ActiveModel::Serializer, &block)
-end


### PR DESCRIPTION
While looking at the tests noticed that this wasn't used anymore.