### PR TITLE
Fix: Don't pass serializer option to associated serializers

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -217,7 +217,7 @@ module ActiveModel
         if serializer_class
           serializer = serializer_class.new(
             association_value,
-            options.merge(serializer_from_options(association_options))
+            options.except(:serializer).merge(serializer_from_options(association_options))
           )
         elsif !association_value.nil? && !association_value.instance_of?(Object)
           association_options[:association_options][:virtual_value] = association_value

--- a/test/action_controller/adapter_selector_test.rb
+++ b/test/action_controller/adapter_selector_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActionController
   module Serialization
     class AdapterSelectorTest < ActionController::TestCase
-      class MyController < ActionController::Base
+      class AdapterSelectorTestController < ActionController::Base
         def render_using_default_adapter
           @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           render json: @profile
@@ -20,7 +20,7 @@ module ActionController
         end
       end
 
-      tests MyController
+      tests AdapterSelectorTestController
 
       def test_render_using_default_adapter
         get :render_using_default_adapter

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -57,11 +57,10 @@ module ActionController
         end
 
         def render_using_explicit_each_serializer
-          @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
-          @author  = Author.new(id: 1, name: 'Joao Moura.')
-          @post    = Post.new({ id: 1, title: 'New Post', body: 'Body', comments: [@comment], author: @author })
+          location       = Location.new(id: 42, lat: '-23.550520', lng: '-46.633309')
+          place          = Place.new(id: 1337, name: 'Amazing Place', locations: [location])
 
-          render json: @post, each_serializer: PostSerializer
+          render json: place, each_serializer: PlaceSerializer
         end
       end
 
@@ -118,25 +117,19 @@ module ActionController
         get :render_using_explicit_each_serializer
 
         expected = {
-          id: 1,
-          title: 'New Post',
-          body: 'Body',
-          comments: [
+          id: 1337,
+          name: "Amazing Place",
+          locations: [
             {
-              id: 1,
-              body: 'ZOMG A COMMENT' }
-          ],
-          blog: {
-            id: 999,
-            name: 'Custom blog'
-          },
-          author: {
-            id: 1,
-            name: 'Joao Moura.'
-          }
+              id: 42,
+              lat: "-23.550520",
+              lng: "-46.633309",
+              place: "Nowhere" # is a virtual attribute on LocationSerializer
+            }
+          ]
         }
 
-        assert_equal expected.to_json, @response.body
+        assert_equal expected.to_json, response.body
       end
     end
   end

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActionController
   module Serialization
     class ExplicitSerializerTest < ActionController::TestCase
-      class MyController < ActionController::Base
+      class ExplicitSerializerTestController < ActionController::Base
         def render_using_explicit_serializer
           @profile = Profile.new(name: 'Name 1',
                                  description: 'Description 1',
@@ -65,7 +65,7 @@ module ActionController
         end
       end
 
-      tests MyController
+      tests ExplicitSerializerTestController
 
       def test_render_using_explicit_serializer
         get :render_using_explicit_serializer

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -55,6 +55,14 @@ module ActionController
 
           render json: [@post], each_serializer: PostPreviewSerializer
         end
+
+        def render_using_explicit_each_serializer
+          @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
+          @author  = Author.new(id: 1, name: 'Joao Moura.')
+          @post    = Post.new({ id: 1, title: 'New Post', body: 'Body', comments: [@comment], author: @author })
+
+          render json: @post, each_serializer: PostSerializer
+        end
       end
 
       tests MyController
@@ -102,6 +110,31 @@ module ActionController
             "author" => { "id" => assigns(:author).id }
           }
         ]
+
+        assert_equal expected.to_json, @response.body
+      end
+
+      def test_render_using_explicit_each_serializer
+        get :render_using_explicit_each_serializer
+
+        expected = {
+          id: 1,
+          title: 'New Post',
+          body: 'Body',
+          comments: [
+            {
+              id: 1,
+              body: 'ZOMG A COMMENT' }
+          ],
+          blog: {
+            id: 999,
+            name: 'Custom blog'
+          },
+          author: {
+            id: 1,
+            name: 'Joao Moura.'
+          }
+        }
 
         assert_equal expected.to_json, @response.body
       end

--- a/test/action_controller/json_api_linked_test.rb
+++ b/test/action_controller/json_api_linked_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActionController
   module Serialization
     class JsonApiLinkedTest < ActionController::TestCase
-      class MyController < ActionController::Base
+      class JsonApiLinkedTestController < ActionController::Base
         def setup_post
           ActionController::Base.cache_store.clear
           @role1 = Role.new(id: 1, name: 'admin')
@@ -78,7 +78,7 @@ module ActionController
         end
       end
 
-      tests MyController
+      tests JsonApiLinkedTestController
 
       def test_render_resource_without_include
         get :render_resource_without_include

--- a/test/action_controller/rescue_from_test.rb
+++ b/test/action_controller/rescue_from_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActionController
   module Serialization
     class RescueFromTest < ActionController::TestCase
-      class MyController < ActionController::Base
+      class RescueFromTestController < ActionController::Base
         rescue_from Exception, with: :handle_error
 
         def render_using_raise_error_serializer
@@ -16,7 +16,7 @@ module ActionController
         end
       end
 
-      tests MyController
+      tests RescueFromTestController
 
       def test_rescue_from
         get :render_using_raise_error_serializer

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActionController
   module Serialization
     class ImplicitSerializerTest < ActionController::TestCase
-      class MyController < ActionController::Base
+      class ImplicitSerializationTestController < ActionController::Base
         def render_using_implicit_serializer
           @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           render json: @profile
@@ -152,7 +152,7 @@ module ActionController
         end
       end
 
-      tests MyController
+      tests ImplicitSerializationTestController
 
       # We just have Null for now, this will change
       def test_render_using_implicit_serializer


### PR DESCRIPTION
Fixes #870

Commit af81a40 introduced passing a serializer's 'options'
along to its associated model serializers.

Thus, an explicit 'each_serializer' passed to render for a
singular resource would be passed on as the implicit 'serializer'
for its associations.

With @bf4