### PR TITLE
Make Adapters registerable so they are not namespace-constrained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .config
 .yardoc
 Gemfile.lock
+Gemfile.local
 InstalledFiles
 _yardoc
 coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,39 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
+Style/IndentationConsistency:
+  Exclude:
+    - lib/active_model/serializer/adapter/flatten_json.rb
+    - lib/active_model/serializer/adapter/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json.rb
+    - lib/active_model/serializer/adapter/json/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json_api.rb
+    - lib/active_model/serializer/adapter/json_api/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json_api/pagination_links.rb
+    - lib/active_model/serializer/adapter/null.rb
+
+Style/IndentationWidth:
+  Exclude:
+    - lib/active_model/serializer/adapter/flatten_json.rb
+    - lib/active_model/serializer/adapter/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json.rb
+    - lib/active_model/serializer/adapter/json/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json_api.rb
+    - lib/active_model/serializer/adapter/json_api/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json_api/pagination_links.rb
+    - lib/active_model/serializer/adapter/null.rb
+
+Style/AccessModifierIndentation:
+  Exclude:
+    - lib/active_model/serializer/adapter/flatten_json.rb
+    - lib/active_model/serializer/adapter/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json.rb
+    - lib/active_model/serializer/adapter/json/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json_api.rb
+    - lib/active_model/serializer/adapter/json_api/fragment_cache.rb
+    - lib/active_model/serializer/adapter/json_api/pagination_links.rb
+    - lib/active_model/serializer/adapter/null.rb
+
 Lint/NestedMethodDefinition:
   Enabled: false
   Exclude:
@@ -15,9 +48,6 @@ Lint/NestedMethodDefinition:
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
-
-Style/SpecialGlobalVars:
-  Enabled: false
 
 Metrics/AbcSize:
   Max: 35 # TODO: Lower to 15

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Lint/NestedMethodDefinition:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 
+Style/SpecialGlobalVars:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 35 # TODO: Lower to 15
 

--- a/.simplecov
+++ b/.simplecov
@@ -8,7 +8,7 @@
   when 'jruby', 'rbx'
     96.0
   else
-    98.3
+    98.1
   end
 }.to_f.round(2)
 # rubocop:disable Style/DoubleNegation

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source 'https://rubygems.org'
+#
+# Add a Gemfile.local to locally bundle gems outside of version control
+local_gemfile = File.join(File.expand_path('..', __FILE__), 'Gemfile.local')
+eval_gemfile local_gemfile if File.readable?(local_gemfile)
 
 # Specify your gem's dependencies in active_model_serializers.gemspec
 gemspec

--- a/docs/general/adapters.md
+++ b/docs/general/adapters.md
@@ -32,7 +32,7 @@ resources in the `"included"` member when the resource names are included in the
 
 ## Choosing an adapter
 
-If you want to use a different adapter, such as JsonApi, you can change this in an initializer:
+If you want to use a specify a default adapter, such as JsonApi, you can change this in an initializer:
 
 ```ruby
 ActiveModel::Serializer.config.adapter = ActiveModel::Serializer::Adapter::JsonApi
@@ -44,8 +44,59 @@ or
 ActiveModel::Serializer.config.adapter = :json_api
 ```
 
-If you want to have a root key in your responses you should use the Json adapter, instead of the default FlattenJson:
+If you want to have a root key for each resource in your responses, you should use the Json or
+JsonApi adapters instead of the default FlattenJson:
 
 ```ruby
 ActiveModel::Serializer.config.adapter = :json
 ```
