### PR TITLE
allow subclasses of ActiveModel::Serializer to override associations

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -97,10 +97,14 @@ module ActiveModel
         return unless object
 
         Enumerator.new do |y|
-          self.class._reflections.each do |reflection|
+          reflections.each do |reflection|
             y.yield reflection.build_association(self, options)
           end
         end
+      end
+
+      def reflections
+        self.class._reflections
       end
     end
   end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -102,6 +102,13 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
+CustomizablePostSerializer = Class.new(PostSerializer) do
+  def reflections
+    excludes = @options[:excludes] || []
+    super.select{ |r| excludes.exclude?(r.name) }
+  end
+end
+
 SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
   has_many :related

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -145,6 +145,14 @@ module ActiveModel
         assert expected_association_keys.include? :writer
         assert expected_association_keys.include? :site
       end
+
+      def test_overriding_associations
+        serializer = CustomizablePostSerializer.new(@post, excludes: [:comments])
+
+        association_keys = serializer.associations.map(&:key)
+
+        assert association_keys.exclude? :comments
+      end
     end
   end
 end


### PR DESCRIPTION
This makes it possible for subclasses of ActiveModel::Serializer to override associations based on @options.