### PR TITLE
allow id attribute to be overriden

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -50,9 +50,12 @@ module ActiveModel
       key = options.fetch(:key, attr)
       @_attributes_keys[attr] = { key: key } if key != attr
       @_attributes << key unless @_attributes.include?(key)
-      define_method key do
-        object.read_attribute_for_serialization(attr)
-      end unless method_defined?(key) || _fragmented.respond_to?(attr)
+
+      unless respond_to?(key, false) || _fragmented.respond_to?(attr)
+        define_method key do
+          object.read_attribute_for_serialization(attr)
+        end
+      end
     end
 
     def self.fragmented(serializer)

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -33,6 +33,15 @@ module ActiveModel
 
         assert_equal([:title], serializer_class._attributes)
       end
+
+      def test_id_attribute_override
+        serializer = Class.new(ActiveModel::Serializer) do
+          attribute :name, key: :id
+        end
+
+        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer.new(@blog))
+        assert_equal({ blog: { id: "AMS Hints" } }, adapter.serializable_hash)
+      end
     end
   end
 end


### PR DESCRIPTION
sometimes serialized id and the model id are not the same.