+
+## Advanced adapter configuration
+
+### Registering an adapter
+
+The default adapter can be configured, as above, to use any class given to it.
+
+An adapter may also be specified, e.g. when rendering, as a class or as a symbol.
+If a symbol, then the adapter must be, e.g. `:great_example`,
+`ActiveModel::Serializer::Adapter::GreatExample`, or registered.
+
+There are two ways to register an adapter:
+
+1) The simplest, is to subclass `ActiveModel::Serializer::Adapter`, e.g. the below will
+register the `Example::UsefulAdapter` as `:useful_adapter`.
+
+```ruby
+module Example
+  class UsefulAdapter < ActiveModel::Serializer::Adapter
+  end
+end
+```
+
+You'll notice that the name it registers is the class name underscored, not the full namespace.
+
+Under the covers, when the `ActiveModel::Serializer::Adapter` is subclassed, it registers
+the subclass as `register(:useful_adapter, Example::UsefulAdapter)`
+
+2) Any class can be registered as an adapter by calling `register` directly on the
+`ActiveModel::Serializer::Adapter` class. e.g., the below registers `MyAdapter` as
+`:special_adapter`.
+
+```ruby
+class MyAdapter; end
+ActiveModel::Serializer::Adapter.register(:special_adapter, MyAdapter)
+```
+
+### Looking up an adapter
+
+| `ActiveModel::Serializer::Adapter.adapter_map` | A Hash of all known adapters { adapter_name => adapter_class } |
+| `ActiveModel::Serializer::Adapter.adapters`    | A (sorted) Array of all known adapter_names |
+| `ActiveModel::Serializer::Adapter.get(name_or_klass)` |  The adapter_class, else raises an `ActiveModel::Serializer::Adapter::UnknownAdapter` error |
+| `ActiveModel::Serializer::Adapter.adapter_class(adapter)` | delegates to `ActiveModel::Serializer::Adapter.get(adapter)` |
+| `ActiveModel::Serializer.adapter` | a convenience method for `ActiveModel::Serializer::Adapter.get(config.adapter)` |
+
+The registered adapter name is always a String, but may be looked up as a Symbol or String.
+Helpfully, the Symbol or String is underscored, so that `get(:my_adapter)` and `get("MyAdapter")`
+may both be used.
+
+For more information, see [the Adapter class on GitHub](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer/adapter.rb)

--- a/docs/general/adapters.md
+++ b/docs/general/adapters.md
@@ -91,9 +91,9 @@ ActiveModel::Serializer::Adapter.register(:special_adapter, MyAdapter)
 
 | `ActiveModel::Serializer::Adapter.adapter_map` | A Hash of all known adapters { adapter_name => adapter_class } |
 | `ActiveModel::Serializer::Adapter.adapters`    | A (sorted) Array of all known adapter_names |
-| `ActiveModel::Serializer::Adapter.get(name_or_klass)` |  The adapter_class, else raises an `ActiveModel::Serializer::Adapter::UnknownAdapter` error |
-| `ActiveModel::Serializer::Adapter.adapter_class(adapter)` | delegates to `ActiveModel::Serializer::Adapter.get(adapter)` |
-| `ActiveModel::Serializer.adapter` | a convenience method for `ActiveModel::Serializer::Adapter.get(config.adapter)` |
+| `ActiveModel::Serializer::Adapter.lookup(name_or_klass)` |  The adapter_class, else raises an `ActiveModel::Serializer::Adapter::UnknownAdapter` error |
+| `ActiveModel::Serializer::Adapter.adapter_class(adapter)` | delegates to `ActiveModel::Serializer::Adapter.lookup(adapter)` |
+| `ActiveModel::Serializer.adapter` | a convenience method for `ActiveModel::Serializer::Adapter.lookup(config.adapter)` |
 
 The registered adapter name is always a String, but may be looked up as a Symbol or String.
 Helpfully, the Symbol or String is underscored, so that `get(:my_adapter)` and `get("MyAdapter")`

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -76,7 +76,7 @@ module ActiveModel
     private
 
     ActiveModelSerializers.silence_warnings do
-    attr_reader :resource, :adapter_opts, :serializer_opts
+      attr_reader :resource, :adapter_opts, :serializer_opts
     end
   end
 end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -94,9 +94,9 @@ module ActiveModel
       end
     end
 
-    # @see ActiveModel::Serializer::Adapter.get
+    # @see ActiveModel::Serializer::Adapter.lookup
     def self.adapter
-      ActiveModel::Serializer::Adapter.get(config.adapter)
+      ActiveModel::Serializer::Adapter.lookup(config.adapter)
     end
 
     def self.root_name

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -94,19 +94,9 @@ module ActiveModel
       end
     end
 
+    # @see ActiveModel::Serializer::Adapter.get
     def self.adapter
-      adapter_class = case config.adapter
-                      when Symbol
-                        ActiveModel::Serializer::Adapter.adapter_class(config.adapter)
-                      when Class
-                        config.adapter
-                      end
-      unless adapter_class
-        valid_adapters = Adapter.constants.map { |klass| ":#{klass.to_s.downcase}" }
-        raise ArgumentError, "Unknown adapter: #{config.adapter}. Valid adapters are: #{valid_adapters}"
-      end
-
-      adapter_class
+      ActiveModel::Serializer::Adapter.get(config.adapter)
     end
 
     def self.root_name

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -5,11 +5,11 @@ module ActiveModel
       ADAPTER_MAP = {}
       private_constant :ADAPTER_MAP if defined?(private_constant)
       extend ActiveSupport::Autoload
