### PR TITLE
Let FlattenJson adapter decide it doesn't include meta

### DIFF
--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -22,7 +22,7 @@ module ActiveModel
 
       def as_json(options = nil)
         hash = serializable_hash(options)
-        include_meta(hash) unless self.class == FlattenJson
+        include_meta(hash)
         hash
       end
 

--- a/lib/active_model/serializer/adapter/flatten_json.rb
+++ b/lib/active_model/serializer/adapter/flatten_json.rb
@@ -6,6 +6,13 @@ module ActiveModel
           super
           @result
         end
+
+        private
+
+        # no-op: FlattenJson adapter does not include meta data, because it does not support root.
+        def include_meta(json)
+          json
+        end
       end
     end
   end


### PR DESCRIPTION
Why should the superclass get to decide it wants to
exclude meta from one of its subclasses.  I say don't ask
if we're a FlattenJson adapter, tell the adapter to
include the meta and let FlattenJson no-op on it.

From discussion in https://github.com/rails-api/active_model_serializers/pull/1041