### PR TITLE
Prioritize object `type` over serializer `type`

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -177,7 +177,7 @@ module ActiveModel
     end
 
     def type
-      object.class.model_name.plural
+      object.respond_to?(:type) ? object.type : object.class.model_name.plural
     end
 
     def attributes(options = {})

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -33,6 +33,29 @@ module ActiveModel
 
         assert_equal([:title], serializer_class._attributes)
       end
+
+      def test_type_attribute
+        serializer_class = Class.new(ActiveModel::Serializer){ attribute :type }
+
+        adapter = ActiveModel::Serializer::Adapter::FlattenJson.new(serializer_class.new(@blog))
+        assert_equal({type: 'blogs'}, adapter.serializable_hash)
+      end
+
+      def test_type_attribute_on_object
+        @blog.define_singleton_method(:type){ 'type' }
+        serializer_class = Class.new(ActiveModel::Serializer){ attribute :type }
+
+        adapter = ActiveModel::Serializer::Adapter::FlattenJson.new(serializer_class.new(@blog))
+        assert_equal({type: @blog.type}, adapter.serializable_hash)
+      end
+
+      def test_type_attribute_on_object_with_nil_value
+        @blog.define_singleton_method(:type){ nil }
+        serializer_class = Class.new(ActiveModel::Serializer){ attribute :type }
+
+        adapter = ActiveModel::Serializer::Adapter::FlattenJson.new(serializer_class.new(@blog))
+        assert_equal({type: @blog.type}, adapter.serializable_hash)
+      end
     end
   end
 end


### PR DESCRIPTION
I had some records being serialized that have `type` attributes. With the 0.10.x update, `ActiveModel::Serializer#type` was introduced which ended up ignoring the serialized object's type. This change makes it so if an object responds to `type`, then it will use the object's value, otherwise, it will use the serializer's.

Do note that anyone using the `:json_api` adapter may have to update their serializers, if they have an object with a `type` attribute, but still prefer to use the serializer's fallback type over the object's value.

It may be worth exploring a more robust way of handling these types of scenarios, where the serializer class defines methods that conflict with the underlying object (i.e. `type`, `id`, `json_key`, and possible future ones). Maybe they need to be handled in the adapters that rely on them. Thoughts?