### PR TITLE
Fixing issue where fragment cache calls underlying attribute methods multiple times even when cached

### DIFF
--- a/lib/active_model/serializer/adapter/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/fragment_cache.rb
@@ -35,8 +35,9 @@ module ActiveModel
         private
 
         def cached_attributes(klass, serializers)
-          cached_attributes     = (klass._cache_only) ? klass._cache_only : serializer.attributes.keys.delete_if {|attr| klass._cache_except.include?(attr) }
-          non_cached_attributes = serializer.attributes.keys.delete_if {|attr| cached_attributes.include?(attr) }
+          attributes            = serializer.class._attributes
+          cached_attributes     = (klass._cache_only) ? klass._cache_only : attributes.reject {|attr| klass._cache_except.include?(attr) }
+          non_cached_attributes = attributes - cached_attributes
 
           cached_attributes.each do |attribute|
             options = serializer.class._attributes_keys[attribute]


### PR DESCRIPTION
Fragment cache was calling `Serializer#attributes` method multiple times when trying to trying to resolve cached/non-cached attribute keys, which in turn was calling those respective methods in the underlying ActiveModel object, which results is more calls to the underlying object than if the object wasn't cached.

This has now been fixed by getting the fragment cache to use the `Serializer::_attributes` variable which can be used to resolve the cached/non-cached attribute keys.

I would have loved to add some tests into this but my Minitest - Fu is non-existent, and I spent way too much time already trying to figure out how to verify the call counts to specific methods, any help on this would be greatly appreciated.