### PR TITLE
Fragment cache fails for models inside a module

### DIFF
--- a/test/adapter/fragment_cache_test.rb
+++ b/test/adapter/fragment_cache_test.rb
@@ -20,6 +20,13 @@ module ActiveModel
           }
           assert_equal(@role_hash.fetch, expected_result)
         end
+
+        def test_this_works
+          role            = Test::NestedRole.new(name: 'Great Author', description:nil)
+          role_serializer = RoleSerializer.new(role)
+          role_hash       = FragmentCache.new(RoleSerializer.adapter.new(role_serializer), role_serializer, {}, nil).fetch
+          p role_hash
+        end
       end
     end
   end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -64,9 +64,13 @@ Author   = Class.new(Model)
 Bio      = Class.new(Model)
 Blog     = Class.new(Model)
 Role     = Class.new(Model)
-User = Class.new(Model)
+User     = Class.new(Model)
 Location = Class.new(Model)
 Place    = Class.new(Model)
+
+module Test
+  NestedRole     = Class.new(Model)
+end
 
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)


### PR DESCRIPTION
It will fail when trying to set constant because `Test::NestedRoleCachedSerializer` is not a correct constant name.
