### PR TITLE
Enabling fields option to json adapter

### DIFF
--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -14,6 +14,13 @@ module ActiveModel
       def initialize(serializer, options = {})
         @serializer = serializer
         @options = options
+
+        if fields = @options.delete(:fields)
+          @fieldset = ActiveModel::Serializer::Fieldset.new(fields, serializer.json_key)
+          @options[:fieldset] = @fieldset
+        else
+          @fieldset = options[:fieldset]
+        end
       end
 
       def serializable_hash(options = nil)

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -5,13 +5,13 @@ module ActiveModel
     class Adapter
       class Json < Adapter
         def serializable_hash(options = nil)
-          options ||= {}
           if serializer.respond_to?(:each)
-            @result = serializer.map { |s| FlattenJson.new(s).serializable_hash(options) }
+            @result = serializer.map { |s| FlattenJson.new(s, @options).serializable_hash(options) }
           else
             @hash = {}
 
             @core = cache_check(serializer) do
+              options = {fields: @fieldset && @fieldset.fields_for(serializer)}
               serializer.attributes(options)
             end
 
@@ -23,14 +23,15 @@ module ActiveModel
                 array_serializer = serializer
                 @hash[association.key] = array_serializer.map do |item|
                   cache_check(item) do
-                    item.attributes(opts)
+                    item.attributes(opts.merge(fields: @fieldset && @fieldset.fields_for(item)))
                   end
                 end
               else
                 @hash[association.key] =
                   if serializer && serializer.object
                     cache_check(serializer) do
-                      serializer.attributes(options)
+                      options[:fields] = @fieldset && @fieldset.fields_for(association)
+                      association.attributes(options)
                     end
                   elsif opts[:virtual_value]
                     opts[:virtual_value]

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -30,8 +30,8 @@ module ActiveModel
                 @hash[association.key] =
                   if serializer && serializer.object
                     cache_check(serializer) do
-                      options[:fields] = @fieldset && @fieldset.fields_for(association)
-                      association.attributes(options)
+                      options[:fields] = @fieldset && @fieldset.fields_for(serializer)
+                      serializer.attributes(options)
                     end
                   elsif opts[:virtual_value]
                     opts[:virtual_value]

--- a/lib/active_model/serializer/adapter/json/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/json/fragment_cache.rb
@@ -5,7 +5,14 @@ module ActiveModel
         class FragmentCache
 
           def fragment_cache(cached_hash, non_cached_hash)
-            non_cached_hash.merge cached_hash
+            core_cached = cached_hash.values.first
+            core_non_cached = non_cached_hash.values.first
+
+            if core_cached.is_a?(Hash) && core_non_cached.is_a?(Hash)
+              core_non_cached.merge core_cached
+            else
+              non_cached_hash.merge cached_hash
+            end
           end
 
         end

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -7,19 +7,13 @@ module ActiveModel
         def initialize(serializer, options = {})
           super
           @hash = { data: [] }
-
-          if fields = options.delete(:fields)
-            @fieldset = ActiveModel::Serializer::Fieldset.new(fields, serializer.json_key)
-          else
-            @fieldset = options[:fieldset]
-          end
         end
 
         def serializable_hash(options = nil)
           options ||= {}
           if serializer.respond_to?(:each)
             serializer.each do |s|
-              result = self.class.new(s, @options.merge(fieldset: @fieldset)).serializable_hash(options)
+              result = self.class.new(s, @options.merge(fieldset: @fieldset)).serializable_hash
               @hash[:data] << result[:data]
 
               if result[:included]
@@ -28,7 +22,7 @@ module ActiveModel
               end
             end
           else
-            @hash[:data] = attributes_for_serializer(serializer, options)
+            @hash[:data] = attributes_for_serializer(serializer, @options)
             add_resource_relationships(@hash[:data], serializer)
           end
           @hash
@@ -96,6 +90,7 @@ module ActiveModel
         end
 
         def resource_object_for(serializer, options)
+          options ||= {}
           options[:fields] = @fieldset && @fieldset.fields_for(serializer)
           options[:required_fields] = [:id, :json_api_type]
 

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -139,6 +139,22 @@ module ActionController
           render json: like
         end
 
+        def render_json_filtering_fields
+          with_adapter ActiveModel::Serializer::Adapter::Json do
+            profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+            render json: profile, fields: [:name]
+          end
+        end
+
+        def render_json_filtering_relationship_fields
+          with_adapter ActiveModel::Serializer::Adapter::Json do
+            author = Author.new(id: 1, name: 'Joao Moura.')
+            role = Role.new({ id: 42, name: 'ZOMG A ROLE', description: 'DESCRIPTION HERE', author: author })
+
+            render json: role, fields: {role: [:name], author: [:id]}
+          end
+        end
+
         private
         def generate_cached_serializer(obj)
           ActiveModel::SerializableResource.new(obj).to_json
@@ -399,6 +415,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
+
       def test_warn_overridding_use_adapter_as_falsy_on_controller_instance
         controller = Class.new(ImplicitSerializationTestController) {
           def use_adapter?
@@ -419,6 +436,35 @@ module ActionController
         assert_equal "", (capture(:stderr) {
           controller.get_serializer(Profile.new)
         })
+      end
+
+      def test_json_adapter_filtering_fields
+        get :render_json_filtering_fields
+
+        expected = {
+          profile: {
+            name: 'Name 1'
+          }
+        }
+
+        assert_equal 'application/json', @response.content_type
+        assert_equal expected.to_json, @response.body
+      end
+
+      def test_json_adapter_filtering_relationship_fields
+        get :render_json_filtering_relationship_fields
+
+        expected = {
+          role: {
+            name: 'ZOMG A ROLE',
+            author: {
+              id: 1
+            }
+          }
+        }
+
+        assert_equal 'application/json', @response.content_type
+        assert_equal expected.to_json, @response.body
       end
     end
   end


### PR DESCRIPTION
It fix #992

```fields``` option was used on Json API adapter but never on Json adapter. This implements the ```fields``` option on it.

It enables you to filter the fields you want on `render` method call:
```ruby
class ProfileSerialization < ActiveModel::Serializer
  attributes :name, :description

  has_many :friends
end
```

```ruby
# ProfileController

# Define the resource fields you want in the response
def show
  @profile = Profile.find(params[:id)
   render json: profile, fields: [:name]
end

# You can also define the resource relationships fields you want in the response
def show_with_some_relationship_data
  @profile = Profile.find(params[:id)
   render json: profile, fields: {profile: [:name], friends: [:id]}
end
```