-      require 'active_model/serializer/adapter/json'
-      require 'active_model/serializer/adapter/json_api'
-      autoload :FlattenJson
-      autoload :Null
       autoload :FragmentCache
+      autoload :Json
+      autoload :JsonApi
+      autoload :Null
+      autoload :FlattenJson
 
       def self.create(resource, options = {})
         override = options.delete(:adapter)
@@ -60,14 +60,14 @@ module ActiveModel
             register(adapter_name, adapter_class)
             adapter_class
           }
-        rescue ArgumentError
+        rescue ArgumentError => e
           failure_message =
             "Unknown adapter: #{adapter.inspect}. Valid adapters are: #{adapters}"
-          raise UnknownAdapterError, failure_message, $!.backtrace
-        rescue NameError
+          raise UnknownAdapterError, failure_message, e.backtrace
+        rescue NameError => e
           failure_message =
-            "NameError: #{$!.message}. Unknown adapter: #{adapter.inspect}. Valid adapters are: #{adapters}"
-          raise UnknownAdapterError, failure_message, $!.backtrace
+            "NameError: #{e.message}. Unknown adapter: #{adapter.inspect}. Valid adapters are: #{adapters}"
+          raise UnknownAdapterError, failure_message, e.backtrace
         end
 
         # @api private

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -60,11 +60,7 @@ module ActiveModel
             register(adapter_name, adapter_class)
             adapter_class
           }
-        rescue ArgumentError => e
-          failure_message =
-            "Unknown adapter: #{adapter.inspect}. Valid adapters are: #{adapters}"
-          raise UnknownAdapterError, failure_message, e.backtrace
-        rescue NameError => e
+        rescue NameError, ArgumentError => e
           failure_message =
             "NameError: #{e.message}. Unknown adapter: #{adapter.inspect}. Valid adapters are: #{adapters}"
           raise UnknownAdapterError, failure_message, e.backtrace
@@ -73,7 +69,7 @@ module ActiveModel
         # @api private
         def find_by_name(adapter_name)
           adapter_name = adapter_name.to_s.classify.tr('API', 'Api')
-          "ActiveModel::Serializer::Adapter::#{adapter_name}".safe_constantize or # rubocop:disable Style/AndOr
+          ActiveModel::Serializer::Adapter.const_get(adapter_name.to_sym) or # rubocop:disable Style/AndOr
             fail UnknownAdapterError
         end
         private :find_by_name

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -17,9 +17,9 @@ module ActiveModel
         klass.new(resource, options)
       end
 
-      # @see ActiveModel::Serializer::Adapter.get
+      # @see ActiveModel::Serializer::Adapter.lookup
       def self.adapter_class(adapter)
-        ActiveModel::Serializer::Adapter.get(adapter)
+        ActiveModel::Serializer::Adapter.lookup(adapter)
       end
 
       # Only the Adapter class has these methods.
@@ -49,7 +49,7 @@ module ActiveModel
         # @param  adapter [String, Symbol, Class] name to fetch adapter by
         # @return [ActiveModel::Serializer::Adapter] subclass of Adapter
         # @raise  [UnknownAdapterError]
-        def get(adapter)
+        def lookup(adapter)
           # 1. return if is a class
           return adapter if adapter.is_a?(Class)
           adapter_name = adapter.to_s.underscore

--- a/lib/active_model/serializer/adapter/flatten_json.rb
+++ b/lib/active_model/serializer/adapter/flatten_json.rb
@@ -1,7 +1,4 @@
-module ActiveModel
-  class Serializer
-    class Adapter
-      class FlattenJson < Json
+class ActiveModel::Serializer::Adapter::FlattenJson < ActiveModel::Serializer::Adapter::Json
         def serializable_hash(options = {})
           super
           @result
@@ -13,7 +10,4 @@ module ActiveModel
         def include_meta(json)
           json
         end
-      end
-    end
-  end
 end

--- a/lib/active_model/serializer/adapter/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/fragment_cache.rb
@@ -1,7 +1,4 @@
-module ActiveModel
-  class Serializer
-    class Adapter
-      class FragmentCache
+class ActiveModel::Serializer::Adapter::FragmentCache
         attr_reader :serializer
 
         def initialize(adapter, serializer, options)
@@ -75,7 +72,4 @@ module ActiveModel
         def to_valid_const_name(name)
           name.gsub('::', '_')
         end
