### PR TITLE
Rendering array objects that doesn't have serializers

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -43,10 +43,10 @@ module ActionController
           @_serializer_opts[:scope_name] = _serialization_scope
 
           begin
-            object   = serializer.new(resource, @_serializer_opts)
-          rescue ActiveModel::Serializer::ArraySerializer::Error
+            serialized = serializer.new(resource, @_serializer_opts)
+          rescue ActiveModel::Serializer::ArraySerializer::NoSerializerError
           else
-            resource = ActiveModel::Serializer::Adapter.create(object, @_adapter_opts)
+            resource = ActiveModel::Serializer::Adapter.create(serialized, @_adapter_opts)
           end
         end
 

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -39,17 +39,19 @@ module ActionController
           options.partition { |k, _| ADAPTER_OPTION_KEYS.include? k }.map { |h| Hash[h] }
 
         if use_adapter? && (serializer = get_serializer(resource))
-
           @_serializer_opts[:scope] ||= serialization_scope
           @_serializer_opts[:scope_name] = _serialization_scope
 
-          # omg hax
-          object = serializer.new(resource, @_serializer_opts)
-          adapter = ActiveModel::Serializer::Adapter.create(object, @_adapter_opts)
-          super(adapter, options)
-        else
-          super(resource, options)
+          object   = serializer.new(resource, @_serializer_opts)
+
+          if serializer == ActiveModel::Serializer.config.array_serializer
+            resource = ActiveModel::Serializer::Adapter.create(object, @_adapter_opts) unless object.objects.all? {|i| i.nil?}
+          else
+            resource = ActiveModel::Serializer::Adapter.create(object, @_adapter_opts)
+          end
         end
+
+        super(resource, options)
       end
     end
 

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -42,10 +42,9 @@ module ActionController
           @_serializer_opts[:scope] ||= serialization_scope
           @_serializer_opts[:scope_name] = _serialization_scope
 
-          object   = serializer.new(resource, @_serializer_opts)
-
-          if serializer == ActiveModel::Serializer.config.array_serializer
-            resource = ActiveModel::Serializer::Adapter.create(object, @_adapter_opts) unless object.objects.all? {|i| i.nil?}
+          begin
+            object   = serializer.new(resource, @_serializer_opts)
+          rescue ActiveModel::Serializer::ArraySerializer::Error
           else
             resource = ActiveModel::Serializer::Adapter.create(object, @_adapter_opts)
           end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -206,10 +206,22 @@ module ActiveModel
         serializer_class = ActiveModel::Serializer.serializer_for(association_value, association_options)
 
         if serializer_class
-          serializer = serializer_class.new(
-            association_value,
-            options.except(:serializer).merge(serializer_from_options(association_options))
-          )
+          begin
+            serializer = serializer_class.new(
+              association_value,
+              options.except(:serializer).merge(serializer_from_options(association_options))
+            )
+          rescue NoMethodError
+            # 1. Failure to serialize an element in a collection, e.g. [ {hi: "Steve" } ] will fail
+            #    with NoMethodError when the ArraySerializer finds no serializer for the hash { hi: "Steve" },
+            #    and tries to call new on that nil.
+            # 2. Convert association_value to hash using implicit as_json
+            # 3. Set as virtual value (serializer is nil)
+            # 4. Consider warning when this happens
+            virtual_value = association_value
+            virtual_value = virtual_value.as_json if virtual_value.respond_to?(:as_json)
+            association_options[:association_options][:virtual_value] = virtual_value
+          end
         elsif !association_value.nil? && !association_value.instance_of?(Object)
           association_options[:association_options][:virtual_value] = association_value
         end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -211,13 +211,7 @@ module ActiveModel
               association_value,
               options.except(:serializer).merge(serializer_from_options(association_options))
             )
-          rescue ActiveModel::Serializer::ArraySerializer::Error
-            # 1. Failure to serialize an element in a collection, e.g. [ {hi: "Steve" } ] will fail
-            #    with NoMethodError when the ArraySerializer finds no serializer for the hash { hi: "Steve" },
-            #    and tries to call new on that nil.
-            # 2. Convert association_value to hash using implicit as_json
-            # 3. Set as virtual value (serializer is nil)
-            # 4. Consider warning when this happens
+          rescue ActiveModel::Serializer::ArraySerializer::NoSerializerError
             virtual_value = association_value
             virtual_value = virtual_value.as_json if virtual_value.respond_to?(:as_json)
             association_options[:association_options][:virtual_value] = virtual_value

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -211,7 +211,7 @@ module ActiveModel
               association_value,
               options.except(:serializer).merge(serializer_from_options(association_options))
             )
-          rescue NoMethodError
+          rescue ActiveModel::Serializer::ArraySerializer::Error
             # 1. Failure to serialize an element in a collection, e.g. [ {hi: "Steve" } ] will fail
             #    with NoMethodError when the ArraySerializer finds no serializer for the hash { hi: "Steve" },
             #    and tries to call new on that nil.

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -1,6 +1,7 @@
 module ActiveModel
   class Serializer
     class ArraySerializer
