### PR TITLE
Add info to README about changing root key for the JSON adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,17 @@ Doesn't follow any specifc convention.
 
 #### JSON
 
-It also generates a json response but always with a root key. The root key **can't be overridden**, and will be automatically defined accordingly with the objects being serialized.
-Doesn't follow any specifc convention.
+It also generates a json response but always with a root key. Doesn't follow any specifc convention. The root key can only be overwritten by overriding the `json_key` method that's present on the serializer. Be sure to use the singular form of the key.
+
+``` ruby
+class PostSerializer < ActiveModel::Serializer
+  attributes :id, :body
+
+  def json_key
+    "article"
+  end
+end
+```
 
 #### JSONAPI
 


### PR DESCRIPTION
It turns out you actually can change the root key when using the JSON adapter. If you override the `json_key` method, it lets you define a root key that doesn't have to be based on the class name.

Workaround for #986