-      end
-    end
-  end
 end

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -1,9 +1,7 @@
-require 'active_model/serializer/adapter/json/fragment_cache'
+class ActiveModel::Serializer::Adapter::Json < ActiveModel::Serializer::Adapter
+        extend ActiveSupport::Autoload
+        autoload :FragmentCache
 
-module ActiveModel
-  class Serializer
-    class Adapter
-      class Json < Adapter
         def serializable_hash(options = nil)
           options ||= {}
           if serializer.respond_to?(:each)
@@ -44,9 +42,6 @@ module ActiveModel
         end
 
         def fragment_cache(cached_hash, non_cached_hash)
-          Json::FragmentCache.new().fragment_cache(cached_hash, non_cached_hash)
+          ActiveModel::Serializer::Adapter::Json::FragmentCache.new().fragment_cache(cached_hash, non_cached_hash)
         end
-      end
-    end
-  end
 end

--- a/lib/active_model/serializer/adapter/json/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/json/fragment_cache.rb
@@ -1,14 +1,5 @@
-require 'active_model/serializer/adapter/fragment_cache'
-module ActiveModel
-  class Serializer
-    class Adapter
-      class Json < Adapter
-        class FragmentCache
+class ActiveModel::Serializer::Adapter::Json::FragmentCache
           def fragment_cache(cached_hash, non_cached_hash)
             non_cached_hash.merge cached_hash
           end
-        end
-      end
-    end
-  end
 end

--- a/lib/active_model/serializer/adapter/json_api/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/json_api/fragment_cache.rb
@@ -1,9 +1,4 @@
-require 'active_model/serializer/adapter/fragment_cache'
-module ActiveModel
-  class Serializer
-    class Adapter
-      class JsonApi < Adapter
-        class FragmentCache
+class ActiveModel::Serializer::Adapter::JsonApi::FragmentCache
           def fragment_cache(root, cached_hash, non_cached_hash)
             hash              = {}
             core_cached       = cached_hash.first
@@ -15,8 +10,4 @@ module ActiveModel
 
             hash.deep_merge no_root_non_cache.deep_merge no_root_cache
           end
-        end
-      end
-    end
-  end
 end

--- a/lib/active_model/serializer/adapter/json_api/pagination_links.rb
+++ b/lib/active_model/serializer/adapter/json_api/pagination_links.rb
@@ -1,8 +1,4 @@
-module ActiveModel
-  class Serializer
-    class Adapter
-      class JsonApi < Adapter
-        class PaginationLinks
+class ActiveModel::Serializer::Adapter::JsonApi::PaginationLinks
           FIRST_PAGE = 1
 
           attr_reader :collection, :context
@@ -51,8 +47,4 @@ module ActiveModel
           def query_parameters
             @query_parameters ||= context.query_parameters
           end
-        end
-      end
-    end
-  end
 end

--- a/lib/active_model/serializer/adapter/null.rb
+++ b/lib/active_model/serializer/adapter/null.rb
@@ -1,11 +1,5 @@
-module ActiveModel
-  class Serializer
-    class Adapter
-      class Null < Adapter
+class ActiveModel::Serializer::Adapter::Null < ActiveModel::Serializer::Adapter
         def serializable_hash(options = nil)
           {}
         end
-      end
-    end
-  end
 end

--- a/lib/active_model/serializer/fieldset.rb
+++ b/lib/active_model/serializer/fieldset.rb
@@ -18,7 +18,7 @@ module ActiveModel
       private
 
       ActiveModelSerializers.silence_warnings do
-      attr_reader :raw_fields, :root
+        attr_reader :raw_fields, :root
       end
 
       def parsed_fields

--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -25,7 +25,7 @@ class DefaultScopeNameTest < ActionController::TestCase
     end
   end
 
- tests UserTestController
+  tests UserTestController
 
   def test_default_scope_name
     get :render_new_user

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -19,16 +19,6 @@ module ActiveModel
         assert_equal @serializer, @adapter.serializer
       end
 
-      def test_adapter_class_for_known_adapter
-        klass = ActiveModel::Serializer::Adapter.adapter_class(:json_api)
-        assert_equal ActiveModel::Serializer::Adapter::JsonApi, klass
-      end
-
-      def test_adapter_class_for_unknown_adapter
-        klass = ActiveModel::Serializer::Adapter.adapter_class(:json_simple)
-        assert_nil klass
-      end
-
       def test_create_adapter
         adapter = ActiveModel::Serializer::Adapter.create(@serializer)
         assert_equal ActiveModel::Serializer::Adapter::FlattenJson, adapter.class

