### PR TITLE
Fix #876 - include meta when using json adapter with custom root

### DIFF
--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -75,7 +75,7 @@ module ActiveModel
       end
 
       def root
-        serializer.json_key
+        @options.fetch(:root) { serializer.json_key }
       end
 
       def include_meta(json)

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -37,10 +37,11 @@ module ActiveModel
             @result = @core.merge @hash
           end
 
-          if root = options.fetch(:root, serializer.json_key)
+          if root
             @result = { root => @result }
+          else
+            @result
           end
-          @result
         end
       end
 

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -14,6 +14,11 @@ module ActionController
           render json: @profile, root: "custom_root"
         end
 
+        def render_using_custom_root_and_meta
+          @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+          render json: @profile, root: "custom_root", meta: { total: 10 }
+        end
+
         def render_using_default_adapter_root
           with_adapter ActiveModel::Serializer::Adapter::JsonApi do
             # JSON-API adapter sets root by default
@@ -26,6 +31,14 @@ module ActionController
           # JSON-API adapter sets root by default
           @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           render json: @profile, root: "profile", adapter: :json_api
+        end
+
+        def render_array_using_custom_root_and_meta
+          array = [
+            Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+            Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })
+          ]
+          render json: array, root: "custom_root", meta: { total: 10 }
         end
 
         def render_array_using_implicit_serializer
@@ -161,6 +174,13 @@ module ActionController
         assert_equal '{"custom_root":{"name":"Name 1","description":"Description 1"}}', @response.body
       end
 
+      def test_render_using_custom_root_and_meta
+        get :render_using_custom_root_and_meta
+
+        assert_equal 'application/json', @response.content_type
+        assert_equal '{"custom_root":{"name":"Name 1","description":"Description 1"},"meta":{"total":10}}', @response.body
+      end
+
       def test_render_using_default_root
         get :render_using_default_adapter_root
 
@@ -194,6 +214,25 @@ module ActionController
         }
 
         assert_equal 'application/json', @response.content_type
+        assert_equal expected.to_json, @response.body
+      end
+
+      def test_render_array_using_custom_root_and_meta
+        get :render_array_using_custom_root_and_meta
+        assert_equal 'application/json', @response.content_type
+
+        expected = { custom_root: [
+          {
+            name: 'Name 1',
+            description: 'Description 1',
+          },
+          {
+            name: 'Name 2',
+            description: 'Description 2',
+          }],
+          meta: { total: 10 }
+        }
+
         assert_equal expected.to_json, @response.body
       end
 

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -48,8 +48,8 @@ module ActiveModel
         assert_equal expected, adapter.as_json
       end
 
-      def test_meta_is_not_used_on_arrays
-        serializer = ArraySerializer.new([@blog], root: "blog", meta: {total: 10}, meta_key: "haha_meta")
+      def test_meta_is_not_present_on_arrays_without_root
+        serializer = ArraySerializer.new([@blog], meta: {total: 10})
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
         expected = [{
           id: 1,
@@ -67,11 +67,38 @@ module ActiveModel
         assert_equal expected, adapter.as_json
       end
 
+      def test_meta_is_present_on_arrays_with_root
+        serializer = ArraySerializer.new([@blog], meta: {total: 10}, meta_key: "haha_meta")
+        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, root: 'blog')
+        expected = {
+          'blog' => [{
+            id: 1,
+            name: "AMS Hints",
+            writer: {
+              id: 2,
+              name: "Steve"
+            },
+            articles: [{
+              id: 3,
+              title: "AMS",
+              body: nil
+            }]
+          }],
+          'haha_meta' => {
+            total: 10
+          }
+        }
+        assert_equal expected, adapter.as_json
+      end
+
       private
 
       def load_adapter(options)
-        serializer = AlternateBlogSerializer.new(@blog, options)
-        ActiveModel::Serializer::Adapter::Json.new(serializer)
+        adapter_opts, serializer_opts =
+          options.partition { |k, _| ActionController::Serialization::ADAPTER_OPTION_KEYS.include? k }.map { |h| Hash[h] }
+
+        serializer = AlternateBlogSerializer.new(@blog, serializer_opts)
+        ActiveModel::Serializer::Adapter::Json.new(serializer, adapter_opts)
       end
     end
   end


### PR DESCRIPTION
This PR fixes issue #876 where meta was not being included when using the JSON adapter and a custom root.