### PR TITLE
Defining Json-API Adapter as Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ AMS does this through two components: **serializers** and **adapters**.
 Serializers describe _which_ attributes and relationships should be serialized.
 Adapters describe _how_ attributes and relationships should be serialized.
 
+By default AMS will use the JsonApi Adapter that follows RC3 of the format specified in [jsonapi.org/format](http://jsonapi.org/format).
+Check how to change the adapter in the sections bellow.
+
 # RELEASE CANDIDATE, PLEASE READ
 
 This is the master branch of AMS. It will become the `0.10.0` release when it's
@@ -47,17 +50,17 @@ end
 ```
 
 Generally speaking, you as a user of AMS will write (or generate) these
-serializer classes. If you want to use a different adapter, such as a JsonApi, you can
+serializer classes. If you want to use a different adapter, such as a normal Json adapter without the JsonApi conventions, you can
 change this in an initializer:
 
 ```ruby
-ActiveModel::Serializer.config.adapter = ActiveModel::Serializer::Adapter::JsonApi
+ActiveModel::Serializer.config.adapter = ActiveModel::Serializer::Adapter::Json
 ```
 
 or
 
 ```ruby
-ActiveModel::Serializer.config.adapter = :json_api
+ActiveModel::Serializer.config.adapter = :json
 ```
 
 You won't need to implement an adapter unless you wish to use a new format or

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -6,7 +6,7 @@ module ActiveModel
 
       included do |base|
         base.config.array_serializer = ActiveModel::Serializer::ArraySerializer
-        base.config.adapter = :json
+        base.config.adapter = :json_api
       end
     end
   end

--- a/test/action_controller/adapter_selector_test.rb
+++ b/test/action_controller/adapter_selector_test.rb
@@ -4,7 +4,7 @@ module ActionController
   module Serialization
     class AdapterSelectorTest < ActionController::TestCase
       class MyController < ActionController::Base
-        def render_using_default_adapter
+        def render_using_the_initializer_defined_adapter
           @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           render json: @profile
         end
@@ -23,7 +23,7 @@ module ActionController
       tests MyController
 
       def test_render_using_default_adapter
-        get :render_using_default_adapter
+        get :render_using_the_initializer_defined_adapter
         assert_equal '{"name":"Name 1","description":"Description 1"}', response.body
       end
 

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,3 +1,5 @@
+ActiveModel::Serializer.config.adapter = :json
+
 class Model
   def initialize(hash={})
     @attributes = hash
@@ -64,7 +66,7 @@ Author   = Class.new(Model)
 Bio      = Class.new(Model)
 Blog     = Class.new(Model)
 Role     = Class.new(Model)
-User = Class.new(Model)
+User     = Class.new(Model)
 Location = Class.new(Model)
 Place    = Class.new(Model)
 


### PR DESCRIPTION
As we decided, it's time to push JSON-API forward by making it the default adapter into AMS.
We really believe this is one of the greatest features into 0.10.x version, and that could help a lot of different projects from different technologies.
Despite of being a *small* change, we expect to see more people using it's conventions once we merge it.
@steveklabnik @guilleiguaran @kurko  