### PR TITLE
Fix transient tests failures

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rails", ">= 4.0"
   spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "timecop", ">= 0.7"
   spec.add_development_dependency "rake"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 
+require 'timecop'
 require 'rails'
 require 'action_controller'
 require 'action_controller/test_case'


### PR DESCRIPTION
These changes fix the issue #961.

I added the timecop gem as suggested by @kurko. 

Freezing the time in the two tests should fix the transient failures.