### PR TITLE
Update fragment cache to support namespaced objects

### DIFF
--- a/lib/active_model/serializer/adapter/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/fragment_cache.rb
@@ -54,8 +54,8 @@ module ActiveModel
         end
 
         def fragment_serializer(name, klass)
-          cached     = "#{name.capitalize}CachedSerializer"
-          non_cached = "#{name.capitalize}NonCachedSerializer"
+          cached     = "#{to_valid_const_name(name)}CachedSerializer"
+          non_cached = "#{to_valid_const_name(name)}NonCachedSerializer"
 
           Object.const_set cached, Class.new(ActiveModel::Serializer) unless Object.const_defined?(cached)
           Object.const_set non_cached, Class.new(ActiveModel::Serializer) unless Object.const_defined?(non_cached)
@@ -71,6 +71,10 @@ module ActiveModel
           serializers = {cached: cached, non_cached: non_cached}
           cached_attributes(klass, serializers)
           serializers
+        end
+
+        def to_valid_const_name(name)
+          name.gsub('::', '_')
         end
       end
     end

--- a/test/adapter/fragment_cache_test.rb
+++ b/test/adapter/fragment_cache_test.rb
@@ -4,11 +4,14 @@ module ActiveModel
     class Adapter
       class FragmentCacheTest < Minitest::Test
         def setup
+          @spam            = Spam::UnrelatedLink.new(id: "spam-id-1")
           @author          = Author.new(name: 'Joao M. D. Moura')
           @role            = Role.new(name: 'Great Author', description:nil)
           @role.author     = [@author]
           @role_serializer = RoleSerializer.new(@role)
+          @spam_serializer = Spam::UnrelatedLinkSerializer.new(@spam)
           @role_hash       = FragmentCache.new(RoleSerializer.adapter.new(@role_serializer), @role_serializer, {})
+          @spam_hash       = FragmentCache.new(Spam::UnrelatedLinkSerializer.adapter.new(@spam_serializer), @spam_serializer, {})
         end
 
         def test_fragment_fetch_with_virtual_attributes
@@ -19,6 +22,13 @@ module ActiveModel
             name: @role.name
           }
           assert_equal(@role_hash.fetch, expected_result)
+        end
+
+        def test_fragment_fetch_with_namespaced_object
+          expected_result = {
+            id: @spam.id
+          }
+          assert_equal(@spam_hash.fetch, expected_result)
         end
       end
     end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -250,6 +250,7 @@ VirtualValueSerializer = Class.new(ActiveModel::Serializer) do
 end
 
 Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do
+  cache only: [:id]
   attributes :id
 end
 


### PR DESCRIPTION
The code to name the cached and uncached serializers didn't take into account namespaces in object names. This would exhibit itself with an error like: `NameError: wrong constant name Spam::unrelatedLinkCachedSerializer`.

The use of `.capitalize` didn't take all the scenarios into account. Since the name being passed in is already from an existing class name (`serializer.object.class.name`) there is no need to capitalize the value, instead I just did a simple string replacement for `::` namespace delimiters into `_`s.