### PR TITLE
Splitting json adapter into two 

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -6,7 +6,7 @@ module ActionController
 
     include ActionController::Renderers
 
-    ADAPTER_OPTION_KEYS = [:include, :fields, :root, :adapter]
+    ADAPTER_OPTION_KEYS = [:include, :fields, :adapter]
 
     included do
       class_attribute :_serialization_scope

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -168,11 +168,7 @@ module ActiveModel
     end
 
     def json_key
-      if root.nil?
-        self.class.root_name
-      else
-        root
-      end
+      self.class.root_name
     end
 
     def id

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -145,14 +145,6 @@ module ActiveModel
       adapter_class
     end
 
-    def self._root
-      @@root ||= false
-    end
-
-    def self._root=(root)
-      @@root = root
-    end
-
     def self.root_name
       name.demodulize.underscore.sub(/_serializer$/, '') if name
     end
@@ -162,7 +154,7 @@ module ActiveModel
     def initialize(object, options = {})
       @object     = object
       @options    = options
-      @root       = options[:root] || (self.class._root ? self.class.root_name : false)
+      @root       = options[:root]
       @meta       = options[:meta]
       @meta_key   = options[:meta_key]
       @scope      = options[:scope]
@@ -176,7 +168,7 @@ module ActiveModel
     end
 
     def json_key
-      if root == true || root.nil?
+      if root.nil?
         self.class.root_name
       else
         root

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -83,7 +83,7 @@ module ActiveModel
       end
 
       def root
-        serializer.json_key.to_sym
+        serializer.json_key.to_sym if serializer.json_key
       end
 
       def include_meta(json)

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -48,7 +48,7 @@ module ActiveModel
             yield
           end
         elsif is_fragment_cached?
-          FragmentCache.new(self, @cached_serializer, @options, @root).fetch
+          FragmentCache.new(self, @cached_serializer, @options).fetch
         else
           yield
         end

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -87,7 +87,7 @@ module ActiveModel
       end
 
       def include_meta(json)
-        json[meta_key] = meta if meta && root
+        json[meta_key] = meta if meta
         json
       end
     end

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -5,6 +5,7 @@ module ActiveModel
     class Adapter
       extend ActiveSupport::Autoload
       autoload :Json
+      autoload :FlattenJson
       autoload :Null
       autoload :JsonApi
 
@@ -82,7 +83,7 @@ module ActiveModel
       end
 
       def root
-        serializer.json_key
+        serializer.json_key.to_sym
       end
 
       def include_meta(json)

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -82,7 +82,7 @@ module ActiveModel
       end
 
       def root
-        @options.fetch(:root) { serializer.json_key }
+        serializer.json_key
       end
 
       def include_meta(json)

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -22,7 +22,8 @@ module ActiveModel
 
       def as_json(options = {})
         hash = serializable_hash(options)
-        include_meta(hash)
+        include_meta(hash) unless self.class == FlattenJson
+        hash
       end
 
       def self.create(resource, options = {})

--- a/lib/active_model/serializer/adapter/flatten_json.rb
+++ b/lib/active_model/serializer/adapter/flatten_json.rb
@@ -6,10 +6,6 @@ module ActiveModel
           super
           @result
         end
-
-        def root
-          false
-        end
       end
     end
   end

--- a/lib/active_model/serializer/adapter/flatten_json.rb
+++ b/lib/active_model/serializer/adapter/flatten_json.rb
@@ -8,10 +8,10 @@ module ActiveModel
           super
           @result
         end
-      end
 
-      def fragment_cache(cached_hash, non_cached_hash)
-        Json::FragmentCache.new().fragment_cache(cached_hash, non_cached_hash)
+        def root
+          false
+        end
       end
     end
   end

--- a/lib/active_model/serializer/adapter/flatten_json.rb
+++ b/lib/active_model/serializer/adapter/flatten_json.rb
@@ -1,0 +1,18 @@
+require 'active_model/serializer/adapter/json/fragment_cache'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class FlattenJson < Json
+        def serializable_hash(options = {})
+          super
+          @result
+        end
+      end
+
+      def fragment_cache(cached_hash, non_cached_hash)
+        Json::FragmentCache.new().fragment_cache(cached_hash, non_cached_hash)
+      end
+    end
+  end
+end

--- a/lib/active_model/serializer/adapter/flatten_json.rb
+++ b/lib/active_model/serializer/adapter/flatten_json.rb
@@ -1,5 +1,3 @@
-require 'active_model/serializer/adapter/json/fragment_cache'
-
 module ActiveModel
   class Serializer
     class Adapter

