### PR TITLE
add support for string value serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -120,7 +120,7 @@ module ActiveModel
     end
 
     def self.serializer_for(resource, options = {})
-      if resource.respond_to?(:serializer_class)
+      serializer = if resource.respond_to?(:serializer_class)
         resource.serializer_class
       elsif resource.respond_to?(:to_ary)
         config.array_serializer
@@ -129,6 +129,8 @@ module ActiveModel
           .fetch(:association_options, {})
           .fetch(:serializer, get_serializer_for(resource.class))
       end
+
+      serializer.respond_to?(:constantize) ? serializer.constantize : serializer
     end
 
     def self.adapter

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -14,6 +14,7 @@ module ActiveModel
             :serializer,
             ActiveModel::Serializer.serializer_for(object)
           )
+          serializer_class = serializer_class.constantize if serializer_class.respond_to?(:constantize)
 
           if serializer_class.nil?
             fail NoSerializerError, "No serializer found for object: #{object.inspect}"

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -31,6 +31,13 @@ module ActiveModel
         refute serializers.first.custom_options.key?(:serializer)
       end
 
+      def test_serializer_option_string_value
+        serializers = ArraySerializer.new([@post], {serializer: "PostSerializer"}).to_a
+
+        assert_kind_of PostSerializer, serializers.last
+        assert_kind_of Post, serializers.last.object
+      end
+
       def test_meta_and_meta_key_attr_readers
         meta_content = {meta: "the meta", meta_key: "the meta key"}
         @serializer = ArraySerializer.new([@comment, @post], meta_content)

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -133,7 +133,7 @@ module ActiveModel
         assert_equal(inherited_klass._associations, expected_associations)
       end
 
-      def test_associations_string_serializer
+      def test_associations_serializer_string_name
         inherited_klass = Class.new(PostSerializer) do
           belongs_to :blog, serializer: "CustomBlogSerializer"
         end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -133,6 +133,19 @@ module ActiveModel
         assert_equal(inherited_klass._associations, expected_associations)
       end
 
+      def test_associations_string_serializer
+        inherited_klass = Class.new(PostSerializer) do
+          belongs_to :blog, serializer: "CustomBlogSerializer"
+        end
+        serializer = inherited_klass.new(@post)
+
+        expected_association_serializers = []
+        serializer.each_association do |key, serializer, options|
+          expected_association_serializers << serializer
+        end
+        assert expected_association_serializers.map(&:class).include? CustomBlogSerializer
+      end
+
       def test_associations_custom_keys
         serializer = PostWithCustomKeysSerializer.new(@post)
 

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -32,11 +32,15 @@ module ActiveModel
         class CustomProfile
           def serializer_class; ProfileSerializer; end
         end
+        class CustomProfileString
+          def serializer_class; "ProfileSerializer"; end
+        end
 
         def setup
           @profile = Profile.new
           @my_profile = MyProfile.new
           @custom_profile = CustomProfile.new
+          @custom_profile_string = CustomProfileString.new
           @model = ::Model.new
         end
 
@@ -57,6 +61,11 @@ module ActiveModel
 
         def test_serializer_custom_serializer
           serializer = ActiveModel::Serializer.serializer_for(@custom_profile)
+          assert_equal ProfileSerializer, serializer
+        end
+
+        def test_serializer_string_serializer
+          serializer = ActiveModel::Serializer.serializer_for(@custom_profile_string)
           assert_equal ProfileSerializer, serializer
         end
       end


### PR DESCRIPTION
I was having issues specifying a string name of a serializer when upgrading to from v0.9.3 to v0.10.0rc2. For example:

``` ruby
class PostSerializer < ActiveModel::Serializer
  belongs_to :blog, serializer: "CustomBlogSerializer"
end
```

This PR should allow for that again.