### PR TITLE
JSON Adapter Refactoring

### DIFF
--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -40,7 +40,7 @@ module ActiveModel
 
       private
 
-     def cache_check(serializer)
+      def cache_check(serializer)
         @cached_serializer = serializer
         @klass             = @cached_serializer.class
         if is_cached?

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -32,7 +32,13 @@ module ActiveModel
             serializer = PostSerializer.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
-            assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], blog: {id: 999, name: "Custom blog"}, author: nil}, adapter.serializable_hash)
+            expected_hash = {title: "Hello!!",
+                             body: "Hello, world!!",
+                             id: 43,
+                             comments: [],
+                             blog: {id: 999, name: "Custom blog"},
+                             author: nil}
+            assert_equal(expected_hash, adapter.serializable_hash)
           end
         end
       end


### PR DESCRIPTION
I pulled the logic from the `serializable_hash` into private methods. This way it's a lot easier to understand what the code does. No logic has changed, I verified it with the passing unit tests.