--- a/lib/active_model/serializer/adapter/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/fragment_cache.rb
@@ -5,8 +5,7 @@ module ActiveModel
 
         attr_reader :serializer
 
-        def initialize(adapter, serializer, options, root)
-          @root       = root
+        def initialize(adapter, serializer, options)
           @options    = options
           @adapter    = adapter
           @serializer = serializer

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -6,7 +6,7 @@ module ActiveModel
       class Json < Adapter
         def serializable_hash(options = {})
           if serializer.respond_to?(:each)
-            @result = serializer.map{|s| self.class.new(s).serializable_hash }
+            @result = serializer.map{|s| FlattenJson.new(s).serializable_hash }
           else
             @hash = {}
 

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -37,11 +37,7 @@ module ActiveModel
             @result = @core.merge @hash
           end
 
-          if root
-            @result = { root => @result }
-          else
-            @result
-          end
+          { root => @result }
         end
       end
 

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -39,10 +39,11 @@ module ActiveModel
 
           { root => @result }
         end
-      end
 
-      def fragment_cache(cached_hash, non_cached_hash)
-        Json::FragmentCache.new().fragment_cache(cached_hash, non_cached_hash)
+        def fragment_cache(cached_hash, non_cached_hash)
+          Json::FragmentCache.new().fragment_cache(cached_hash, non_cached_hash)
+        end
+
       end
     end
   end

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -6,7 +6,6 @@ module ActiveModel
       class JsonApi < Adapter
         def initialize(serializer, options = {})
           super
-          serializer.root = true
           @hash = { data: [] }
 
           if fields = options.delete(:fields)

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -21,7 +21,7 @@ module ActiveModel
       end
 
       def json_key
-        @objects.first.json_key if @objects.first
+        @objects.first.json_key.pluralize if @objects.first
       end
 
       def root=(root)

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -7,8 +7,6 @@ module ActiveModel
       attr_reader :meta, :meta_key
 
       def initialize(objects, options = {})
-        options.merge!(root: nil)
-
         @objects = objects.map do |object|
           serializer_class = options.fetch(
             :serializer,
@@ -21,7 +19,7 @@ module ActiveModel
       end
 
       def json_key
-        @objects.first.json_key.pluralize if @objects.first
+        @objects.first.json_key if @objects.first
       end
 
       def root=(root)

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -19,7 +19,7 @@ module ActiveModel
       end
 
       def json_key
-        @objects.first.json_key if @objects.first
+        @objects.first.json_key.pluralize if @objects.first
       end
 
       def root=(root)

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -7,7 +7,8 @@ module ActiveModel
       attr_reader :meta, :meta_key
 
       def initialize(objects, options = {})
-        @objects = objects.map do |object|
+        @resource = objects
+        @objects  = objects.map do |object|
           serializer_class = options.fetch(
             :serializer,
             ActiveModel::Serializer.serializer_for(object)
@@ -19,7 +20,11 @@ module ActiveModel
       end
 
       def json_key
-        @objects.first.json_key.pluralize if @objects.first
+        if @objects.first
+          @objects.first.json_key.pluralize
+        else
+          @resource.name.downcase.pluralize if @resource.try(:name)
+        end
       end
 
       def root=(root)

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -6,7 +6,7 @@ module ActiveModel
 
       included do |base|
         base.config.array_serializer = ActiveModel::Serializer::ArraySerializer
-        base.config.adapter = :json
+        base.config.adapter = :flatten_json
       end
     end
   end

--- a/lib/active_model/serializer/fieldset.rb
+++ b/lib/active_model/serializer/fieldset.rb
@@ -12,7 +12,7 @@ module ActiveModel
       end
 
       def fields_for(serializer)
-        key = serializer.json_key || serializer.class.root_name
+        key = serializer.json_key
         fields[key.to_sym]
       end
 

--- a/lib/active_model/serializer/fieldset.rb
+++ b/lib/active_model/serializer/fieldset.rb
@@ -13,7 +13,7 @@ module ActiveModel
 
       def fields_for(serializer)
         key = serializer.json_key
-        fields[key.to_sym]
+        fields[key.to_sym] || fields[key.pluralize.to_sym]
       end
 
     private

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -77,12 +77,10 @@ module ActionController
         get :render_array_using_explicit_serializer
         assert_equal 'application/json', @response.content_type
 
-        expected = {
-          'paginated' => [
-            { 'name' => 'Name 1' },
-            { 'name' => 'Name 2' }
-          ]
-        }
+        expected = [
+          { 'name' => 'Name 1' },
+          { 'name' => 'Name 2' }
+        ]
 
         assert_equal expected.to_json, @response.body
       end

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -10,13 +10,17 @@ module ActionController
         end
 
         def render_using_custom_root
-          @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
-          render json: @profile, root: "custom_root"
+          with_adapter ActiveModel::Serializer::Adapter::Json do
+            @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+            render json: @profile, root: "custom_root"
+          end
         end
 
         def render_using_custom_root_and_meta
-          @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
-          render json: @profile, root: "custom_root", meta: { total: 10 }
+          with_adapter ActiveModel::Serializer::Adapter::Json do
+            @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+            render json: @profile, root: "custom_root", meta: { total: 10 }
+          end
         end
 
         def render_using_default_adapter_root
@@ -34,11 +38,13 @@ module ActionController
         end
 
         def render_array_using_custom_root_and_meta
-          array = [
-            Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
-            Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })
-          ]
-          render json: array, root: "custom_root", meta: { total: 10 }
+          with_adapter ActiveModel::Serializer::Adapter::Json do
+            array = [
+              Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),
+              Profile.new({ name: 'Name 2', description: 'Description 2', comments: 'Comments 2' })
+            ]
+            render json: array, root: "custom_root", meta: { total: 10 }
+          end
         end
 
         def render_array_using_implicit_serializer
