### PR TITLE
Fixed a bug that appeared when json adapter serialize a nil association

### DIFF
--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -23,7 +23,7 @@ module ActiveModel
                   end
                 end
               else
-                if association
+                if association && association.object
                   @hash[name] = cache_check(association) do
                     association.attributes(options)
                   end

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -34,6 +34,13 @@ module ActiveModel
 
             assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], blog: {id: 999, name: "Custom blog"}, author: nil}, adapter.serializable_hash)
           end
+
+          def test_include_nil_author_with_specified_serializer
+            serializer = PostPreviewSerializer.new(@anonymous_post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], author: nil}, adapter.serializable_hash)
+          end
         end
       end
     end


### PR DESCRIPTION
Take the following serializers e.g.:

```ruby
AuthorPreviewSerializer = Class.new(ActiveModel::Serializer) do
  attributes :id, :name
end    
PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
  attribute :id
  # note that we specify a serializer for the association
  belongs_to :author, serializer: AuthorPreviewSerializer
end
```
If a post is serialized with Json adapter and its author is nil, then the post would be rendered as : 
```ruby
{ 
  id: 43, 
  author: { id: nil, name: nil }
}
```
instead of
```ruby
{ 
  id: 43, 
  author: nil
}
```

This happens only when the `serializer` option is set for the association.