### PR TITLE
Pagination Serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -5,6 +5,7 @@ module ActiveModel
     extend ActiveSupport::Autoload
     autoload :Configuration
     autoload :ArraySerializer
+    autoload :PaginationSerializer
     autoload :Adapter
     include Configuration
 

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -18,6 +18,8 @@ module ActiveModel
         def serializable_hash(options = nil)
           options = {}
           if serializer.respond_to?(:each)
+            add_pagination if serializer.class == PaginationSerializer
+
             serializer.each do |s|
               result = self.class.new(s, @options.merge(fieldset: @fieldset)).serializable_hash(options)
               @hash[:data] << result[:data]
@@ -79,6 +81,23 @@ module ActiveModel
               add_included(name, association, resource_path) if association
             end if include_nested_assoc? resource_path
           end
+        end
+
+        def add_pagination
+          return if serializer.page_size.nil? || serializer.page_number.nil?
+
+          total_objects = serializer.count
+          total_pages   = (total_objects / serializer.page_size).ceil
+          prev = serializer.page_number == 1 ? nil : "?page[size]=#{serializer.page_size}&page[number]=#{serializer.page_number - 1}"
+          last = serializer.page_number == total_pages ? nil : "?page[size]=#{serializer.page_size}&page[number]=#{serializer.page_number + 1}"
+
+          @hash[:links] = {
+            self:  "?page[size]=#{serializer.page_size}&page[number]=#{serializer.page_number}",
+            first: "?page[size]=#{serializer.page_size}&page[number]=1",
+            last:  "?page[size]=#{serializer.page_size}&page[number]=#{total_pages}",
+            prev:  prev,
+            next:  last
+          }
         end
 
         def attributes_for_serializer(serializer, options)

--- a/lib/active_model/serializer/pagination_serializer.rb
+++ b/lib/active_model/serializer/pagination_serializer.rb
@@ -1,0 +1,16 @@
+module ActiveModel
+  class Serializer
+    class PaginationSerializer < ArraySerializer
+      attr_reader :page_size, :page_number
+
+      def initialize(objects, options = {})
+        @page_size   = options.delete(:page_size)
+        @page_number = options.delete(:page_number)
+
+        super
+
+        @objects = @objects.first.instance_variable_get('@objects')
+      end
+    end
+  end
+end

--- a/test/adapter/json_api/pagination_test.rb
+++ b/test/adapter/json_api/pagination_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi
+        class PaginationTest < Minitest::Test
+          def setup
+            @posts = (1..100).map do |i|
+              Post.new(id: i, title: "Post #{i}", body: "Body #{i}").tap do |post|
+                post.comments = []
+                post.author = Author.new(id: 1, name: 'Steve K.')
+              end
+            end
+            @serializer = ActiveModel::Serializer::PaginationSerializer.new([@posts], page_size: 10, page_number: 1)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
+            ActionController::Base.cache_store.clear
+          end
+
+          def test_pagination_links_for_first_page
+            @serializer = ActiveModel::Serializer::PaginationSerializer.new([@posts], page_size: 10, page_number: 1)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
+
+            expected = {
+              self:  "?page[size]=10&page[number]=1",
+              first: "?page[size]=10&page[number]=1",
+              last:  "?page[size]=10&page[number]=10",
+              prev:  nil,
+              next:  "?page[size]=10&page[number]=2"
+            }
+
+            assert_equal(expected, @adapter.serializable_hash[:links])
+          end
+
+          def test_pagination_links_for_middle_page
+            @serializer = ActiveModel::Serializer::PaginationSerializer.new([@posts], page_size: 5, page_number: 5)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
+
+            expected = {
+              self:  "?page[size]=5&page[number]=5",
+              first: "?page[size]=5&page[number]=1",
+              last:  "?page[size]=5&page[number]=20",
+              prev:  "?page[size]=5&page[number]=4",
+              next:  "?page[size]=5&page[number]=6"
+            }
+
+            assert_equal(expected, @adapter.serializable_hash[:links])
+          end
+
+          def test_pagination_links_for_last_page
+            @serializer = ActiveModel::Serializer::PaginationSerializer.new([@posts], page_size: 9, page_number: 11)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
+
+            expected = {
+              self:  "?page[size]=9&page[number]=11",
+              first: "?page[size]=9&page[number]=1",
+              last:  "?page[size]=9&page[number]=11",
+              prev:  "?page[size]=9&page[number]=10",
+              next:  nil,
+            }
+
+            assert_equal(expected, @adapter.serializable_hash[:links])
+          end
+
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the params for pagination as specified in one alternative
of the JSON API spec http://jsonapi.org/format/#fetching-pagination.

The Pagination Serializer, built on top of the ArraySerializer, allows a
user to pass in two params, page_size and page_number to create a links
attribute in the hash. Note that "number and size" is just one
alternative listed in the JSON API spec.