### PR TITLE
Bump Version Number to 0.10.0.rc2

### DIFF
--- a/lib/active_model/serializer/version.rb
+++ b/lib/active_model/serializer/version.rb
@@ -1,5 +1,5 @@
 module ActiveModel
   class Serializer
-    VERSION = "0.10.0.rc1"
+    VERSION = "0.10.0.rc2"
   end
 end


### PR DESCRIPTION
Due to the fact that users need to switch from the released version to `master` occasionally to pull in upstream bugfixes, it's important that this version number stays in sync with the released version.