+      Error = Class.new(StandardError)
       include Enumerable
       delegate :each, to: :@objects
 
@@ -14,7 +15,9 @@ module ActiveModel
             ActiveModel::Serializer.serializer_for(object)
           )
 
-          unless serializer_class.nil?
+          if serializer_class.nil?
+            fail Error, "No serializer found for object: #{object.inspect}"
+          else
             serializer_class.new(object, options.except(:serializer))
           end
         end

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -1,11 +1,11 @@
 module ActiveModel
   class Serializer
     class ArraySerializer
-      Error = Class.new(StandardError)
+      NoSerializerError = Class.new(StandardError)
       include Enumerable
       delegate :each, to: :@objects
 
-      attr_reader :meta, :meta_key, :objects
+      attr_reader :meta, :meta_key
 
       def initialize(objects, options = {})
         @resource = objects
@@ -16,7 +16,7 @@ module ActiveModel
           )
 
           if serializer_class.nil?
-            fail Error, "No serializer found for object: #{object.inspect}"
+            fail NoSerializerError, "No serializer found for object: #{object.inspect}"
           else
             serializer_class.new(object, options.except(:serializer))
           end

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -4,7 +4,7 @@ module ActiveModel
       include Enumerable
       delegate :each, to: :@objects
 
-      attr_reader :meta, :meta_key
+      attr_reader :meta, :meta_key, :objects
 
       def initialize(objects, options = {})
         @resource = objects
@@ -13,7 +13,10 @@ module ActiveModel
             :serializer,
             ActiveModel::Serializer.serializer_for(object)
           )
-          serializer_class.new(object, options.except(:serializer))
+
+          unless serializer_class.nil?
+            serializer_class.new(object, options.except(:serializer))
+          end
         end
         @meta     = options[:meta]
         @meta_key = options[:meta_key]

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -47,6 +47,14 @@ module ActionController
           render json: @post
         end
 
+        def render_json_object_without_serializer
+          render json: {error: 'Result is Invalid'}
+        end
+
+        def render_json_array_object_without_serializer
+          render json: [{error: 'Result is Invalid'}]
+        end
+
         def update_and_render_object_with_cache_enabled
           @post.updated_at = DateTime.now
 
@@ -158,6 +166,20 @@ module ActionController
 
         assert_equal 'application/json', @response.content_type
         assert_equal expected.to_json, @response.body
+      end
+
+      def test_render_json_object_without_serializer
+        get :render_json_object_without_serializer
+
+        assert_equal 'application/json', @response.content_type
+        assert_equal ({error: 'Result is Invalid'}).to_json, @response.body
+      end
+
+      def test_render_json_array_object_without_serializer
+        get :render_json_array_object_without_serializer
+
+        assert_equal 'application/json', @response.content_type
+        assert_equal ([{error: 'Result is Invalid'}]).to_json, @response.body
       end
 
       def test_render_array_using_implicit_serializer

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -38,7 +38,7 @@ module ActiveModel
               tags: [
                 {"attributes"=>{"id"=>1, "name"=>"#hash_tag"}}
               ]
-            }, adapter.serializable_hash[:post_with_tags])
+            }.to_json, adapter.serializable_hash[:post_with_tags].to_json)
           end
         end
       end

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -8,7 +8,7 @@ module ActiveModel
           def setup
             ActionController::Base.cache_store.clear
             @author = Author.new(id: 1, name: 'Steve K.')
-            @post = Post.new(title: 'New Post', body: 'Body')
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
             @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
             @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
             @post.comments = [@first_comment, @second_comment]
@@ -19,22 +19,26 @@ module ActiveModel
             @post.blog = @blog
             @tag = Tag.new(id: 1, name: "#hash_tag")
             @post.tags = [@tag]
-
-            @serializer = PostSerializer.new(@post)
-            @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
           end
 
           def test_has_many
+            serializer = PostSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
             assert_equal([
                            {id: 1, body: 'ZOMG A COMMENT'},
                            {id: 2, body: 'ZOMG ANOTHER COMMENT'}
-                         ], @adapter.serializable_hash[:post][:comments])
+                         ], adapter.serializable_hash[:post][:comments])
           end
 
           def test_has_many_with_no_serializer
             serializer = PostWithTagsSerializer.new(@post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
-            assert_includes(adapter.as_json, :tags)
+            assert_equal({
+              id: 42,
+              tags: [
+                {"attributes"=>{"id"=>1, "name"=>"#hash_tag"}}
+              ]
+            }, adapter.serializable_hash[:post_with_tags])
           end
         end
       end

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -17,6 +17,8 @@ module ActiveModel
             @second_comment.post = @post
             @blog = Blog.new(id: 1, name: "My Blog!!")
             @post.blog = @blog
+            @tag = Tag.new(id: 1, name: "#hash_tag")
+            @post.tags = [@tag]
 
             @serializer = PostSerializer.new(@post)
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
@@ -28,9 +30,14 @@ module ActiveModel
                            {id: 2, body: 'ZOMG ANOTHER COMMENT'}
                          ], @adapter.serializable_hash[:post][:comments])
           end