--- a/test/serializers/adapter_for_test.rb
+++ b/test/serializers/adapter_for_test.rb
@@ -1,6 +1,8 @@
 module ActiveModel
   class Serializer
     class AdapterForTest < Minitest::Test
+      UnknownAdapterError = ::ActiveModel::Serializer::Adapter::UnknownAdapterError
+
       def setup
         @previous_adapter = ActiveModel::Serializer.config.adapter
       end
@@ -20,6 +22,7 @@ module ActiveModel
         adapter = ActiveModel::Serializer.adapter
         assert_equal ActiveModel::Serializer::Adapter::Null, adapter
       ensure
+        ActiveModel::Serializer.config.adapter = @previous_adapter
       end
 
       def test_overwrite_adapter_with_class
@@ -32,7 +35,7 @@ module ActiveModel
       def test_raises_exception_if_invalid_symbol_given
         ActiveModel::Serializer.config.adapter = :unknown
 
-        assert_raises ArgumentError do
+        assert_raises UnknownAdapterError do
           ActiveModel::Serializer.adapter
         end
       end
@@ -40,9 +43,122 @@ module ActiveModel
       def test_raises_exception_if_it_does_not_know_hot_to_infer_adapter
         ActiveModel::Serializer.config.adapter = 42
 
-        assert_raises ArgumentError do
+        assert_raises UnknownAdapterError do
           ActiveModel::Serializer.adapter
         end
+      end
+
+      def test_adapter_class_for_known_adapter
+        klass = ActiveModel::Serializer::Adapter.adapter_class(:json_api)
+        assert_equal ActiveModel::Serializer::Adapter::JsonApi, klass
+      end
+
+      def test_adapter_class_for_unknown_adapter
+        assert_raises UnknownAdapterError do
+          ActiveModel::Serializer::Adapter.adapter_class(:json_simple)
+        end
+      end
+
+      def test_adapter_map
+        expected_adapter_map = {
+          'json'.freeze              => ActiveModel::Serializer::Adapter::Json,
+          'json_api'.freeze          => ActiveModel::Serializer::Adapter::JsonApi,
+          'flatten_json'.freeze      => ActiveModel::Serializer::Adapter::FlattenJson,
+          'null'.freeze              => ActiveModel::Serializer::Adapter::Null
+        }
+        assert_equal ActiveModel::Serializer::Adapter.adapter_map, expected_adapter_map
+      end
+
+      def test_adapters
+        assert_equal ActiveModel::Serializer::Adapter.adapters.sort, [
+          'flatten_json'.freeze,
+          'json'.freeze,
+          'json_api'.freeze,
+          'null'.freeze
+        ]
+      end
+
+      def test_get_adapter_by_string_name
+        assert_equal ActiveModel::Serializer::Adapter.get('json'.freeze), ActiveModel::Serializer::Adapter::Json
+      end
+
+      def test_get_adapter_by_symbol_name
+        assert_equal ActiveModel::Serializer::Adapter.get(:json), ActiveModel::Serializer::Adapter::Json
+      end
+
+      def test_get_adapter_by_class
+        klass = ActiveModel::Serializer::Adapter::Json
+        assert_equal ActiveModel::Serializer::Adapter.get(klass), klass
+      end
+
+      def test_get_adapter_from_environment_registers_adapter
+        ActiveModel::Serializer::Adapter.const_set(:AdapterFromEnvironment, Class.new)
+        klass = ::ActiveModel::Serializer::Adapter::AdapterFromEnvironment
+        name = 'adapter_from_environment'.freeze
+        assert_equal ActiveModel::Serializer::Adapter.get(name), klass
+        assert ActiveModel::Serializer::Adapter.adapters.include?(name)
+      ensure
+        ActiveModel::Serializer::Adapter.adapter_map.delete(name)
+        ActiveModel::Serializer::Adapter.send(:remove_const, :AdapterFromEnvironment)
+      end
+
+      def test_get_adapter_for_unknown_name
+        assert_raises UnknownAdapterError do
+          ActiveModel::Serializer::Adapter.get(:json_simple)
+        end
+      end
+
+      def test_adapter
+        assert_equal ActiveModel::Serializer.config.adapter, :flatten_json
+        assert_equal ActiveModel::Serializer.adapter, ActiveModel::Serializer::Adapter::FlattenJson
+      end
+
+      def test_register_adapter
+        new_adapter_name  = :foo
+        new_adapter_klass = Class.new
+        ActiveModel::Serializer::Adapter.register(new_adapter_name, new_adapter_klass)
+        assert ActiveModel::Serializer::Adapter.adapters.include?('foo'.freeze)
+        assert ActiveModel::Serializer::Adapter.get(:foo), new_adapter_klass
+      ensure
+        ActiveModel::Serializer::Adapter.adapter_map.delete(new_adapter_name.to_s)
+      end
+
+      def test_inherited_adapter_hooks_register_adapter
+        Object.const_set(:MyAdapter, Class.new)
+        my_adapter = MyAdapter
+        ActiveModel::Serializer::Adapter.inherited(my_adapter)
+        assert_equal ActiveModel::Serializer::Adapter.get(:my_adapter), my_adapter
+      ensure
+        ActiveModel::Serializer::Adapter.adapter_map.delete('my_adapter'.freeze)
+        Object.send(:remove_const, :MyAdapter)
+      end
+
+      def test_inherited_adapter_hooks_register_demodulized_adapter
+        Object.const_set(:MyNamespace, Module.new)
+        MyNamespace.const_set(:MyAdapter, Class.new)
+        my_adapter = MyNamespace::MyAdapter
+        ActiveModel::Serializer::Adapter.inherited(my_adapter)
+        assert_equal ActiveModel::Serializer::Adapter.get(:my_adapter), my_adapter
+      ensure
+        ActiveModel::Serializer::Adapter.adapter_map.delete('my_adapter'.freeze)
+        MyNamespace.send(:remove_const, :MyAdapter)
+        Object.send(:remove_const, :MyNamespace)
+      end
+
+      def test_inherited_adapter_hooks_register_subclass_of_registered_adapter
+        Object.const_set(:MyAdapter, Class.new)
+        my_adapter = MyAdapter
+        Object.const_set(:MySubclassedAdapter, Class.new(MyAdapter))
+        my_subclassed_adapter = MySubclassedAdapter
+        ActiveModel::Serializer::Adapter.inherited(my_adapter)
+        ActiveModel::Serializer::Adapter.inherited(my_subclassed_adapter)
+        assert_equal ActiveModel::Serializer::Adapter.get(:my_adapter), my_adapter
+        assert_equal ActiveModel::Serializer::Adapter.get(:my_subclassed_adapter), my_subclassed_adapter
+      ensure
+        ActiveModel::Serializer::Adapter.adapter_map.delete('my_adapter'.freeze)
+        ActiveModel::Serializer::Adapter.adapter_map.delete('my_subclassed_adapter'.freeze)
+        Object.send(:remove_const, :MyAdapter)
+        Object.send(:remove_const, :MySubclassedAdapter)
       end
     end
   end

