### PR TITLE
added option to include nested associations

### DIFF
--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -19,13 +19,17 @@ module ActiveModel
                 array_serializer = association
                 @hash[name] = array_serializer.map do |item|
                   cache_check(item) do
-                    item.attributes(opts)
+                    opts[:include_nested_associations] ?
+                      self.class.new(item).serializable_hash :
+                      item.attributes(opts)
                   end
                 end
               else
                 if association && association.object
                   @hash[name] = cache_check(association) do
-                    association.attributes(options)
+                    opts[:include_nested_associations] ?
+                      self.class.new(association).serializable_hash :
+                      association.attributes(options)
                   end
                 elsif opts[:virtual_value]
                   @hash[name] = opts[:virtual_value]

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -89,6 +89,19 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
+SimpleAuthorSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :name
+
+  has_one :bio
+end
+
+PostSerializerWithNestedAssociations = Class.new(ActiveModel::Serializer) do
+  attributes :id, :title, :body
+
+  has_many  :comments
+  has_one   :author, serializer: SimpleAuthorSerializer, include_nested_associations: true
+end
+
 SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
   has_many :related

--- a/test/serializers/include_nested_associations_test.rb
+++ b/test/serializers/include_nested_associations_test.rb
@@ -5,7 +5,7 @@ module ActiveModel
     class IncludeNestedAssociationsTest < Minitest::Test
       def setup
         @author = Author.new(name: 'Steve K.')
-        @author.bio = Bio.new(content: 'Hello!', rating: 5)
+        @author.bio = Bio.new(id: 1, content: 'Hello!', rating: 5)
 
         @post = Post.new({ title: 'New Post', body: 'Body' })
 
@@ -24,7 +24,12 @@ module ActiveModel
       def test_no_option_is_passed_in
         @post_serializer = PostSerializerWithNestedAssociations.new(@post)
         json = ActiveModel::Serializer::Adapter::Json.new(@post_serializer).as_json
-        assert json[:author][:bio] != nil
+        expected_return = {
+          id: 1,
+          content: 'Hello!',
+          rating: 5
+        }
+        assert_equal json[:author][:bio] , expected_return
       end
     end
   end

--- a/test/serializers/include_nested_associations_test.rb
+++ b/test/serializers/include_nested_associations_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class IncludeNestedAssociationsTest < Minitest::Test
+      def setup
+        @author = Author.new(name: 'Steve K.')
+        @author.bio = Bio.new(content: 'Hello!', rating: 5)
+
+        @post = Post.new({ title: 'New Post', body: 'Body' })
+
+        @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
+        @post.comments = [@comment]
+
+        @post.author = @author
+      end
+
+      def test_no_nested_association_are_included_by_default
+        @post_serializer = PostSerializer.new(@post)
+        json = ActiveModel::Serializer::Adapter::Json.new(@post_serializer).as_json
+        assert_nil json[:author][:bio]
+      end
+
+      def test_no_option_is_passed_in
+        @post_serializer = PostSerializerWithNestedAssociations.new(@post)
+        json = ActiveModel::Serializer::Adapter::Json.new(@post_serializer).as_json
+        assert json[:author][:bio] != nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Devs can now use a new parameter in Serializer classes when defining associations (has_many, has_one, ...): `include_nested_assosiations`.

If this option is true, serialization will "follow" the association including not only its attributes, but also its associations.