### PR TITLE
Bug fix for ArraySerializer json_key

### DIFF
--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -29,7 +29,7 @@ module ActiveModel
         if @objects.first
           @objects.first.json_key.pluralize
         else
-          @resource.name.downcase.pluralize if @resource.try(:name)
+          @resource.name.underscore.pluralize if @resource.try(:name)
         end
       end
 

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -38,6 +38,17 @@ module ActiveModel
         assert_equal @serializer.meta, "the meta"
         assert_equal @serializer.meta_key, "the meta key"
       end
+
+      def test_json_key_when_resource_is_empty
+        Array.class_eval do
+          def name
+            'PostComment'
+          end
+        end
+        @post_comments = []
+        @serializer = ArraySerializer.new(@post_comments)
+        assert_equal @serializer.json_key, "post_comments"
+      end
     end
   end
 end


### PR DESCRIPTION
When the resource is a zero result query,
i.e. post_comments = PostComment.where("1=0")
the json_key will become 'postcomments' rather than 'post_comments'.
Using 'underscore' instead of 'downcase' fixes the error.