### PR TITLE
Add relationship information to PORO models.

### DIFF
--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,6 +1,12 @@
 class Model
   FILE_DIGEST = Digest::MD5.hexdigest(File.open(__FILE__).read)
 
+  @@associations = {}
+
+  def self.associations=(assoc)
+    @@associations = assoc
+  end
+
   def self.model_name
     @_model_name ||= ActiveModel::Name.new(self)
   end
@@ -37,6 +43,8 @@ class Model
       @attributes[$1.to_sym] = args[0]
     elsif @attributes.key?(meth)
       @attributes[meth]
+    elsif @@associations.key?(meth)
+      @@associations[meth] == :has_many ? [] : nil
     else
       super
     end
@@ -109,6 +117,14 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
+Post.associations = {
+  comments: :has_many,
+  tags: :has_many,
+  related: :has_many,
+  author: :belongs_to,
+  blog: :belongs_to
+}
+
 SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
   has_many :related
@@ -130,6 +146,11 @@ CommentSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
+Comment.associations = {
+  post: :belongs_to,
+  author: :belongs_to
+}
+
 AuthorSerializer = Class.new(ActiveModel::Serializer) do
   cache key:'writer', skip_digest: true
   attributes :id, :name
@@ -138,6 +159,12 @@ AuthorSerializer = Class.new(ActiveModel::Serializer) do
   has_many :roles, embed: :ids
   has_one :bio
 end
+
+Author.associations = {
+  posts: :has_many,
+  roles: :has_many,
+  bio: :has_one
+}
 
 RoleSerializer = Class.new(ActiveModel::Serializer) do
   cache only: [:name], skip_digest: true
@@ -150,11 +177,19 @@ RoleSerializer = Class.new(ActiveModel::Serializer) do
   belongs_to :author
 end
 
+Role.associations = {
+  author: :belongs_to
+}
+
 LikeSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :time
 
   belongs_to :likeable
 end
+
+Like.associations = {
+  likeable: :belongs_to
+}
 
 LocationSerializer = Class.new(ActiveModel::Serializer) do
   cache only: [:place], skip_digest: true
@@ -167,11 +202,19 @@ LocationSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
+Location.associations = {
+  place: :belongs_to
+}
+
 PlaceSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :name
 
   has_many :locations
 end
+
+Place.associations = {
+  locations: :has_many
+}
 
 BioSerializer = Class.new(ActiveModel::Serializer) do
   cache except: [:content], skip_digest: true
@@ -180,6 +223,10 @@ BioSerializer = Class.new(ActiveModel::Serializer) do
   belongs_to :author
 end
 
+Bio.associations = {
+  author: :belongs_to
+}
+
 BlogSerializer = Class.new(ActiveModel::Serializer) do
   cache key: 'blog'
   attributes :id, :name
@@ -187,6 +234,11 @@ BlogSerializer = Class.new(ActiveModel::Serializer) do
   belongs_to :writer
   has_many :articles
 end
+
+Blog.associations = {
+  writer: :belongs_to,
+  articles: :has_many
+}
 
 PaginatedSerializer = Class.new(ActiveModel::Serializer::ArraySerializer) do
   def json_key

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -78,23 +78,69 @@ class ProfilePreviewSerializer < ActiveModel::Serializer
   urls :posts, :comments
 end
 
-Post     = Class.new(Model)
-Like     = Class.new(Model)
-Author   = Class.new(Model)
-Bio      = Class.new(Model)
-Blog     = Class.new(Model)
-Role     = Class.new(Model)
-User     = Class.new(Model)
+Post = Class.new(Model)
+Post.associations = {
+  comments: :has_many,
+  tags: :has_many,
+  related: :has_many,
+  author: :belongs_to,
+  blog: :belongs_to
+}
+
+Like = Class.new(Model)
+Like.associations = {
+  likeable: :belongs_to
+}
+
+Author = Class.new(Model)
+Author.associations = {
+  posts: :has_many,
+  roles: :has_many,
+  bio: :has_one
+}
+
+Bio = Class.new(Model)
+Bio.associations = {
+  author: :belongs_to
+}
+
+Blog = Class.new(Model)
+Blog.associations = {
+  writer: :belongs_to,
+  articles: :has_many
+}
+
+Role = Class.new(Model)
+Role.associations = {
+  author: :belongs_to
+}
+
+User = Class.new(Model)
+
 Location = Class.new(Model)
-Place    = Class.new(Model)
-Tag      = Class.new(Model)
+Location.associations = {
+  place: :belongs_to
+}
+
+Place = Class.new(Model)
+Place.associations = {
+  locations: :has_many
+}
+
+Tag = Class.new(Model)
+
 VirtualValue = Class.new(Model)
-Comment  = Class.new(Model) do
+
+Comment = Class.new(Model) do
   # Uses a custom non-time-based cache key
   def cache_key
     "#{self.class.name.downcase}/#{self.id}"
   end
 end
+Comment.associations = {
+  post: :belongs_to,
+  author: :belongs_to
+}
 
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
@@ -117,14 +163,6 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-Post.associations = {
-  comments: :has_many,
-  tags: :has_many,
-  related: :has_many,
-  author: :belongs_to,
-  blog: :belongs_to
-}
-
 SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
   has_many :related
@@ -146,11 +184,6 @@ CommentSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-Comment.associations = {
-  post: :belongs_to,
-  author: :belongs_to
-}
-
 AuthorSerializer = Class.new(ActiveModel::Serializer) do
   cache key:'writer', skip_digest: true
   attributes :id, :name
@@ -159,12 +192,6 @@ AuthorSerializer = Class.new(ActiveModel::Serializer) do
   has_many :roles, embed: :ids
   has_one :bio
 end
-
-Author.associations = {
-  posts: :has_many,
-  roles: :has_many,
-  bio: :has_one
-}
 
 RoleSerializer = Class.new(ActiveModel::Serializer) do
   cache only: [:name], skip_digest: true
@@ -177,19 +204,11 @@ RoleSerializer = Class.new(ActiveModel::Serializer) do
   belongs_to :author
 end
 
-Role.associations = {
-  author: :belongs_to
-}
-
 LikeSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :time
 
   belongs_to :likeable
 end
-
-Like.associations = {
-  likeable: :belongs_to
-}
 
 LocationSerializer = Class.new(ActiveModel::Serializer) do
   cache only: [:place], skip_digest: true
@@ -202,19 +221,11 @@ LocationSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-Location.associations = {
-  place: :belongs_to
-}
-
 PlaceSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :name
 
   has_many :locations
 end
-
-Place.associations = {
-  locations: :has_many
-}
 
 BioSerializer = Class.new(ActiveModel::Serializer) do
   cache except: [:content], skip_digest: true
@@ -223,10 +234,6 @@ BioSerializer = Class.new(ActiveModel::Serializer) do
   belongs_to :author
 end
 
-Bio.associations = {
-  author: :belongs_to
-}
-
 BlogSerializer = Class.new(ActiveModel::Serializer) do
   cache key: 'blog'
   attributes :id, :name
@@ -234,11 +241,6 @@ BlogSerializer = Class.new(ActiveModel::Serializer) do
   belongs_to :writer
   has_many :articles
 end
-
-Blog.associations = {
-  writer: :belongs_to,
-  articles: :has_many
-}
 
 PaginatedSerializer = Class.new(ActiveModel::Serializer::ArraySerializer) do
   def json_key


### PR DESCRIPTION
In order to test deserializers (#950), test models should respond to associations getters depending on the type of association (`has_many => [], belongs_to => nil, has_one => nil`), event if the association is not explicitly set.