### PR TITLE
Support proper parse the file name in mingw platform.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,6 @@ if version == "master"
 else
   gem "rails", "~> #{version}.0"
 end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -29,8 +29,8 @@ module ActiveModel
       base._attributes = self._attributes.try(:dup) || []
       base._attributes_keys = self._attributes_keys.try(:dup) || {}
       base._urls = []
-      serializer_file = File.open(caller.first[/^[^:]+/])
-      base._cache_digest = Digest::MD5.hexdigest(serializer_file.read)
+      serializer_file_path = caller.first[/\A\S+(?=:\d+:in)/]
+      base._cache_digest = Digest::MD5.hexdigest(File.read(serializer_file_path))
       super
     end
 

--- a/test/generators/serializer_generator_test.rb
+++ b/test/generators/serializer_generator_test.rb
@@ -46,7 +46,11 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
   def test_with_no_attributes_does_not_add_extra_space
     run_generator ["account"]
     assert_file "app/serializers/account_serializer.rb" do |content|
-      assert_no_match /\n\nend/, content
+      if RUBY_PLATFORM =~ /mingw/
+        assert_no_match /\r\n\r\nend/, content
+      else
+        assert_no_match /\n\nend/, content
+      end
     end
   end
 end


### PR DESCRIPTION
Original regexp will failed the file name parse in Windows.

Example link: http://rubular.com/r/QRJfZ11BZL