### PR TITLE
serializable_hash and as_json should take options = nil

### DIFF
--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -16,11 +16,11 @@ module ActiveModel
         @options = options
       end
 
-      def serializable_hash(options = {})
+      def serializable_hash(options = nil)
         raise NotImplementedError, 'This is an abstract method. Should be implemented at the concrete adapter.'
       end
 
-      def as_json(options = {})
+      def as_json(options = nil)
         hash = serializable_hash(options)
         include_meta(hash) unless self.class == FlattenJson
         hash

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -4,9 +4,10 @@ module ActiveModel
   class Serializer
     class Adapter
       class Json < Adapter
-        def serializable_hash(options = {})
+        def serializable_hash(options = nil)
+          options ||= {}
           if serializer.respond_to?(:each)
-            @result = serializer.map{|s| FlattenJson.new(s).serializable_hash }
+            @result = serializer.map{|s| FlattenJson.new(s).serializable_hash(options) }
           else
             @hash = {}
 

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -15,10 +15,11 @@ module ActiveModel
           end
         end
 
-        def serializable_hash(options = {})
+        def serializable_hash(options = nil)
+          options = {}
           if serializer.respond_to?(:each)
             serializer.each do |s|
-              result = self.class.new(s, @options.merge(fieldset: @fieldset)).serializable_hash
+              result = self.class.new(s, @options.merge(fieldset: @fieldset)).serializable_hash(options)
               @hash[:data] << result[:data]
 
               if result[:included]
@@ -27,7 +28,7 @@ module ActiveModel
               end
             end
           else
-            @hash[:data] = attributes_for_serializer(serializer, @options)
+            @hash[:data] = attributes_for_serializer(serializer, options)
             add_resource_relationships(@hash[:data], serializer)
           end
           @hash

--- a/lib/active_model/serializer/adapter/null.rb
+++ b/lib/active_model/serializer/adapter/null.rb
@@ -2,7 +2,7 @@ module ActiveModel
   class Serializer
     class Adapter
       class Null < Adapter
-        def serializable_hash(options = {})
+        def serializable_hash(options = nil)
           {}
         end
       end


### PR DESCRIPTION
per ActiveModel::Serialization#serializable_hash 
https://github.com/rails/rails/blob/96bb004fc6e67cdf1b873f11ad5f8efd06949797/activemodel/lib/active_model/serialization.rb
```ruby
   def serializable_hash(options = nil)
       options ||= {}
```

Otherwise, passing in nil to `as_json` or `serializable_hash` makes things
blow up when passing nil into attributes

Extracted from https://github.com/rails-api/active_model_serializers/pull/954