### PR TITLE
Allow :key to be specified for attributes overridden in the serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -45,7 +45,11 @@ module ActiveModel
       @_attributes_keys[attr] = {key: key} if key != attr
       @_attributes << key unless @_attributes.include?(key)
       define_method key do
-        object.read_attribute_for_serialization(attr)
+        if attr != key && self.class.method_defined?(attr)
+          self.send(attr)
+        else
+          object.read_attribute_for_serialization(attr)
+        end
       end unless method_defined?(key) || _fragmented.respond_to?(attr)
     end
 

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -33,6 +33,19 @@ module ActiveModel
 
         assert_equal([:title], serializer_class._attributes)
       end
+
+      def test_serializer_attribute_definition_with_key
+        serializer_class = Class.new(ActiveModel::Serializer) do
+          attribute :posts_count, key: :numPosts
+
+          def posts_count
+            20
+          end
+        end
+
+        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer_class.new({}))
+        assert_equal({:numPosts => 20}, adapter.serializable_hash)
+      end
     end
   end
 end


### PR DESCRIPTION
This makes the following example code function as expected:

```ruby
class BlogSerializer < ActiveModel::Serializer
  attribute :num_article, key: :articlesCount

  def num_articles
    object.articles.count
  end
end
```

An alternative to the above is to specify the attribute and corresponding method as `articlesCount`, but this allows us to follow ruby code conventions while allowing us to customize the response as expected by the client.