### PR TITLE
Capture app warnings on test run

### DIFF
--- a/test/capture_warnings.rb
+++ b/test/capture_warnings.rb
@@ -1,0 +1,57 @@
+# https://raw.githubusercontent.com/metric_fu/metric_fu/master/spec/capture_warnings.rb
+require "tempfile"
+require "fileutils"
+
+class CaptureWarnings
+  def initialize(fail_on_warnings = true)
+    @fail_on_warnings = fail_on_warnings
+    @stderr_file = Tempfile.new("app.stderr")
+    @app_root ||= Dir.pwd
+    @output_dir = File.join(app_root, "tmp")
+    FileUtils.mkdir_p(output_dir)
+    @bundle_dir = File.join(app_root, "bundle")
+  end
+
+  def before_tests
+    $stderr.reopen(stderr_file.path)
+    $VERBOSE = true
+    at_exit { $stderr.reopen(STDERR) }
+  end
+
+  def after_tests
+    stderr_file.rewind
+    lines = stderr_file.read.split("\n").uniq
+    stderr_file.close!
+
+    $stderr.reopen(STDERR)
+
+    app_warnings, other_warnings = lines.partition { |line|
+      line.include?(app_root) && !line.include?(bundle_dir)
+    }
+
+    if app_warnings.any?
+      puts <<-WARNINGS
+#{'-' * 30} app warnings: #{'-' * 30}
+
+#{app_warnings.join("\n")}
+
+#{'-' * 75}
+      WARNINGS
+    end
+
+    if other_warnings.any?
+      File.write(File.join(output_dir, "warnings.txt"), other_warnings.join("\n") << "\n")
+      puts
+      puts "Non-app warnings written to tmp/warnings.txt"
+      puts
+    end
+
+    # fail the build...
+    if fail_on_warnings && app_warnings.any?
+      abort "Failing build due to app warnings: #{app_warnings.inspect}"
+    end
+  end
+
+  private
+  attr_reader :stderr_file, :app_root, :output_dir, :bundle_dir, :fail_on_warnings
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,12 @@ require 'fileutils'
 # Ensure backward compatibility with Minitest 4
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
+require "capture_warnings"
+@capture_warnings = CaptureWarnings.new(fail_build = false)
+@capture_warnings.before_tests
+at_exit do
+  @capture_warnings.after_tests
+end
 require 'active_model_serializers'
 
 class Foo < Rails::Application


### PR DESCRIPTION
Once we fix the warnings we can easily flip the bit and make them fail the tests

MiniTest doesn't appear to have a before/after suite like RSpec does

I've set `@capture_warnings = CaptureWarnings.new(fail_build = false)`. So, it'll just print 'em out. Once we smite them, we can set `@capture_warnings = CaptureWarnings.new(fail_build = true)`

Here's warnings copied from one of the Travis builds.

```plain
------------------------------ app warnings: ------------------------------
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer.rb:244: warning: private attribute?
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/fieldset.rb:21: warning: private attribute?
/home/travis/build/rails-api/active_model_serializers/test/fixtures/poro.rb:96: warning: method redefined; discarding old blog
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer.rb:105: warning: previous definition of blog was here
/home/travis/build/rails-api/active_model_serializers/test/fixtures/poro.rb:139: warning: method redefined; discarding old slug
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer.rb:41: warning: previous definition of slug was here
/home/travis/build/rails-api/active_model_serializers/test/fixtures/poro.rb:158: warning: method redefined; discarding old place
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer.rb:105: warning: previous definition of place was here
/home/travis/build/rails-api/active_model_serializers/test/fixtures/poro.rb:245: warning: method redefined; discarding old reviews
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer.rb:105: warning: previous definition of reviews was here
/home/travis/build/rails-api/active_model_serializers/test/fixtures/poro.rb:248: warning: method redefined; discarding old maker
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer.rb:105: warning: previous definition of maker was here
/home/travis/build/rails-api/active_model_serializers/test/action_controller/serialization_scope_name_test.rb:7: warning: method redefined; discarding old admin?
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer.rb:41: warning: previous definition of admin? was here
/home/travis/build/rails-api/active_model_serializers/test/action_controller/serialization_scope_name_test.rb:37: warning: method redefined; discarding old admin?
/home/travis/build/rails-api/active_model_serializers/test/action_controller/serialization_test.rb:111: warning: assigned but unused variable - author
/home/travis/build/rails-api/active_model_serializers/test/action_controller/serialization_test.rb:176: warning: (...) interpreted as grouped expression
/home/travis/build/rails-api/active_model_serializers/test/action_controller/serialization_test.rb:183: warning: (...) interpreted as grouped expression
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter.rb:57: warning: mismatched indentations at 'end' with 'def' at 45
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/fragment_cache.rb:3: warning: loading in progress, circular require considered harmful - /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter.rb
	from /home/travis/build/rails-api/active_model_serializers/test/adapter/fragment_cache_test.rb:2:in `<top (required)>'
	from /home/travis/build/rails-api/active_model_serializers/test/adapter/fragment_cache_test.rb:3:in `<module:ActiveModel>'
	from /home/travis/build/rails-api/active_model_serializers/test/adapter/fragment_cache_test.rb:4:in `<class:Serializer>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter.rb:1:in `<top (required)>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/fragment_cache.rb:1:in `<top (required)>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/fragment_cache.rb:2:in `<module:ActiveModel>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/fragment_cache.rb:3:in `<class:Serializer>'
/home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/json/fragment_cache.rb:4: warning: loading in progress, circular require considered harmful - /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/json.rb
	from /home/travis/build/rails-api/active_model_serializers/test/adapter/json/belongs_to_test.rb:3:in `<top (required)>'
	from /home/travis/build/rails-api/active_model_serializers/test/adapter/json/belongs_to_test.rb:4:in `<module:ActiveModel>'
	from /home/travis/build/rails-api/active_model_serializers/test/adapter/json/belongs_to_test.rb:5:in `<class:Serializer>'
	from /home/travis/build/rails-api/active_model_serializers/test/adapter/json/belongs_to_test.rb:6:in `<class:Adapter>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/json.rb:1:in `<top (required)>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/json/fragment_cache.rb:1:in `<top (required)>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/json/fragment_cache.rb:2:in `<module:ActiveModel>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/serializer/adapter/json/fragment_cache.rb:3:in `<class:Serializer>'
	from /home/travis/build/rails-api/active_model_serializers/lib/active_model/seri
---------------------------------------------------------------------------

```