--- a/test/serializers/adapter_for_test.rb
+++ b/test/serializers/adapter_for_test.rb
@@ -83,33 +83,33 @@ module ActiveModel
         ]
       end
 
-      def test_get_adapter_by_string_name
-        assert_equal ActiveModel::Serializer::Adapter.get('json'.freeze), ActiveModel::Serializer::Adapter::Json
+      def test_lookup_adapter_by_string_name
+        assert_equal ActiveModel::Serializer::Adapter.lookup('json'.freeze), ActiveModel::Serializer::Adapter::Json
       end
 
-      def test_get_adapter_by_symbol_name
-        assert_equal ActiveModel::Serializer::Adapter.get(:json), ActiveModel::Serializer::Adapter::Json
+      def test_lookup_adapter_by_symbol_name
+        assert_equal ActiveModel::Serializer::Adapter.lookup(:json), ActiveModel::Serializer::Adapter::Json
       end
 
-      def test_get_adapter_by_class
+      def test_lookup_adapter_by_class
         klass = ActiveModel::Serializer::Adapter::Json
-        assert_equal ActiveModel::Serializer::Adapter.get(klass), klass
+        assert_equal ActiveModel::Serializer::Adapter.lookup(klass), klass
       end
 
-      def test_get_adapter_from_environment_registers_adapter
+      def test_lookup_adapter_from_environment_registers_adapter
         ActiveModel::Serializer::Adapter.const_set(:AdapterFromEnvironment, Class.new)
         klass = ::ActiveModel::Serializer::Adapter::AdapterFromEnvironment
         name = 'adapter_from_environment'.freeze
-        assert_equal ActiveModel::Serializer::Adapter.get(name), klass
+        assert_equal ActiveModel::Serializer::Adapter.lookup(name), klass
         assert ActiveModel::Serializer::Adapter.adapters.include?(name)
       ensure
         ActiveModel::Serializer::Adapter.adapter_map.delete(name)
         ActiveModel::Serializer::Adapter.send(:remove_const, :AdapterFromEnvironment)
       end
 
