### PR TITLE
Add ArraySerializer#object like Serializer

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -163,19 +163,21 @@ module ActiveModel
 
         def add_links(options)
           links = @hash.fetch(:links) { {} }
-          resources = serializer.instance_variable_get(:@resource)
-          @hash[:links] = add_pagination_links(links, resources, options) if is_paginated?(resources)
+          collection = serializer.object
+          if is_paginated?(collection)
+            @hash[:links] = add_pagination_links(links, collection, options)
+          end
         end
 
-        def add_pagination_links(links, resources, options)
-          pagination_links = JsonApi::PaginationLinks.new(resources, options[:context]).serializable_hash(options)
+        def add_pagination_links(links, collection, options)
+          pagination_links = JsonApi::PaginationLinks.new(collection, options[:context]).serializable_hash(options)
           links.update(pagination_links)
         end
 
-        def is_paginated?(resource)
-          resource.respond_to?(:current_page) &&
-            resource.respond_to?(:total_pages) &&
-            resource.respond_to?(:size)
+        def is_paginated?(collection)
+          collection.respond_to?(:current_page) &&
+            collection.respond_to?(:total_pages) &&
+            collection.respond_to?(:size)
         end
       end
     end

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -15,6 +15,10 @@ module ActiveModel
         resource
       end
 
+      def test_has_object_reader_serializer_interface
+        assert_equal @serializer.object, @resource
+      end
+
       def test_respond_to_each
         assert_respond_to @serializer, :each
       end


### PR DESCRIPTION
Useful for adapters that need access to the collection the ArraySerializer
is serializing.  e.g.

https://github.com/rails-api/active_model_serializers/blob/87c47f8fdcf38627e92f0b5496bc7831a02025e2/lib/active_model/serializer/adapter/json_api.rb#L166-L167

```ruby
  resources = serializer.instance_variable_get(:@resource)
  @hash[:links] = add_pagination_links(links, resources, options) if is_paginated?(resources)
end

def add_pagination_links(links, resources, options)
  pagination_links = JsonApi::PaginationLinks.new(resources, options[:context]).serializable_hash(options)
```

would become

```ruby
  @hash[:links] = add_pagination_links(links, options)
end

def add_pagination_links(links, options)
  resources = serializer.object
  return links unless is_paginated?(resources)
  pagination_links = JsonApi::PaginationLinks.new(resources, options[:context]).serializable_hash(options)
```