### PR TITLE
Add ability to override the default adapter on a per-serializer basis

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -9,6 +9,7 @@ module ActiveModel
     include Configuration
 
     class << self
+      attr_accessor :_adapter
       attr_accessor :_attributes
       attr_accessor :_attributes_keys
       attr_accessor :_associations
@@ -130,13 +131,20 @@ module ActiveModel
       end
     end
 
+    def self.use_adapter(adapter)
+      self._adapter = adapter
+    end
+
     def self.adapter
-      adapter_class = case config.adapter
+      configured_adapter = _adapter || config.adapter
+
+      adapter_class = case configured_adapter
       when Symbol
-        ActiveModel::Serializer::Adapter.adapter_class(config.adapter)
+        ActiveModel::Serializer::Adapter.adapter_class(configured_adapter)
       when Class
-        config.adapter
+        configured_adapter
       end
+
       unless adapter_class
         valid_adapters = Adapter.constants.map { |klass| ":#{klass.to_s.downcase}" }
         raise ArgumentError, "Unknown adapter: #{config.adapter}. Valid adapters are: #{valid_adapters}"

--- a/test/serializers/adapter_for_test.rb
+++ b/test/serializers/adapter_for_test.rb
@@ -1,5 +1,9 @@
 module ActiveModel
   class Serializer
+    class OverriddenAdapterSerializer < ActiveModel::Serializer
+      use_adapter :json
+    end
+
     class AdapterForTest < Minitest::Test
       def setup
         @previous_adapter = ActiveModel::Serializer.config.adapter
@@ -28,6 +32,13 @@ module ActiveModel
 
         adapter = ActiveModel::Serializer.adapter
         assert_equal ActiveModel::Serializer::Adapter::Null, adapter
+      end
+
+      def test_adapter_specified_in_serializer
+        ActiveModel::Serializer.config.adapter = ActiveModel::Serializer::Adapter::Null
+
+        adapter = OverriddenAdapterSerializer.adapter
+        assert_equal ActiveModel::Serializer::Adapter::Json, adapter
       end
 
       def test_raises_exception_if_invalid_symbol_given


### PR DESCRIPTION
At the moment, the adapter can only be set as app-wide configuration. This doesn't deal well with the case where multiple adapters might be relevant in different cases - for instance, in my context, most API endpoints where we use serializers are designed to match the JSON API spec, but we also have OAuth endpoints that respond with plain old JSON.

This makes it possible to specify an adapter on a per-serializer class basis, like this:

```ruby
class OverriddenAdapterSerializer < ActiveModel::Serializer
  use_adapter :json
end
```

Interested to hear thoughts. This seems to add significant value with little cost in additional code or complexity.