### PR TITLE
Updates JSON API Adapter to generate RC4 schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AMS does this through two components: **serializers** and **adapters**.
 Serializers describe _which_ attributes and relationships should be serialized.
 Adapters describe _how_ attributes and relationships should be serialized.
 
-By default AMS will use the JsonApi Adapter that follows RC3 of the format specified in [jsonapi.org/format](http://jsonapi.org/format).
+By default AMS will use the JsonApi Adapter that follows RC4 of the format specified in [jsonapi.org/format](http://jsonapi.org/format).
 Check how to change the adapter in the sections bellow.
 
 # RELEASE CANDIDATE, PLEASE READ
@@ -178,7 +178,7 @@ end
 
 #### JSONAPI
 
-This adapter follows RC3 of the format specified in
+This adapter follows RC4 of the format specified in
 [jsonapi.org/format](http://jsonapi.org/format). It will include the associated
 resources in the `"included"` member when the resource names are included in the
 `include` option.

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -29,7 +29,7 @@ module ActiveModel
             end
           else
             @hash[:data] = attributes_for_serializer(serializer, @options)
-            add_resource_links(@hash[:data], serializer)
+            add_resource_relationships(@hash[:data], serializer)
           end
           @hash
         end
@@ -41,18 +41,18 @@ module ActiveModel
 
         private
 
-        def add_links(resource, name, serializers)
-          resource[:links] ||= {}
-          resource[:links][name] ||= { linkage: [] }
-          resource[:links][name][:linkage] += serializers.map { |serializer| { type: serializer.type, id: serializer.id.to_s } }
+        def add_relationships(resource, name, serializers)
+          resource[:relationships] ||= {}
+          resource[:relationships][name] ||= { data: [] }
+          resource[:relationships][name][:data] += serializers.map { |serializer| { type: serializer.type, id: serializer.id.to_s } }
         end
 
-        def add_link(resource, name, serializer, val=nil)
-          resource[:links] ||= {}
-          resource[:links][name] = { linkage: nil }
+        def add_relationship(resource, name, serializer, val=nil)
+          resource[:relationships] ||= {}
+          resource[:relationships][name] = { data: nil }
 
           if serializer && serializer.object
-            resource[:links][name][:linkage] = { type: serializer.type, id: serializer.id.to_s }
+            resource[:relationships][name][:data] = { type: serializer.type, id: serializer.id.to_s }
           end
         end
 
@@ -68,7 +68,7 @@ module ActiveModel
             serializers.each do |serializer|
               attrs = attributes_for_serializer(serializer, @options)
 
-              add_resource_links(attrs, serializer, add_included: false)
+              add_resource_relationships(attrs, serializer, add_included: false)
 
               @hash[:included].push(attrs) unless @hash[:included].include?(attrs)
             end
@@ -128,19 +128,19 @@ module ActiveModel
           end
         end
 
-        def add_resource_links(attrs, serializer, options = {})
+        def add_resource_relationships(attrs, serializer, options = {})
           options[:add_included] = options.fetch(:add_included, true)
 
           serializer.each_association do |name, association, opts|
-            attrs[:links] ||= {}
+            attrs[:relationships] ||= {}
 
             if association.respond_to?(:each)
-              add_links(attrs, name, association)
+              add_relationships(attrs, name, association)
             else
               if opts[:virtual_value]
-                add_link(attrs, name, nil, opts[:virtual_value])
+                add_relationship(attrs, name, nil, opts[:virtual_value])
               else
-                add_link(attrs, name, association)
+                add_relationship(attrs, name, association)
               end
             end
 

--- a/lib/active_model/serializer/adapter/json_api/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/json_api/fragment_cache.rb
@@ -10,9 +10,10 @@ module ActiveModel
             core_non_cached   = non_cached_hash.first
             no_root_cache     = cached_hash.delete_if {|key, value| key == core_cached[0] }
             no_root_non_cache = non_cached_hash.delete_if {|key, value| key == core_non_cached[0] }
-            cached_resource   = (core_cached[1]) ? core_cached[1].merge(core_non_cached[1]) : core_non_cached[1]
+            cached_resource   = (core_cached[1]) ? core_cached[1].deep_merge(core_non_cached[1]) : core_non_cached[1]
             hash = (root) ? { root => cached_resource } : cached_resource
-            hash.merge no_root_non_cache.merge no_root_cache
+
+            hash.deep_merge no_root_non_cache.deep_merge no_root_cache
           end
 
         end

--- a/test/action_controller/adapter_selector_test.rb
+++ b/test/action_controller/adapter_selector_test.rb
@@ -32,10 +32,12 @@ module ActionController
 
         expected = {
           data: {
-            name: "Name 1",
-            description: "Description 1",
             id: assigns(:profile).id.to_s,
-            type: "profiles"
+            type: "profiles",
+            attributes: {
+              name: "Name 1",
+              description: "Description 1",
+            }
           }
         }
 

--- a/test/action_controller/json_api_linked_test.rb
+++ b/test/action_controller/json_api_linked_test.rb
@@ -104,10 +104,10 @@ module ActionController
             "attributes" => {
               "name" => "Steve K."
             },
-            "links" => {
-              "posts" => { "linkage" => [] },
-              "roles" => { "linkage" => [{ "type" =>"roles", "id" => "1" }, { "type" =>"roles", "id" => "2" }] },
-              "bio" => { "linkage" => nil }
+            "relationships" => {
+              "posts" => { "data" => [] },
+              "roles" => { "data" => [{ "type" =>"roles", "id" => "1" }, { "type" =>"roles", "id" => "2" }] },
+              "bio" => { "data" => nil }
             }
           }, {
             "id" => "1",
@@ -117,8 +117,8 @@ module ActionController
               "description" => nil,
               "slug" => "admin-1"
             },
-            "links" => {
-              "author" => { "linkage" => { "type" =>"authors", "id" => "1" } }
+            "relationships" => {
+              "author" => { "data" => { "type" =>"authors", "id" => "1" } }
             }
           }, {
             "id" => "2",
@@ -128,8 +128,8 @@ module ActionController
               "description" => nil,
               "slug" => "colab-2"
             },
-            "links" => {
-              "author" => { "linkage" => { "type" =>"authors", "id" => "1" } }
+            "relationships" => {
+              "author" => { "data" => { "type" =>"authors", "id" => "1" } }
             }
           }
         ]

--- a/test/action_controller/json_api_linked_test.rb
+++ b/test/action_controller/json_api_linked_test.rb
@@ -91,7 +91,7 @@ module ActionController
         response = JSON.parse(@response.body)
         assert response.key? 'included'
         assert_equal 1, response['included'].size
-        assert_equal 'Steve K.', response['included'].first['name']
+        assert_equal 'Steve K.', response['included'].first['attributes']['name']
       end
 
       def test_render_resource_with_nested_has_many_include
@@ -101,7 +101,9 @@ module ActionController
           {
             "id" => "1",
             "type" => "authors",
-            "name" => "Steve K.",
+            "attributes" => {
+              "name" => "Steve K."
+            },
             "links" => {
               "posts" => { "linkage" => [] },
               "roles" => { "linkage" => [{ "type" =>"roles", "id" => "1" }, { "type" =>"roles", "id" => "2" }] },
@@ -110,18 +112,22 @@ module ActionController
           }, {
             "id" => "1",
             "type" => "roles",
-            "name" => "admin",
-            "description" => nil,
-            "slug" => "admin-1",
+            "attributes" => {
+              "name" => "admin",
+              "description" => nil,
+              "slug" => "admin-1"
+            },
             "links" => {
               "author" => { "linkage" => { "type" =>"authors", "id" => "1" } }
             }
           }, {
             "id" => "2",
             "type" => "roles",
-            "name" => "colab",
-            "description" => nil,
-            "slug" => "colab-2",
+            "attributes" => {
+              "name" => "colab",
+              "description" => nil,
+              "slug" => "colab-2"
+            },
             "links" => {
               "author" => { "linkage" => { "type" =>"authors", "id" => "1" } }
             }
@@ -135,7 +141,7 @@ module ActionController
         response = JSON.parse(@response.body)
         assert response.key? 'included'
         assert_equal 1, response['included'].size
-        assert_equal 'Anonymous', response['included'].first['name']
+        assert_equal 'Anonymous', response['included'].first['attributes']['name']
       end
 
       def test_render_collection_without_include

--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -27,7 +27,7 @@ class DefaultScopeNameTest < ActionController::TestCase
 
   def test_default_scope_name
     get :render_new_user
-    assert_equal '{"data":{"admin?":false,"id":"1","type":"users"}}', @response.body
+    assert_equal '{"data":{"id":"1","type":"users","attributes":{"admin?":false}}}', @response.body
   end
 end
 
@@ -58,6 +58,6 @@ class SerializationScopeNameTest < ActionController::TestCase
 
   def test_override_scope_name_with_controller
     get :render_new_user
-    assert_equal '{"data":{"admin?":true,"id":"1","type":"users"}}', @response.body
+    assert_equal '{"data":{"id":"1","type":"users","attributes":{"admin?":true}}}', @response.body
   end
 end

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -166,10 +166,12 @@ module ActionController
 
         expected = {
           data: {
-            name: "Name 1",
-            description: "Description 1",
             id: assigns(:profile).id.to_s,
-            type: "profiles"
+            type: "profiles",
+            attributes: {
+              name: "Name 1",
+              description: "Description 1"
+            }
           }
         }
 
@@ -182,10 +184,12 @@ module ActionController
 
         expected = {
           data: {
-            name: "Name 1",
-            description: "Description 1",
             id: assigns(:profile).id.to_s,
-            type: "profiles"
+            type: "profiles",
+            attributes: {
+              name: "Name 1",
+              description: "Description 1"
+            }
           }
         }
 
@@ -217,10 +221,12 @@ module ActionController
         expected = {
           data: [
             {
-              name: "Name 1",
-              description: "Description 1",
               id: assigns(:profiles).first.id.to_s,
-              type: "profiles"
+              type: "profiles",
+              attributes: {
+                name: "Name 1",
+                description: "Description 1"
+              }
             }
           ],
           meta: {

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -32,9 +32,9 @@ module ActiveModel
           end
 
           def test_includes_post_id
-            expected = { linkage: { type: "posts", id: "42" } }
+            expected = { data: { type: "posts", id: "42" } }
 
-            assert_equal(expected, @adapter.serializable_hash[:data][:links][:post])
+            assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:post])
           end
 
           def test_includes_linked_post
@@ -46,10 +46,10 @@ module ActiveModel
                 title: 'New Post',
                 body: 'Body',
               },
-              links: {
-                comments: { linkage: [ { type: "comments", id: "1" } ] },
-                blog: { linkage: { type: "blogs", id: "999" } },
-                author: { linkage: { type: "authors", id: "1" } }
+              relationships: {
+                comments: { data: [ { type: "comments", id: "1" } ] },
+                blog: { data: { type: "blogs", id: "999" } },
+                author: { data: { type: "authors", id: "1" } }
               }
             }]
             assert_equal expected, @adapter.serializable_hash[:included]
@@ -63,10 +63,10 @@ module ActiveModel
               attributes: {
                 title: 'New Post'
               },
-              links: {
-                comments: { linkage: [ { type: "comments", id: "1" } ] },
-                blog: { linkage: { type: "blogs", id: "999" } },
-                author: { linkage: { type: "authors", id: "1" } }
+              relationships: {
+                comments: { data: [ { type: "comments", id: "1" } ] },
+                blog: { data: { type: "blogs", id: "999" } },
+                author: { data: { type: "authors", id: "1" } }
               }
             }]
             assert_equal expected, @adapter.serializable_hash[:included]
@@ -76,22 +76,22 @@ module ActiveModel
             serializer = PostSerializer.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
 
-            assert_equal({comments: { linkage: [] }, blog: { linkage: { type: "blogs", id: "999" } }, author: { linkage: nil }}, adapter.serializable_hash[:data][:links])
+            assert_equal({comments: { data: [] }, blog: { data: { type: "blogs", id: "999" } }, author: { data: nil }}, adapter.serializable_hash[:data][:relationships])
           end
 
           def test_include_type_for_association_when_different_than_name
             serializer = BlogSerializer.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
-            links = adapter.serializable_hash[:data][:links]
+            relationships = adapter.serializable_hash[:data][:relationships]
             expected = {
               writer: {
-                linkage: {
+                data: {
                   type: "authors",
                   id: "1"
                 }
               },
               articles: {
-                linkage: [
+                data: [
                   {
                     type: "posts",
                     id: "42"
@@ -103,7 +103,7 @@ module ActiveModel
                 ]
               }
             }
-            assert_equal expected, links
+            assert_equal expected, relationships
           end
 
           def test_include_linked_resources_with_type_name
@@ -117,10 +117,10 @@ module ActiveModel
                 attributes: {
                   name: "Steve K."
                 },
-                links: {
-                  posts: { linkage: [] },
-                  roles: { linkage: [] },
-                  bio: { linkage: nil }
+                relationships: {
+                  posts: { data: [] },
+                  roles: { data: [] },
+                  bio: { data: nil }
                 }
               },{
                 id: "42",
@@ -129,10 +129,10 @@ module ActiveModel
                   title: "New Post",
                   body: "Body"
                 },
-                links: {
-                  comments: { linkage: [ { type: "comments", id: "1" } ] },
-                  blog: { linkage: { type: "blogs", id: "999" } },
-                  author: { linkage: { type: "authors", id: "1" } }
+                relationships: {
+                  comments: { data: [ { type: "comments", id: "1" } ] },
+                  blog: { data: { type: "blogs", id: "999" } },
+                  author: { data: { type: "authors", id: "1" } }
                 }
               }, {
                 id: "43",
@@ -141,10 +141,10 @@ module ActiveModel
                   title: "Hello!!",
                   body: "Hello, world!!"
                 },
-                links: {
-                  comments: { linkage: [] },
-                  blog: { linkage: { type: "blogs", id: "999" } },
-                  author: { linkage: nil }
+                relationships: {
+                  comments: { data: [] },
+                  blog: { data: { type: "blogs", id: "999" } },
+                  author: { data: nil }
                 }
               }
             ]

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -42,8 +42,10 @@ module ActiveModel
             expected = [{
               id: "42",
               type: "posts",
-              title: 'New Post',
-              body: 'Body',
+              attributes: {
+                title: 'New Post',
+                body: 'Body',
+              },
               links: {
                 comments: { linkage: [ { type: "comments", id: "1" } ] },
                 blog: { linkage: { type: "blogs", id: "999" } },
@@ -58,7 +60,9 @@ module ActiveModel
             expected = [{
               id: "42",
               type: "posts",
-              title: 'New Post',
+              attributes: {
+                title: 'New Post'
+              },
               links: {
                 comments: { linkage: [ { type: "comments", id: "1" } ] },
                 blog: { linkage: { type: "blogs", id: "999" } },
@@ -110,7 +114,9 @@ module ActiveModel
               {
                 id: "1",
                 type: "authors",
-                name: "Steve K.",
+                attributes: {
+                  name: "Steve K."
+                },
                 links: {
                   posts: { linkage: [] },
                   roles: { linkage: [] },
@@ -119,8 +125,10 @@ module ActiveModel
               },{
                 id: "42",
                 type: "posts",
-                title: "New Post",
-                body: "Body",
+                attributes: {
+                  title: "New Post",
+                  body: "Body"
+                },
                 links: {
                   comments: { linkage: [ { type: "comments", id: "1" } ] },
                   blog: { linkage: { type: "blogs", id: "999" } },
@@ -129,8 +137,10 @@ module ActiveModel
               }, {
                 id: "43",
                 type: "posts",
-                title: "Hello!!",
-                body: "Hello, world!!",
+                attributes: {
+                  title: "Hello!!",
+                  body: "Hello, world!!"
+                },
                 links: {
                   comments: { linkage: [] },
                   blog: { linkage: { type: "blogs", id: "999" } },

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -33,10 +33,10 @@ module ActiveModel
                   title: "Hello!!",
                   body: "Hello, world!!"
                 },
-                links: {
-                  comments: { linkage: [] },
-                  blog: { linkage: { type: "blogs", id: "999" } },
-                  author: { linkage: { type: "authors", id: "1" } }
+                relationships: {
+                  comments: { data: [] },
+                  blog: { data: { type: "blogs", id: "999" } },
+                  author: { data: { type: "authors", id: "1" } }
                 }
               },
               {
@@ -46,10 +46,10 @@ module ActiveModel
                   title: "New Post",
                   body: "Body"
                 },
-                links: {
-                  comments: { linkage: [] },
-                  blog: { linkage: { type: "blogs", id: "999" } },
-                  author: { linkage: { type: "authors", id: "1" } }
+                relationships: {
+                  comments: { data: [] },
+                  blog: { data: { type: "blogs", id: "999" } },
+                  author: { data: { type: "authors", id: "1" } }
                 }
               }
             ]
@@ -67,10 +67,10 @@ module ActiveModel
                 attributes: {
                   title: "Hello!!"
                 },
-                links: {
-                  comments: { linkage: [] },
-                  blog: { linkage: { type: "blogs", id: "999" } },
-                  author: { linkage: { type: "authors", id: "1" } }
+                relationships: {
+                  comments: { data: [] },
+                  blog: { data: { type: "blogs", id: "999" } },
+                  author: { data: { type: "authors", id: "1" } }
                 }
               },
               {
@@ -79,10 +79,10 @@ module ActiveModel
                 attributes: {
                   title: "New Post"
                 },
-                links: {
-                  comments: { linkage: [] },
-                  blog: { linkage: { type: "blogs", id: "999" } },
-                  author: { linkage: { type: "authors", id: "1" } }
+                relationships: {
+                  comments: { data: [] },
+                  blog: { data: { type: "blogs", id: "999" } },
+                  author: { data: { type: "authors", id: "1" } }
                 }
               }
             ]

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -29,8 +29,10 @@ module ActiveModel
               {
                 id: "1",
                 type: "posts",
-                title: "Hello!!",
-                body: "Hello, world!!",
+                attributes: {
+                  title: "Hello!!",
+                  body: "Hello, world!!"
+                },
                 links: {
                   comments: { linkage: [] },
                   blog: { linkage: { type: "blogs", id: "999" } },
@@ -40,8 +42,10 @@ module ActiveModel
               {
                 id: "2",
                 type: "posts",
-                title: "New Post",
-                body: "Body",
+                attributes: {
+                  title: "New Post",
+                  body: "Body"
+                },
                 links: {
                   comments: { linkage: [] },
                   blog: { linkage: { type: "blogs", id: "999" } },
@@ -60,7 +64,9 @@ module ActiveModel
               {
                 id: "1",
                 type: "posts",
-                title: "Hello!!",
+                attributes: {
+                  title: "Hello!!"
+                },
                 links: {
                   comments: { linkage: [] },
                   blog: { linkage: { type: "blogs", id: "999" } },
@@ -70,7 +76,9 @@ module ActiveModel
               {
                 id: "2",
                 type: "posts",
-                title: "New Post",
+                attributes: {
+                  title: "New Post"
+                },
                 links: {
                   comments: { linkage: [] },
                   blog: { linkage: { type: "blogs", id: "999" } },

--- a/test/adapter/json_api/has_many_embed_ids_test.rb
+++ b/test/adapter/json_api/has_many_embed_ids_test.rb
@@ -26,13 +26,13 @@ module ActiveModel
 
           def test_includes_comment_ids
             expected = {
-              linkage: [
+              data: [
                 { type: "posts", id: "1"},
                 { type: "posts", id: "2"}
               ]
             }
 
-            assert_equal(expected, @adapter.serializable_hash[:data][:links][:posts])
+            assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:posts])
           end
 
           def test_no_includes_linked_comments

--- a/test/adapter/json_api/has_many_explicit_serializer_test.rb
+++ b/test/adapter/json_api/has_many_explicit_serializer_test.rb
@@ -30,13 +30,13 @@ module ActiveModel
 
           def test_includes_comment_ids
             expected = {
-              linkage: [
+              data: [
                 { type: 'comments', id: '1' },
                 { type: 'comments', id: '2' }
               ]
             }
 
-            assert_equal(expected, @adapter.serializable_hash[:data][:links][:comments])
+            assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:comments])
           end
 
           def test_includes_linked_data
@@ -45,22 +45,22 @@ module ActiveModel
               {
                 id: '1',
                 type: 'comments',
-                links: {
-                  post: { linkage: { type: 'posts', id: @post.id.to_s } }
+                relationships: {
+                  post: { data: { type: 'posts', id: @post.id.to_s } }
                 }
               },
               {
                 id: '2',
                 type: 'comments',
-                links: {
-                  post: { linkage: { type: 'posts', id: @post.id.to_s } }
+                relationships: {
+                  post: { data: { type: 'posts', id: @post.id.to_s } }
                 }
               },
               {
                 id: @author.id.to_s,
                 type: "authors",
-                links: {
-                  posts: { linkage: [ {type: "posts", id: @post.id.to_s } ] }
+                relationships: {
+                  posts: { data: [ {type: "posts", id: @post.id.to_s } ] }
                 }
               }
             ]
@@ -70,26 +70,26 @@ module ActiveModel
 
           def test_includes_author_id
             expected = {
-              linkage: { type: "authors", id: @author.id.to_s }
+              data: { type: "authors", id: @author.id.to_s }
             }
 
-            assert_equal(expected, @adapter.serializable_hash[:data][:links][:author])
+            assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:author])
           end
 
           def test_explicit_serializer_with_null_resource
             @post.author = nil
 
-            expected = { linkage: nil }
+            expected = { data: nil }
 
-            assert_equal(expected, @adapter.serializable_hash[:data][:links][:author])
+            assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:author])
           end
 
           def test_explicit_serializer_with_null_collection
             @post.comments = []
 
-            expected = { linkage: [] }
+            expected = { data: [] }
 
-            assert_equal(expected, @adapter.serializable_hash[:data][:links][:comments])
+            assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:comments])
           end
         end
       end

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -43,7 +43,9 @@ module ActiveModel
             expected = [{
               id: "1",
               type: "comments",
-              body: 'ZOMG A COMMENT',
+              attributes: {
+                body: 'ZOMG A COMMENT'
+              },
               links: {
                 post: { linkage: { type: "posts", id: "1" } },
                 author: { linkage: nil }
@@ -51,7 +53,9 @@ module ActiveModel
             }, {
               id: "2",
               type: "comments",
-              body: 'ZOMG ANOTHER COMMENT',
+              attributes: {
+                body: 'ZOMG ANOTHER COMMENT'
+              },
               links: {
                 post: { linkage: { type: "posts", id: "1" } },
                 author: { linkage: nil }

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -33,9 +33,9 @@ module ActiveModel
           end
 
           def test_includes_comment_ids
-            expected = { linkage: [ { type: "comments", id: "1" }, { type: "comments", id: "2" } ] }
+            expected = { data: [ { type: "comments", id: "1" }, { type: "comments", id: "2" } ] }
 
-            assert_equal(expected, @adapter.serializable_hash[:data][:links][:comments])
+            assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:comments])
           end
 
           def test_includes_linked_comments
@@ -46,9 +46,9 @@ module ActiveModel
               attributes: {
                 body: 'ZOMG A COMMENT'
               },
-              links: {
-                post: { linkage: { type: "posts", id: "1" } },
-                author: { linkage: nil }
+              relationships: {
+                post: { data: { type: "posts", id: "1" } },
+                author: { data: nil }
               }
             }, {
               id: "2",
@@ -56,9 +56,9 @@ module ActiveModel
               attributes: {
                 body: 'ZOMG ANOTHER COMMENT'
               },
-              links: {
-                post: { linkage: { type: "posts", id: "1" } },
-                author: { linkage: nil }
+              relationships: {
+                post: { data: { type: "posts", id: "1" } },
+                author: { data: nil }
               }
             }]
             assert_equal expected, @adapter.serializable_hash[:included]
@@ -69,16 +69,16 @@ module ActiveModel
             expected = [{
               id: "1",
               type: "comments",
-              links: {
-                post: { linkage: { type: "posts", id: "1" } },
-                author: { linkage: nil }
+              relationships: {
+                post: { data: { type: "posts", id: "1" } },
+                author: { data: nil }
               }
             }, {
               id: "2",
               type: "comments",
-              links: {
-                post: { linkage: { type: "posts", id: "1" } },
-                author: { linkage: nil }
+              relationships: {
+                post: { data: { type: "posts", id: "1" } },
+                author: { data: nil }
               }
             }]
             assert_equal expected, @adapter.serializable_hash[:included]
@@ -94,9 +94,9 @@ module ActiveModel
           def test_include_type_for_association_when_different_than_name
             serializer = BlogSerializer.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
-            actual = adapter.serializable_hash[:data][:links][:articles]
+            actual = adapter.serializable_hash[:data][:relationships][:articles]
             expected = {
-              linkage: [{
+              data: [{
                 type: "posts",
                 id: "1"
               }]

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -30,9 +30,9 @@ module ActiveModel
           end
 
           def test_includes_bio_id
-            expected = { linkage: { type: "bios", id: "43" } }
+            expected = { data: { type: "bios", id: "43" } }
 
-            assert_equal(expected, @adapter.serializable_hash[:data][:links][:bio])
+            assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:bio])
           end
 
           def test_includes_linked_bio
@@ -46,8 +46,8 @@ module ActiveModel
                   content:"AMS Contributor",
                   rating: nil
                 },
-                links: {
-                  author: { linkage: { type: "authors", id: "1" } }
+                relationships: {
+                  author: { data: { type: "authors", id: "1" } }
                 }
               }
             ]

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -41,9 +41,11 @@ module ActiveModel
             expected = [
               {
                 id: "43",
-                rating: nil,
                 type: "bios",
-                content:"AMS Contributor",
+                attributes: {
+                  content:"AMS Contributor",
+                  rating: nil
+                },
                 links: {
                   author: { linkage: { type: "authors", id: "1" } }
                 }

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -59,10 +59,10 @@ module ActiveModel
                     title: "Hello!!",
                     body: "Hello, world!!"
                   },
-                  links: {
-                    comments: { linkage: [ { type: "comments", id: '1' }, { type: "comments", id: '2' } ] },
-                    blog: { linkage: { type: "blogs", id: "999" } },
-                    author: { linkage: { type: "authors", id: "1" } }
+                  relationships: {
+                    comments: { data: [ { type: "comments", id: '1' }, { type: "comments", id: '2' } ] },
+                    blog: { data: { type: "blogs", id: "999" } },
+                    author: { data: { type: "authors", id: "1" } }
                   }
                 },
                 {
@@ -72,10 +72,10 @@ module ActiveModel
                     title: "New Post",
                     body: "Body"
                   },
-                  links: {
-                    comments: { linkage: [] },
-                    blog: { linkage: { type: "blogs", id: "999" } },
-                    author: { linkage: { type: "authors", id: "2" } }
+                  relationships: {
+                    comments: { data: [] },
+                    blog: { data: { type: "blogs", id: "999" } },
+                    author: { data: { type: "authors", id: "2" } }
                   }
                 }
               ],
@@ -86,9 +86,9 @@ module ActiveModel
                   attributes: {
                     body: "ZOMG A COMMENT"
                   },
-                  links: {
-                    post: { linkage: { type: "posts", id: "10" } },
-                    author: { linkage: nil }
+                  relationships: {
+                    post: { data: { type: "posts", id: "10" } },
+                    author: { data: nil }
                   }
                 }, {
                   id: "2",
@@ -96,9 +96,9 @@ module ActiveModel
                   attributes: {
                     body: "ZOMG ANOTHER COMMENT",
                   },
-                  links: {
-                    post: { linkage: { type: "posts", id: "10" } },
-                    author: { linkage: nil }
+                  relationships: {
+                    post: { data: { type: "posts", id: "10" } },
+                    author: { data: nil }
                   }
                 }, {
                   id: "1",
@@ -106,10 +106,10 @@ module ActiveModel
                   attributes: {
                     name: "Steve K."
                   },
-                  links: {
-                    posts: { linkage: [ { type: "posts", id: "10" }, { type: "posts", id: "30" } ] },
-                    roles: { linkage: [] },
-                    bio: { linkage: { type: "bios", id: "1" } }
+                  relationships: {
+                    posts: { data: [ { type: "posts", id: "10" }, { type: "posts", id: "30" } ] },
+                    roles: { data: [] },
+                    bio: { data: { type: "bios", id: "1" } }
                   }
                 }, {
                   id: "1",
@@ -118,8 +118,8 @@ module ActiveModel
                     content: "AMS Contributor",
                     rating: nil
                   },
-                  links: {
-                    author: { linkage: { type: "authors", id: "1" } }
+                  relationships: {
+                    author: { data: { type: "authors", id: "1" } }
                   }
                 }, {
                   id: "2",
@@ -127,10 +127,10 @@ module ActiveModel
                   attributes: {
                     name: "Tenderlove"
                   },
-                  links: {
-                    posts: { linkage: [ { type: "posts", id:"20" } ] },
-                    roles: { linkage: [] },
-                    bio: { linkage: { type: "bios", id: "2" } }
+                  relationships: {
+                    posts: { data: [ { type: "posts", id:"20" } ] },
+                    roles: { data: [] },
+                    bio: { data: { type: "bios", id: "2" } }
                   }
                 }, {
                   id: "2",
@@ -139,8 +139,8 @@ module ActiveModel
                     rating: nil,
                     content: "Rails Contributor",
                   },
-                  links: {
-                    author: { linkage: { type: "authors", id: "2" } }
+                  relationships: {
+                    author: { data: { type: "authors", id: "2" } }
                   }
                 }
               ]
@@ -167,10 +167,10 @@ module ActiveModel
                 attributes: {
                   name: "Steve K."
                 },
-                links: {
-                  posts: { linkage: [ { type: "posts", id: "10"}, { type: "posts", id: "30" }] },
-                  roles: { linkage: [] },
-                  bio: { linkage: { type: "bios", id: "1" }}
+                relationships: {
+                  posts: { data: [ { type: "posts", id: "10"}, { type: "posts", id: "30" }] },
+                  roles: { data: [] },
+                  bio: { data: { type: "bios", id: "1" }}
                 }
               }, {
                 id: "10",
@@ -179,10 +179,10 @@ module ActiveModel
                   title: "Hello!!",
                   body: "Hello, world!!"
                 },
-                links: {
-                  comments: { linkage: [ { type: "comments", id: "1"}, { type: "comments", id: "2" }] },
-                  blog: { linkage: { type: "blogs", id: "999" } },
-                  author: { linkage: { type: "authors", id: "1" } }
+                relationships: {
+                  comments: { data: [ { type: "comments", id: "1"}, { type: "comments", id: "2" }] },
+                  blog: { data: { type: "blogs", id: "999" } },
+                  author: { data: { type: "authors", id: "1" } }
                 }
               }, {
                 id: "30",
@@ -191,10 +191,10 @@ module ActiveModel
                   title: "Yet Another Post",
                   body: "Body"
                 },
-                links: {
-                  comments: { linkage: [] },
-                  blog: { linkage: { type: "blogs", id: "999" } },
-                  author: { linkage: { type: "authors", id: "1" } }
+                relationships: {
+                  comments: { data: [] },
+                  blog: { data: { type: "blogs", id: "999" } },
+                  author: { data: { type: "authors", id: "1" } }
                 }
               }
             ]
@@ -208,16 +208,16 @@ module ActiveModel
             spammy_post.related = [Spam::UnrelatedLink.new(id: 456)]
             serializer = SpammyPostSerializer.new(spammy_post)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
-            links = adapter.serializable_hash[:data][:links]
+            relationships = adapter.serializable_hash[:data][:relationships]
             expected = {
               related: {
-                linkage: [{
+                data: [{
                   type: 'unrelated_links',
                   id: '456'
                 }]
               }
             }
-            assert_equal expected, links
+            assert_equal expected, relationships
           end
 
           def test_multiple_references_to_same_resource
@@ -235,15 +235,15 @@ module ActiveModel
                   title: "Hello!!",
                   body: "Hello, world!!"
                 },
-                links: {
+                relationships: {
                   comments: {
-                    linkage: [{type: "comments", id: "1"}, {type: "comments", id: "2"}]
+                    data: [{type: "comments", id: "1"}, {type: "comments", id: "2"}]
                   },
                   blog: {
-                    linkage: {type: "blogs", id: "999"}
+                    data: {type: "blogs", id: "999"}
                   },
                   author: {
-                    linkage: {type: "authors", id: "1"}
+                    data: {type: "authors", id: "1"}
                   }
                 }
               }
@@ -268,9 +268,9 @@ module ActiveModel
                   title: "Hello!!",
                   body: "Hello, world!!"
                 },
-                links: {
-                  comments: { linkage: [ { type: "comments", id: '1' }, { type: "comments", id: '2' } ] },
-                  author: { linkage: nil }
+                relationships: {
+                  comments: { data: [ { type: "comments", id: '1' }, { type: "comments", id: '2' } ] },
+                  author: { data: nil }
                 }
               }
             }

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -54,9 +54,11 @@ module ActiveModel
               data: [
                 {
                   id: "10",
-                  title: "Hello!!",
-                  body: "Hello, world!!",
                   type: "posts",
+                  attributes: {
+                    title: "Hello!!",
+                    body: "Hello, world!!"
+                  },
                   links: {
                     comments: { linkage: [ { type: "comments", id: '1' }, { type: "comments", id: '2' } ] },
                     blog: { linkage: { type: "blogs", id: "999" } },
@@ -65,9 +67,11 @@ module ActiveModel
                 },
                 {
                   id: "20",
-                  title: "New Post",
-                  body: "Body",
                   type: "posts",
+                  attributes: {
+                    title: "New Post",
+                    body: "Body"
+                  },
                   links: {
                     comments: { linkage: [] },
                     blog: { linkage: { type: "blogs", id: "999" } },
@@ -78,24 +82,30 @@ module ActiveModel
               included: [
                 {
                   id: "1",
-                  body: "ZOMG A COMMENT",
                   type: "comments",
+                  attributes: {
+                    body: "ZOMG A COMMENT"
+                  },
                   links: {
                     post: { linkage: { type: "posts", id: "10" } },
                     author: { linkage: nil }
                   }
                 }, {
                   id: "2",
-                  body: "ZOMG ANOTHER COMMENT",
                   type: "comments",
+                  attributes: {
+                    body: "ZOMG ANOTHER COMMENT",
+                  },
                   links: {
                     post: { linkage: { type: "posts", id: "10" } },
                     author: { linkage: nil }
                   }
                 }, {
                   id: "1",
-                  name: "Steve K.",
                   type: "authors",
+                  attributes: {
+                    name: "Steve K."
+                  },
                   links: {
                     posts: { linkage: [ { type: "posts", id: "10" }, { type: "posts", id: "30" } ] },
                     roles: { linkage: [] },
@@ -103,16 +113,20 @@ module ActiveModel
                   }
                 }, {
                   id: "1",
-                  rating: nil,
                   type: "bios",
-                  content: "AMS Contributor",
+                  attributes: {
+                    content: "AMS Contributor",
+                    rating: nil
+                  },
                   links: {
                     author: { linkage: { type: "authors", id: "1" } }
                   }
                 }, {
                   id: "2",
-                  name: "Tenderlove",
                   type: "authors",
+                  attributes: {
+                    name: "Tenderlove"
+                  },
                   links: {
                     posts: { linkage: [ { type: "posts", id:"20" } ] },
                     roles: { linkage: [] },
@@ -120,9 +134,11 @@ module ActiveModel
                   }
                 }, {
                   id: "2",
-                  rating: nil,
                   type: "bios",
-                  content: "Rails Contributor",
+                  attributes: {
+                    rating: nil,
+                    content: "Rails Contributor",
+                  },
                   links: {
                     author: { linkage: { type: "authors", id: "2" } }
                   }
@@ -148,7 +164,9 @@ module ActiveModel
               {
                 id: "1",
                 type: "authors",
-                name: "Steve K.",
+                attributes: {
+                  name: "Steve K."
+                },
                 links: {
                   posts: { linkage: [ { type: "posts", id: "10"}, { type: "posts", id: "30" }] },
                   roles: { linkage: [] },
@@ -157,8 +175,10 @@ module ActiveModel
               }, {
                 id: "10",
                 type: "posts",
-                title: "Hello!!",
-                body: "Hello, world!!",
+                attributes: {
+                  title: "Hello!!",
+                  body: "Hello, world!!"
+                },
                 links: {
                   comments: { linkage: [ { type: "comments", id: "1"}, { type: "comments", id: "2" }] },
                   blog: { linkage: { type: "blogs", id: "999" } },
@@ -167,8 +187,10 @@ module ActiveModel
               }, {
                 id: "30",
                 type: "posts",
-                title: "Yet Another Post",
-                body: "Body",
+                attributes: {
+                  title: "Yet Another Post",
+                  body: "Body"
+                },
                 links: {
                   comments: { linkage: [] },
                   blog: { linkage: { type: "blogs", id: "999" } },
@@ -208,9 +230,11 @@ module ActiveModel
             expected = [
               {
                 id: "10",
-                title: "Hello!!",
-                body: "Hello, world!!",
                 type: "posts",
+                attributes: {
+                  title: "Hello!!",
+                  body: "Hello, world!!"
+                },
                 links: {
                   comments: {
                     linkage: [{type: "comments", id: "1"}, {type: "comments", id: "2"}]
@@ -239,9 +263,11 @@ module ActiveModel
             expected = {
               data: {
                 id: "10",
-                title: "Hello!!",
-                body: "Hello, world!!",
                 type: "posts",
+                attributes: {
+                  title: "Hello!!",
+                  body: "Hello, world!!"
+                },
                 links: {
                   comments: { linkage: [ { type: "comments", id: '1' }, { type: "comments", id: '2' } ] },
                   author: { linkage: nil }


### PR DESCRIPTION
As JSON API RC4 was published yesterday (with the final release date pushed back to 2015-05-28), this pull request updates the `JsonApi` adapter to match the new changes to the schema. 

Relevant changes to the spec:

* Attributes (other than id and type) are now nested under the `attributes` key. 
* Relationships are now nested under the `relationships` key instead of the `links` key
* The `linkage` key for relationships is now called `data`

This resulted in these changes to the gem:

* Tests are adjusted to reflect the new schema
* The adapter now renders the new schema
* The methods releated to links are renamed to avoid confusion
* `fragment_cache` now does a deep_merge instead of just a simple merge

Feedback welcome! I'm happy to adjust things as necessary. :)