### PR TITLE
Fix incorrect s/options = {}/options ||= {}

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -16,7 +16,7 @@ module ActiveModel
         end
 
         def serializable_hash(options = nil)
-          options = {}
+          options ||= {}
           if serializer.respond_to?(:each)
             serializer.each do |s|
               result = self.class.new(s, @options.merge(fieldset: @fieldset)).serializable_hash(options)


### PR DESCRIPTION
Introduced in #965, surfaced in #1041

(Thanks @bacarini for finding this!)