@@ -219,6 +225,7 @@ module ActionController
 
       def test_render_array_using_custom_root_and_meta
         get :render_array_using_custom_root_and_meta
+
         assert_equal 'application/json', @response.content_type
 
         expected = { custom_root: [

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -173,20 +173,6 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_using_custom_root
-        get :render_using_custom_root
-
-        assert_equal 'application/json', @response.content_type
-        assert_equal '{"custom_root":{"name":"Name 1","description":"Description 1"}}', @response.body
-      end
-
-      def test_render_using_custom_root_and_meta
-        get :render_using_custom_root_and_meta
-
-        assert_equal 'application/json', @response.content_type
-        assert_equal '{"custom_root":{"name":"Name 1","description":"Description 1"},"meta":{"total":10}}', @response.body
-      end
-
       def test_render_using_default_root
         get :render_using_default_adapter_root
 
@@ -220,26 +206,6 @@ module ActionController
         }
 
         assert_equal 'application/json', @response.content_type
-        assert_equal expected.to_json, @response.body
-      end
-
-      def test_render_array_using_custom_root_and_meta
-        get :render_array_using_custom_root_and_meta
-
-        assert_equal 'application/json', @response.content_type
-
-        expected = { custom_root: [
-          {
-            name: 'Name 1',
-            description: 'Description 1',
-          },
-          {
-            name: 'Name 2',
-            description: 'Description 2',
-          }],
-          meta: { total: 10 }
-        }
-
         assert_equal expected.to_json, @response.body
       end
 

--- a/test/adapter/fragment_cache_test.rb
+++ b/test/adapter/fragment_cache_test.rb
@@ -8,7 +8,7 @@ module ActiveModel
           @role            = Role.new(name: 'Great Author', description:nil)
           @role.author     = [@author]
           @role_serializer = RoleSerializer.new(@role)
-          @role_hash       = FragmentCache.new(RoleSerializer.adapter.new(@role_serializer), @role_serializer, {}, nil)
+          @role_hash       = FragmentCache.new(RoleSerializer.adapter.new(@role_serializer), @role_serializer, {})
         end
 
         def test_fragment_fetch_with_virtual_attributes

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -25,21 +25,21 @@ module ActiveModel
           end
 
           def test_includes_post
-            assert_equal({id: 42, title: 'New Post', body: 'Body'}, @adapter.serializable_hash[:post])
+            assert_equal({id: 42, title: 'New Post', body: 'Body'}, @adapter.serializable_hash[:comment][:post])
           end
 
           def test_include_nil_author
             serializer = PostSerializer.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
-            assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], blog: {id: 999, name: "Custom blog"}, author: nil}, adapter.serializable_hash)
+            assert_equal({post: {title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], blog: {id: 999, name: "Custom blog"}, author: nil}}, adapter.serializable_hash)
           end
 
           def test_include_nil_author_with_specified_serializer
             serializer = PostPreviewSerializer.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
