### PR TITLE
Use underscored json_root when serializing a collection

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -127,7 +127,7 @@ module ActiveModel
     end
 
     def json_key
-      @root || object.class.model_name.to_s.downcase
+      @root || object.class.model_name.to_s.underscore
     end
 
     def id

--- a/test/serializers/root_test.rb
+++ b/test/serializers/root_test.rb
@@ -5,13 +5,17 @@ module ActiveModel
     class RootTest < Minitest::Test
 
       def setup
-        @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
-        @profile_serializer = ProfileSerializer.new(@post, {root: 'smth'})
+        @virtual_value = VirtualValue.new(id: 1)
       end
 
       def test_overwrite_root
-        setup
-        assert_equal('smth', @profile_serializer.json_key)
+        serializer = VirtualValueSerializer.new(@virtual_value, {root: 'smth'})
+        assert_equal('smth', serializer.json_key)
+      end
+
+      def test_underscore_in_root
+        serializer = VirtualValueSerializer.new(@virtual_value)
+        assert_equal('virtual_value', serializer.json_key)
       end
 
     end


### PR DESCRIPTION
#### The Issue
Assuming we're using the `:json` adapter with an activerecord model `DataPoint` currently we get this when serializing a collection:

```
GET http://localhost:3000/data_points

=>
{
  "datapoints": [...]
}
```

Expected key would be `data_points`.

The behaviour was changed in [this](https://github.com/rails-api/active_model_serializers/commit/418721302bf494b01618fbde6f198201a8a4b3dd) commit and there are some great examples in [this comment](https://github.com/rails-api/active_model_serializers/commit/418721302bf494b01618fbde6f198201a8a4b3dd#commitcomment-12442906) by @bolshakov.

I've included a high level test in `test/adapter/json/collection_test.rb` to better illustrate the point, changes to this file can be reverted before merging.

Appreciate any feedback, will gladly rewrite this multiple times, etc.