### PR TITLE
fix generators template bug

### DIFF
--- a/lib/generators/serializer/templates/serializer.rb
+++ b/lib/generators/serializer/templates/serializer.rb
@@ -1,8 +1,8 @@
 <% module_namespacing do -%>
 class <%= class_name %>Serializer < <%= parent_class_name %>
   attributes <%= attributes_names.map(&:inspect).join(", ") %>
-end
 <% association_names.each do |attribute| -%>
   has_one :<%= attribute %>
 <% end -%>
+end
 <% end -%>

--- a/test/generators/serializer_generator_test.rb
+++ b/test/generators/serializer_generator_test.rb
@@ -39,6 +39,7 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
     assert_file "app/serializers/account_serializer.rb" do |serializer|
       assert_match(/^  attributes :id, :name, :description$/, serializer)
       assert_match(/^  has_one :business$/, serializer)
+      assert_match(/^end\n*\z/, serializer)
     end
   end
 


### PR DESCRIPTION
My environment is

```
rails 4.2.3
active_model_serializers 0.10.0.rc2
```

When I executed this code

`$ bin/rails g resource item name:string price:integer user:references`

and generate this code

``` app/serializers/item_serializer.rb
class ItemSerializer < ActiveModel::Serializer
  attributes :id, :name, :price
end
  attribute :user 
```

I think generator template has a bug, and I fixed it.