-            assert_equal({title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], author: nil}, adapter.serializable_hash)
+            assert_equal({posts: {title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], author: nil}}, adapter.serializable_hash)
           end
         end
       end

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -28,7 +28,7 @@ module ActiveModel
             @serializer = ArraySerializer.new([@blog], serializer: CustomBlogSerializer)
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
 
-            expected = {custom_blog:[{
+            expected = {custom_blogs:[{
               id: 1,
               special_attribute: "Special",
               articles: [{id: 1,title: "Hello!!", body: "Hello, world!!"}, {id: 2, title: "New Post", body: "Body"}]
@@ -37,7 +37,7 @@ module ActiveModel
           end
 
           def test_include_multiple_posts
-            expected = { post: [{
+            expected = { posts: [{
               title: "Hello!!",
               body: "Hello, world!!",
               id: 1,

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -28,16 +28,16 @@ module ActiveModel
             @serializer = ArraySerializer.new([@blog], serializer: CustomBlogSerializer)
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
 
-            expected = [{
+            expected = {custom_blog:[{
               id: 1,
               special_attribute: "Special",
               articles: [{id: 1,title: "Hello!!", body: "Hello, world!!"}, {id: 2, title: "New Post", body: "Body"}]
-            }]
+            }]}
             assert_equal expected, @adapter.serializable_hash
           end
 
           def test_include_multiple_posts
-            expected = [{
+            expected = { post: [{
               title: "Hello!!",
               body: "Hello, world!!",
               id: 1,
@@ -63,7 +63,7 @@ module ActiveModel
                 id: 999,
                 name: "Custom blog"
               }
-            }]
+            }]}
             assert_equal expected, @adapter.serializable_hash
           end
         end

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -26,7 +26,7 @@ module ActiveModel
             assert_equal([
                            {id: 1, body: 'ZOMG A COMMENT'},
                            {id: 2, body: 'ZOMG ANOTHER COMMENT'}
-                         ], @adapter.serializable_hash[:comments])
+                         ], @adapter.serializable_hash[:post][:comments])
           end
         end
       end

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -86,7 +86,6 @@ module ActiveModel
                 }
               }
             ]
-
             assert_equal(expected, @adapter.serializable_hash[:data])
           end
 

--- a/test/adapter/json_test.rb
+++ b/test/adapter/json_test.rb
@@ -25,7 +25,7 @@ module ActiveModel
           assert_equal([
                          {id: 1, body: 'ZOMG A COMMENT'},
                          {id: 2, body: 'ZOMG ANOTHER COMMENT'}
-                       ], @adapter.serializable_hash[:comments])
+                       ], @adapter.serializable_hash[:post][:comments])
         end
       end
     end

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -31,7 +31,7 @@ module ActiveModel
 
       def test_create_adapter
         adapter = ActiveModel::Serializer::Adapter.create(@serializer)
-        assert_equal ActiveModel::Serializer::Adapter::Json, adapter.class
+        assert_equal ActiveModel::Serializer::Adapter::FlattenJson, adapter.class
       end
 
       def test_create_adapter_with_override

--- a/test/serializers/adapter_for_test.rb
+++ b/test/serializers/adapter_for_test.rb
@@ -11,7 +11,7 @@ module ActiveModel
 
       def test_returns_default_adapter
         adapter = ActiveModel::Serializer.adapter
-        assert_equal ActiveModel::Serializer::Adapter::Json, adapter
+        assert_equal ActiveModel::Serializer::Adapter::FlattenJson, adapter
       end
 
       def test_overwrite_adapter_with_symbol

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -15,13 +15,13 @@ module ActiveModel
 
       def test_json_serializable_hash
         adapter = ActiveModel::Serializer::Adapter::Json.new(@blog_serializer)
-        assert_equal({:id=>1, :title=>"AMS Hints"}, adapter.serializable_hash)
+        assert_equal({alternate_blog: { id:1, title:"AMS Hints"}}, adapter.serializable_hash)
       end
 
       def test_attribute_inheritance_with_key
         inherited_klass = Class.new(AlternateBlogSerializer)
         blog_serializer = inherited_klass.new(@blog)
-        adapter = ActiveModel::Serializer::Adapter::Json.new(blog_serializer)
+        adapter = ActiveModel::Serializer::Adapter::FlattenJson.new(blog_serializer)
         assert_equal({:id=>1, :title=>"AMS Hints"}, adapter.serializable_hash)
       end
 

--- a/test/serializers/configuration_test.rb
+++ b/test/serializers/configuration_test.rb
@@ -8,7 +8,7 @@ module ActiveModel
       end
 
       def test_default_adapter
-        assert_equal :json, ActiveModel::Serializer.config.adapter
+        assert_equal :flatten_json, ActiveModel::Serializer.config.adapter
       end
     end
   end

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -12,9 +12,10 @@ module ActiveModel
       end
 
       def test_meta_is_present_with_root
-        adapter = load_adapter(root: "blog", meta: {total: 10})
+        serializer = AlternateBlogSerializer.new(@blog, root: "blog", meta: {total: 10})
+        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, root: 'blog')
         expected = {
-          "blog" => {
+          blog: {
             id: 1,
             title: "AMS Hints"
           },
@@ -35,9 +36,10 @@ module ActiveModel
       end
 
       def test_meta_key_is_used
-        adapter = load_adapter(root: "blog", meta: {total: 10}, meta_key: "haha_meta")
+        serializer = AlternateBlogSerializer.new(@blog, root: 'blog', meta: {total: 10}, meta_key: "haha_meta")
+        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, root: 'blog')
         expected = {
-          "blog" => {
+          blog: {
             id: 1,
             title: "AMS Hints"
           },
@@ -50,7 +52,7 @@ module ActiveModel
 
       def test_meta_is_not_present_on_arrays_without_root
         serializer = ArraySerializer.new([@blog], meta: {total: 10})
-        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+        adapter = ActiveModel::Serializer::Adapter::FlattenJson.new(serializer)
         expected = [{
           id: 1,
           name: "AMS Hints",
@@ -71,7 +73,7 @@ module ActiveModel
         serializer = ArraySerializer.new([@blog], meta: {total: 10}, meta_key: "haha_meta")
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, root: 'blog')
         expected = {
-          'blog' => [{
+          blog: [{
             id: 1,
             name: "AMS Hints",
             writer: {
@@ -98,7 +100,7 @@ module ActiveModel
           options.partition { |k, _| ActionController::Serialization::ADAPTER_OPTION_KEYS.include? k }.map { |h| Hash[h] }
 
         serializer = AlternateBlogSerializer.new(@blog, serializer_opts)
-        ActiveModel::Serializer::Adapter::Json.new(serializer, adapter_opts)
+        ActiveModel::Serializer::Adapter::FlattenJson.new(serializer, adapter_opts)
       end
     end
   end

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -12,10 +12,10 @@ module ActiveModel
       end
 
       def test_meta_is_present_with_root
-        serializer = AlternateBlogSerializer.new(@blog, root: "blog", meta: {total: 10})
+        serializer = AlternateBlogSerializer.new(@blog, meta: {total: 10})
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, root: 'blog')
         expected = {
-          blog: {
+          alternate_blog: {
             id: 1,
             title: "AMS Hints"
           },
@@ -39,7 +39,7 @@ module ActiveModel
         serializer = AlternateBlogSerializer.new(@blog, root: 'blog', meta: {total: 10}, meta_key: "haha_meta")
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, root: 'blog')
         expected = {
-          blog: {
+          alternate_blog: {
             id: 1,
             title: "AMS Hints"
           },
@@ -73,7 +73,7 @@ module ActiveModel
         serializer = ArraySerializer.new([@blog], meta: {total: 10}, meta_key: "haha_meta")
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, root: 'blog')
         expected = {
-          blog: [{
+          blogs: [{
             id: 1,
             name: "AMS Hints",
             writer: {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,6 @@ class Foo < Rails::Application
     config.active_support.test_order = :random
     config.logger = Logger.new(nil)
     ActionController::Base.cache_store = :memory_store
-    ActiveModel::Serializer.config.adapter = :flatten_json
   end
 end
 FileUtils.mkdir_p(File.expand_path('../../tmp/cache', __FILE__))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,7 @@ class Foo < Rails::Application
     config.active_support.test_order = :random
     config.logger = Logger.new(nil)
     ActionController::Base.cache_store = :memory_store
+    ActiveModel::Serializer.config.adapter = :flatten_json
   end
 end
 FileUtils.mkdir_p(File.expand_path('../../tmp/cache', __FILE__))


### PR DESCRIPTION
We discussed about the ```root``` option and how it shouldn't be a config but a different adapter itself.

This PR create a ```FlattenJson``` adapter that doesn't support ```root```, the ```Json``` adapter in the other hand will now have ```root``` by default and you will still be able to manually set it with the ```root``` option.

```FlattenJson``` is now the default adapter, the result still will be the same we had before, when the default was ```Json``` adapter without root.