-      def test_get_adapter_for_unknown_name
+      def test_lookup_adapter_for_unknown_name
         assert_raises UnknownAdapterError do
-          ActiveModel::Serializer::Adapter.get(:json_simple)
+          ActiveModel::Serializer::Adapter.lookup(:json_simple)
         end
       end
 
@@ -123,7 +123,7 @@ module ActiveModel
         new_adapter_klass = Class.new
         ActiveModel::Serializer::Adapter.register(new_adapter_name, new_adapter_klass)
         assert ActiveModel::Serializer::Adapter.adapters.include?('foo'.freeze)
-        assert ActiveModel::Serializer::Adapter.get(:foo), new_adapter_klass
+        assert ActiveModel::Serializer::Adapter.lookup(:foo), new_adapter_klass
       ensure
         ActiveModel::Serializer::Adapter.adapter_map.delete(new_adapter_name.to_s)
       end
@@ -132,7 +132,7 @@ module ActiveModel
         Object.const_set(:MyAdapter, Class.new)
         my_adapter = MyAdapter
         ActiveModel::Serializer::Adapter.inherited(my_adapter)
-        assert_equal ActiveModel::Serializer::Adapter.get(:my_adapter), my_adapter
+        assert_equal ActiveModel::Serializer::Adapter.lookup(:my_adapter), my_adapter
       ensure
         ActiveModel::Serializer::Adapter.adapter_map.delete('my_adapter'.freeze)
         Object.send(:remove_const, :MyAdapter)
@@ -143,7 +143,7 @@ module ActiveModel
         MyNamespace.const_set(:MyAdapter, Class.new)
         my_adapter = MyNamespace::MyAdapter
         ActiveModel::Serializer::Adapter.inherited(my_adapter)
-        assert_equal ActiveModel::Serializer::Adapter.get(:my_adapter), my_adapter
+        assert_equal ActiveModel::Serializer::Adapter.lookup(:my_adapter), my_adapter
       ensure
         ActiveModel::Serializer::Adapter.adapter_map.delete('my_adapter'.freeze)
         MyNamespace.send(:remove_const, :MyAdapter)
@@ -157,8 +157,8 @@ module ActiveModel
         my_subclassed_adapter = MySubclassedAdapter
         ActiveModel::Serializer::Adapter.inherited(my_adapter)
         ActiveModel::Serializer::Adapter.inherited(my_subclassed_adapter)
-        assert_equal ActiveModel::Serializer::Adapter.get(:my_adapter), my_adapter
-        assert_equal ActiveModel::Serializer::Adapter.get(:my_subclassed_adapter), my_subclassed_adapter
+        assert_equal ActiveModel::Serializer::Adapter.lookup(:my_adapter), my_adapter
+        assert_equal ActiveModel::Serializer::Adapter.lookup(:my_subclassed_adapter), my_subclassed_adapter
       ensure
         ActiveModel::Serializer::Adapter.adapter_map.delete('my_adapter'.freeze)
         ActiveModel::Serializer::Adapter.adapter_map.delete('my_subclassed_adapter'.freeze)

--- a/test/serializers/adapter_for_test.rb
+++ b/test/serializers/adapter_for_test.rb
@@ -5,6 +5,11 @@ module ActiveModel
 
       def setup
         @previous_adapter = ActiveModel::Serializer.config.adapter
+        # Eager load adapters
+        ActiveModel::Serializer::Adapter.eager_load!
+        [:json_api, :flatten_json, :null, :json].each do |adapter_name|
+          ActiveModel::Serializer::Adapter.lookup(adapter_name)
+        end
       end
 
       def teardown

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,15 +39,6 @@ else
 end
 
 require 'active_model_serializers'
-# eager load autoloaded adapters
-# rubocop:disable Lint/Void
-require 'active_model/serializer/adapter'
-ActiveModel::Serializer::Adapter::Null
-ActiveModel::Serializer::Adapter::Json
-ActiveModel::Serializer::Adapter::FlattenJson
-ActiveModel::Serializer::Adapter::JsonApi
-# rubocop:enable Lint/Void
-require 'active_model/serializer/adapter'
 
 require 'support/stream_capture'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,15 @@ else
 end
 
 require 'active_model_serializers'
+# eager load autoloaded adapters
+# rubocop:disable Lint/Void
+require 'active_model/serializer/adapter'
+ActiveModel::Serializer::Adapter::Null
+ActiveModel::Serializer::Adapter::Json
+ActiveModel::Serializer::Adapter::FlattenJson
+ActiveModel::Serializer::Adapter::JsonApi
+# rubocop:enable Lint/Void
+require 'active_model/serializer/adapter'
 
 require 'support/stream_capture'
 


