### PR TITLE
use model name to determine the type

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -188,7 +188,7 @@ module ActiveModel
     end
 
     def type
-      object.class.to_s.demodulize.underscore.pluralize
+      object.class.model_name.plural
     end
 
     def attributes(options = {})

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -203,7 +203,7 @@ module ActiveModel
             assert_equal expected, alt_adapter.serializable_hash[:included]
           end
 
-          def test_ignore_model_namespace_for_linked_resource_type
+          def test_underscore_model_namespace_for_linked_resource_type
             spammy_post = Post.new(id: 123)
             spammy_post.related = [Spam::UnrelatedLink.new(id: 456)]
             serializer = SpammyPostSerializer.new(spammy_post)
@@ -212,7 +212,7 @@ module ActiveModel
             expected = {
               related: {
                 data: [{
-                  type: 'unrelated_links',
+                  type: 'spam_unrelated_links',
                   id: '456'
                 }]
               }

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,6 +1,10 @@
 class Model
   FILE_DIGEST = Digest::MD5.hexdigest(File.open(__FILE__).read)
 
+  def self.model_name
+    @_model_name ||= ActiveModel::Name.new(self)
+  end
+
   def initialize(hash={})
     @attributes = hash
   end


### PR DESCRIPTION
I propose changing the `Serializer#type` from being based on the classes model_name instead of being based on the class itself.

This provides two advantages:

* It allows the type to be customized at the model layer (currently can only be done at the serializer layer), and the type will be consistent with the other places that rails uses names (like routes).
* The `model_name` memoized so the underscoring and pluralization are only done once, so it should be faster.

It changes the behaviour of namespaced models (was previously demodulized), but the introduction of the demodulization was to change it from `spam/unrelated_links`. I don't know if there is any reason that `unrelated_links` would be preferable to `spam_unrelated_links`
