### PR TITLE
Changing root to model class name

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -169,7 +169,7 @@ module ActiveModel
     end
 
     def json_key
-      @root || self.class.root_name
+      @root || object.class.model_name.to_s.downcase
     end
 
     def id

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -39,7 +39,7 @@ module ActiveModel
             serializer = PostPreviewSerializer.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
-            assert_equal({posts: {title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], author: nil}}, adapter.serializable_hash)
+            assert_equal({post: {title: "Hello!!", body: "Hello, world!!", id: 43, comments: [], author: nil}}, adapter.serializable_hash)
           end
         end
       end

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -28,7 +28,7 @@ module ActiveModel
             @serializer = ArraySerializer.new([@blog], serializer: CustomBlogSerializer)
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
 
-            expected = {custom_blogs:[{
+            expected = {blogs:[{
               id: 1,
               special_attribute: "Special",
               articles: [{id: 1,title: "Hello!!", body: "Hello, world!!"}, {id: 2, title: "New Post", body: "Body"}]

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -38,7 +38,7 @@ module ActiveModel
               tags: [
                 {"attributes"=>{"id"=>1, "name"=>"#hash_tag"}}
               ]
-            }.to_json, adapter.serializable_hash[:post_with_tags].to_json)
+            }.to_json, adapter.serializable_hash[:post].to_json)
           end
         end
       end

--- a/test/adapter/json_test.rb
+++ b/test/adapter/json_test.rb
@@ -39,10 +39,9 @@ module ActiveModel
                     ],
             writer: {id: 1, name: "Steve K."},
             site: {id: 1, name: "My Blog!!"}
-            }, adapter.serializable_hash[:post_with_custom_keys])
+            }, adapter.serializable_hash[:post])
         end
       end
     end
   end
 end
-

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -15,7 +15,7 @@ module ActiveModel
 
       def test_json_serializable_hash
         adapter = ActiveModel::Serializer::Adapter::Json.new(@blog_serializer)
-        assert_equal({alternate_blog: { id:1, title:"AMS Hints"}}, adapter.serializable_hash)
+        assert_equal({blog: { id:1, title:"AMS Hints"}}, adapter.serializable_hash)
       end
 
       def test_attribute_inheritance_with_key

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -15,7 +15,7 @@ module ActiveModel
         serializer = AlternateBlogSerializer.new(@blog, meta: {total: 10})
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
         expected = {
-          alternate_blog: {
+          blog: {
             id: 1,
             title: "AMS Hints"
           },
@@ -40,7 +40,7 @@ module ActiveModel
         serializer = AlternateBlogSerializer.new(@blog, meta: {total: 10}, meta_key: "haha_meta")
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
         expected = {
-          alternate_blog: {
+          blog: {
             id: 1,
             title: "AMS Hints"
           },


### PR DESCRIPTION
As I mentioned on #986 

> Another change I might do is to define the root key based on the model name and not on the serializer one.

This basically changes the default ```root``` used on Json Adapter to be the resource class name instead of the serializer's name.

This is also a prerequisite to other PRs.

example:

This serializer:
```ruby
class FooBarCommentSerializer < ActiveModel::Serializer
  attributes :content
end
```

resulted on this response (using json aadapter):

```json
{
  foo_bar_comment: {
    content: 'ZOMG a comment'
  }
}
```

now it results: 

```json
{
  comment: {
    content: 'ZOMG a comment'
  }
}
```