+
+          def test_has_many_with_no_serializer
+            serializer = PostWithTagsSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+            assert_includes(adapter.as_json, :tags)
+          end
         end
       end
     end
   end
 end
-

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -115,7 +115,7 @@ module ActiveModel
                 id: "1",
                 type: "posts",
                 relationships: {
-                  tags: {:data=>nil}
+                  tags: { data: nil }
                 }
               }
             }, adapter.serializable_hash)

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -29,7 +29,6 @@ module ActiveModel
             @post_without_comments.blog = nil
             @tag = Tag.new(id: 1, name: "#hash_tag")
             @post.tags = [@tag]
-
             @serializer = PostSerializer.new(@post)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
           end
@@ -97,6 +96,7 @@ module ActiveModel
             serializer = BlogSerializer.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
             actual = adapter.serializable_hash[:data][:relationships][:articles]
+
             expected = {
               data: [{
                 type: "posts",
@@ -109,7 +109,16 @@ module ActiveModel
           def test_has_many_with_no_serializer
             serializer = PostWithTagsSerializer.new(@post)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
-            assert_includes(adapter.serializable_hash, :tags)
+
+            assert_equal({
+              data: {
+                id: "1",
+                type: "posts",
+                relationships: {
+                  tags: {:data=>nil}
+                }
+              }
+            }, adapter.serializable_hash)
           end
         end
       end

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -27,6 +27,8 @@ module ActiveModel
             @blog.articles = [@post]
             @post.blog = @blog
             @post_without_comments.blog = nil
+            @tag = Tag.new(id: 1, name: "#hash_tag")
+            @post.tags = [@tag]
 
             @serializer = PostSerializer.new(@post)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
@@ -102,6 +104,12 @@ module ActiveModel
               }]
             }
             assert_equal expected, actual
+          end
+
+          def test_has_many_with_no_serializer
+            serializer = PostWithTagsSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
+            assert_includes(adapter.serializable_hash, :tags)
           end
         end
       end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -76,6 +76,7 @@ Role     = Class.new(Model)
 User     = Class.new(Model)
 Location = Class.new(Model)
 Place    = Class.new(Model)
+Tag      = Class.new(Model)
 Comment  = Class.new(Model) do
   # Uses a custom non-time-based cache key
   def cache_key
@@ -222,6 +223,12 @@ PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
 
   has_many :comments, serializer: CommentPreviewSerializer
   belongs_to :author, serializer: AuthorPreviewSerializer
+end
+
+PostWithTagsSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id
+
+  has_many :tags
 end
 
 Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -71,7 +71,7 @@ module ActiveModel
         PostWithTagsSerializer.new(@post).each_association do |name, serializer, options|
           assert_equal name, :tags
           assert_equal serializer, nil
-          assert_equal [{ attributes: { name: "#hashtagged" }}].as_json, options[:virtual_value]
+          assert_equal [{ attributes: { name: "#hashtagged" }}].to_json, options[:virtual_value].to_json
         end
       end
 

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -71,7 +71,7 @@ module ActiveModel
         PostWithTagsSerializer.new(@post).each_association do |name, serializer, options|
           assert_equal name, :tags
           assert_equal serializer, nil
-          assert_equal options, {:virtual_value=>[{"attributes"=>{"name"=>"#hashtagged"}}]}
+          assert_equal [{ attributes: { name: "#hashtagged" }}].as_json, options[:virtual_value]
         end
       end
 

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -29,8 +29,10 @@ module ActiveModel
         @author.roles = []
         @blog = Blog.new({ name: 'AMS Blog' })
         @post = Post.new({ title: 'New Post', body: 'Body' })
+        @tag = Tag.new({name: '#hashtagged'})
         @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
         @post.comments = [@comment]
+        @post.tags = [@tag]
         @post.blog = @blog
         @comment.post = @post
         @comment.author = nil
@@ -62,6 +64,12 @@ module ActiveModel
           else
             flunk "Unknown association: #{name}"
           end
+        end
+      end
+
+      def test_has_many_with_no_serializer
+        PostWithTagsSerializer.new(@post).each_association do |name, serializer, options|
+          puts "The line above will crash this test"
         end
       end
 

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -69,7 +69,9 @@ module ActiveModel
 
       def test_has_many_with_no_serializer
         PostWithTagsSerializer.new(@post).each_association do |name, serializer, options|
-          puts "The line above will crash this test"
+          assert_equal name, :tags
+          assert_equal serializer, nil
+          assert_equal options, {:virtual_value=>[{"attributes"=>{"name"=>"#hashtagged"}}]}
         end
       end
 


### PR DESCRIPTION
As reported on #772 and #945.
There was a crash when rendering arrays that don't consist of "serializables" classes.
This PR is a first implementation to quickly fix it.

**P.S.** It won't fix #877 yet. 
**P.S.** #954 will need to be updated based on this once merged, around [here](https://github.com/rails-api/active_model_serializers/pull/954/files#diff-07e5a5aaa325f8dc2bcf944d12f0db83R32)