### PR TITLE
Add supports for :links and :data options to has_many associations for jsonapi adapter

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -27,6 +27,7 @@ module ActionController
       end
       ActiveModel::SerializableResource.serialize(resource, options) do |serializable_resource|
         if serializable_resource.serializer?
+          serializable_resource.url_helper = self
           serializable_resource.serialization_scope ||= serialization_scope
           serializable_resource.serialization_scope_name = _serialization_scope
           begin

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -30,6 +30,10 @@ module ActiveModel
       serializer_opts[:scope] = scope
     end
 
+    def url_helper=(url_helper)
+      adapter_opts[:url_helper] = url_helper
+    end
+
     def serialization_scope
       serializer_opts[:scope]
     end

--- a/test/adapter/json_api/has_many_url_test.rb
+++ b/test/adapter/json_api/has_many_url_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+module ActionController
+  module Serialization
+    class JsonApiHasManyUrlTest < ActionController::TestCase
+      class MyController < ActionController::Base
+
+        def render_resource_with_url_association
+          @tag = Tag.new(id: 1)
+          @tag.posts = []
+          render json: @tag, adapter: :json_api, serializer: LinkTagSerializer
+        end
+      end
+
+      tests MyController
+
+      def test_render_resource_with_url_association
+        get :render_resource_with_url_association
+        expected = {
+          data: {
+            id: "1",
+            type: "tags",
+            relationships: {
+              posts: {
+                links: {
+                  related: "http://test.host/tags/1/posts"
+                }
+              }
+            }
+          }
+        }
+        assert_equal expected.to_json, response.body
+      end
+    end
+  end
+end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,8 +1,13 @@
 class Model
+  extend ActiveModel::Naming
   FILE_DIGEST = Digest::MD5.hexdigest(File.open(__FILE__).read)
 
   def self.model_name
     @_model_name ||= ActiveModel::Name.new(self)
+  end
+
+  def to_model
+    self
   end
 
   def initialize(hash={})
@@ -29,9 +34,14 @@ class Model
     @attributes[:id] || @attributes['id'] || object_id
   end
 
+  def to_param
+    id.to_s
+  end
+
   ### Helper methods, not required to be serializable
   #
   # Convenience for adding @attributes readers and writers
+
   def method_missing(meth, *args)
     if meth.to_s =~ /^(.*)=$/
       @attributes[$1.to_sym] = args[0]
@@ -87,6 +97,7 @@ Comment  = Class.new(Model) do
     "#{self.class.name.downcase}/#{self.id}"
   end
 end
+Tag = Class.new(Model)
 
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
@@ -241,6 +252,10 @@ PostWithCustomKeysSerializer = Class.new(ActiveModel::Serializer) do
   has_many :comments, key: :reviews
   belongs_to :author, key: :writer
   has_one :blog, key: :site
+end
+
+LinkTagSerializer = Class.new(ActiveModel::Serializer) do
+  has_many :posts, links: true, data: false
 end
 
 VirtualValueSerializer = Class.new(ActiveModel::Serializer) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -86,6 +86,7 @@ require 'fixtures/poro'
 module TestHelper
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
+    get 'tags/:tag_id/posts', to: 'application#index', as: 'tag_posts'
     get ':controller(/:action(/:id))'
     get ':controller(/:action)'
   end


### PR DESCRIPTION
Adds option to `has_many` relationships have links (`links: true`) and turn of data (`data: false`) for jsonapi.

Replaces #840 
Fixes #834
