### PR TITLE
Prevent possible duplicated attributes in serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -31,6 +31,7 @@ module ActiveModel
     def self.attributes(*attrs)
       attrs = attrs.first if attrs.first.class == Array
       @_attributes.concat attrs
+      @_attributes.uniq!
 
       attrs.each do |attr|
         define_method attr do
@@ -42,7 +43,7 @@ module ActiveModel
     def self.attribute(attr, options = {})
       key = options.fetch(:key, attr)
       @_attributes_keys[attr] = {key: key} if key != attr
-      @_attributes.concat [key]
+      @_attributes << key unless @_attributes.include?(key)
       define_method key do
         object.read_attribute_for_serialization(attr)
       end unless method_defined?(key) || _fragmented.respond_to?(attr)

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -24,6 +24,15 @@ module ActiveModel
         adapter = ActiveModel::Serializer::Adapter::Json.new(blog_serializer)
         assert_equal({:id=>1, :title=>"AMS Hints"}, adapter.serializable_hash)
       end
+
+      def test_multiple_calls_with_the_same_attribute
+        serializer_class = Class.new(ActiveModel::Serializer) do
+          attribute :title
+          attribute :title
+        end
+
+        assert_equal([:title], serializer_class._attributes)
+      end
     end
   end
 end

--- a/test/serializers/attributes_test.rb
+++ b/test/serializers/attributes_test.rb
@@ -49,6 +49,15 @@ module ActiveModel
         assert_equal({id: 1, body: "ZOMG!!", date: "2015", likes: nil},
                      serializer.attributes)
       end
+
+      def test_multiple_calls_with_the_same_attribute
+        serializer_class = Class.new(ActiveModel::Serializer) do
+          attributes :id, :title
+          attributes :id, :title, :title, :body
+        end
+
+        assert_equal([:id, :title, :body], serializer_class._attributes)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is based on #904 . 

The issue was that calling `ActiveModel::Serializer.attributes` or `ActiveModel::Serializer.attribute` methods multiple times with the same attribute would add this attribute again and again to the `@_attributes` variable. As the `attribute` method is called by the `FragmentCache` multiple times, this might be a important issue.