### PR TITLE
root option in render json is not working

### DIFF
--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -37,7 +37,7 @@ module ActiveModel
             @result = @core.merge @hash
           end
 
-          { (options[:root] || root) => @result }
+          { options.fetch(:root) { root } => @result }
         end
 
         def fragment_cache(cached_hash, non_cached_hash)

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -37,7 +37,7 @@ module ActiveModel
             @result = @core.merge @hash
           end
 
-          { root => @result }
+          { (options[:root] || root) => @result }
         end
 
         def fragment_cache(cached_hash, non_cached_hash)


### PR DESCRIPTION
Bug #1046 .

When I try to override the root option while rendering its not working.

```ruby
render json: current_user, root: :session
```
Getting the response as 

```ruby
{ user: { id:1, name:"Albert", email: {albert@abc.xyz} } }
```
