### PR TITLE
Use a more precise generated cache key

### DIFF
--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -72,7 +72,9 @@ module ActiveModel
       end
 
       def object_cache_key
-        (@klass._cache_key) ? "#{@klass._cache_key}/#{@cached_serializer.object.id}-#{@cached_serializer.object.updated_at}" : @cached_serializer.object.cache_key
+        object_time_safe = @cached_serializer.object.updated_at
+        object_time_safe = object_time_safe.strftime("%Y%m%d%H%M%S%9N") if object_time_safe.respond_to?(:strftime)
+        (@klass._cache_key) ? "#{@klass._cache_key}/#{@cached_serializer.object.id}-#{object_time_safe}" : @cached_serializer.object.cache_key
       end
 
       def meta

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -98,13 +98,12 @@ module ActionController
 
         def render_fragment_changed_object_with_relationship
           comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
+          comment2 = Comment.new({ id: 1, body: 'ZOMG AN UPDATED-BUT-NOT-CACHE-EXPIRED COMMENT' })
           author = Author.new(id: 1, name: 'Joao Moura.')
-          post = Post.new({ id: 1, title: 'New Post', body: 'Body', comments: [comment], author: author })
-          post2 = Post.new({ id: 1, title: 'New Post2', body: 'Body2', comments: [comment], author: author })
-          like = Like.new({ id: 1, post: post, time: 3.days.ago })
+          like = Like.new({ id: 1, likeable: comment, time: 3.days.ago })
 
           generate_cached_serializer(like)
-          like.post = post2
+          like.likable = comment2
           like.time = DateTime.now.to_s
 
           render json: like
@@ -229,7 +228,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
 
         get :render_changed_object_with_cache_enabled
-        assert_equal expected.to_json, @response.body
+        assert_not_equal expected.to_json, @response.body
 
         ActionController::Base.cache_store.clear
         get :render_changed_object_with_cache_enabled
@@ -291,10 +290,9 @@ module ActionController
         expected_return = {
           "id"=>1,
           "time"=>DateTime.now.to_s,
-          "post" => {
+          "likeable" => {
             "id"=>1,
-            "title"=>"New Post",
-            "body"=>"Body"
+            "body"=>"ZOMG A COMMENT"
           }
         }
 

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -10,7 +10,7 @@ class Model
   end
 
   def cache_key
-    "#{self.class.name.downcase}/#{self.id}-#{self.updated_at}"
+    "#{self.class.name.downcase}/#{self.id}-#{self.updated_at.strftime("%Y%m%d%H%M%S%9N")}"
   end
 
   def cache_key_with_digest
@@ -18,7 +18,7 @@ class Model
   end
 
   def updated_at
-    @attributes[:updated_at] ||= DateTime.now.to_time.to_i
+    @attributes[:updated_at] ||= DateTime.now.to_time
   end
 
   def read_attribute_for_serialization(name)
@@ -69,7 +69,6 @@ end
 
 Post     = Class.new(Model)
 Like     = Class.new(Model)
-Comment  = Class.new(Model)
 Author   = Class.new(Model)
 Bio      = Class.new(Model)
 Blog     = Class.new(Model)
@@ -77,6 +76,12 @@ Role     = Class.new(Model)
 User     = Class.new(Model)
 Location = Class.new(Model)
 Place    = Class.new(Model)
+Comment  = Class.new(Model) do
+  # Uses a custom non-time-based cache key
+  def cache_key
+    "#{self.class.name.downcase}/#{self.id}"
+  end
+end
 
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
@@ -143,7 +148,7 @@ end
 LikeSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :time
 
-  belongs_to :post
+  belongs_to :likeable
 end
 
 LocationSerializer = Class.new(ActiveModel::Serializer) do

--- a/test/serializers/cache_test.rb
+++ b/test/serializers/cache_test.rb
@@ -48,7 +48,7 @@ module ActiveModel
       def test_cache_key_interpolation_with_updated_at
         author = render_object_with_cache(@author)
         assert_equal(nil, ActionController::Base.cache_store.fetch(@author.cache_key))
-        assert_equal(@author_serializer.attributes.to_json, ActionController::Base.cache_store.fetch("#{@author_serializer.class._cache_key}/#{@author_serializer.object.id}-#{@author_serializer.object.updated_at}").to_json)
+        assert_equal(@author_serializer.attributes.to_json, ActionController::Base.cache_store.fetch("#{@author_serializer.class._cache_key}/#{@author_serializer.object.id}-#{@author_serializer.object.updated_at.strftime("%Y%m%d%H%M%S%9N")}").to_json)
       end
 
       def test_default_cache_key_fallback
@@ -85,7 +85,7 @@ module ActiveModel
         # Generate a new Cache of Post object and each objects related to it.
         render_object_with_cache(@post)
 
-        # Check if if cache the objects separately
+        # Check if it cached the objects separately
         assert_equal(@post_serializer.attributes, ActionController::Base.cache_store.fetch(@post.cache_key))
         assert_equal(@comment_serializer.attributes, ActionController::Base.cache_store.fetch(@comment.cache_key))
 


### PR DESCRIPTION
This change updates the default generated cache key (when the `key: 'foo'` option is specified and the object's `#cache_key` implementation isn't used) to use a more precise version of `updated_at`. By default, it was invoking `updated_at.to_s` which ends up with a cache key value like `cache-key-prefix/807130-2015-05-27 18:11:05 UTC`

This effectively means, if someone specifies a cache key in the serializer (which is really just a cache key prefix value -- I'll save that discussion for another PR perhaps ;) ) it will only be cached with a precision to the minute. So if I have a model and it gets cached, and I update it within the same minute, the cache will not be considered invalid and my model changes will not be reflected.

The ActiveRecord implementation of the default cache key, as you can see here https://github.com/rails/rails/blob/master/activerecord/lib/active_record/integration.rb#L55 , allows some customization but defaults to `updated_at.utc.to_s(:nsec)` which gives a much greater precision. In the example I gave above, it would be `cache-key-prefix/807130-20150527181105000000000`.
Since this gem doesn't have the dependencies to leverage the `:nsec` format helper, I leveraged the same format string to use here. (Currently using a magic string, since the only duplicate copies are in tests.)

I specifically did *not* update the cache_key to use `#utc`, but if that's desired I can update it to use that as well.

I also fixed up some of the tests. The test harnesses were written specifically using `updated_at.to_i` which allowed some implicit assumptions about cache invalidation to be encoded into the tests, which failed (rightly so) when I made the change to use a higher precision value.

:sparkles: :clock3: :sparkles: 

Thanks!
Aaron