### PR DESCRIPTION
Changes:

- Introduce Adapter::lookup for use by Serializer.adapter
- Move Adapter-finding logic from Adapter::adapter_class into Adapter::lookup
- Fix circular load warning as described in https://github.com/rails-api/active_model_serializers/commit/cf6a074a1c62e3f5a30f90a0987b8cf049272953
- Allowed for gem devs to use a [`Gemfile.local`](https://github.com/rails-api/active_model_serializers/pull/1017#discussion_r37602184) for gems not in the gemspec or Gemfile e.g. `pry-byebug` (which was my usecase).
 
Background Ref:
- https://github.com/rails-api/active_model_serializers/pull/1050#issuecomment-133295789
- https://github.com/rails-api/active_model_serializers/pull/1067#discussion_r37710003. 
- The code in this PR was my first attempt to deal with https://github.com/rails-api/active_model_serializers/issues/1006 till I realized a simpler solution.. 

Introduced interfaces:

- non-inherited methods
```ruby
ActiveModel::Serializer::Adapter.adapter_map  # a Hash<adapter_name, adapter_class>
ActiveModel::Serializer::Adapter.adapters     # an Array<adapter_name>
ActiveModel::Serializer::Adapter.register(name, klass) # adds an adapter to the adapter_map
ActiveModel::Serializer::Adapter.lookup(name_or_klass)    # raises UnknownAdapterError error when adapter not found
```

- Automatically register adapters when subclassing

```ruby
     def self.inherited(subclass)
       ActiveModel::Serializer::Adapter.register(subclass.to_s.demodulize,
subclass)
     end
```

- Preserves subclass method `::adapter_class(adapter)`

```ruby
     def self.adapter_class(adapter)
       ActiveModel::Serializer::Adapter.lookup(adapter)
     end
```

- Serializer.adapter now uses `Adapter.lookup(config.adapter)` rather than have
duplicate logic

TODO

Test
- [x] ActiveModel::Serializer::Adapter.adapter_map
- [x] ActiveModel::Serializer::Adapter.adapters
- [x] ActiveModel::Serializer::Adapter.register(name, klass)
- [x] ActiveModel::Serializer::Adapter.get(name_or_klass)
- [x] ActiveModel::Serializer::Adapter::inherited
- [x] ActiveModel::Serializer.adapter

TO CONSIDER

- [x] wrap 'finding adapter by name' logic outside of 'get' method
- [x] Change exception from ArgumentError to UnknownAdapter

TODO in future PR:
- [ ] Change `Adapter` to module (backwards compatible public methods) and make `Adapter::Base` or `Adapter::AbstractClass` 

Full commit message from https://github.com/rails-api/active_model_serializers/commit/cf6a074a1c62e3f5a30f90a0987b8cf049272953

<pre>
Ensure inheritance hooks run
I was seeing transient failures where adapters may not be registered.

e.g. https://travis-ci.org/rails-api/active_model_serializers/builds/77735382

Since we're using the Adapter, JsonApi, and Json classes
as namespaces, some of the conventions we use for modules don't apply.
Basically, we don't want to define the class anywhere besides itself.
Otherwise, the inherited hooks may not run, and some adapters may not
be registered.

For example:

If we have a class Api `class Api; end`
And Api is also used as a namespace for `Api::Product`
And the classes are defined in different files.

In one file:

```ruby
class Api
  autoload :Product
  def self.inherited(subclass)
    puts
    p [:inherited, subclass.name]
    puts
  end
end
```

And in another:

```ruby
class Api
  class Product < Api
    def sell_sell_sell!
      # TODO: sell
    end
  end
end
```

If we load the Api class file first, the inherited hook will be defined on the class
so that when we load the Api::Product class, we'll see the output:

```plain
[ :inherited, Api::Product]
```

However, if we load the Api::Product class first, since it defines the `Api` class
and then inherited from it, the Api file was never loaded, the hook never defined,
and thus never run.

By defining the class as `class Api::Product < Api` We ensure the the Api class
MUST be defined, and thus, the hook will be defined and run and so sunshine and unicorns.

Appendix:

The below would work, but triggers a circular reference warning.
It's also not recommended to mix require with autoload.

```ruby
require 'api'
class Api
  class Product < Api
    def sell_sell_sell!
      # TODO: sell
    end
  end
end
```

This failure scenario was introduced by removing the circular reference warnings in
#1067
</pre>