### PR TITLE
Add configuration option to set resource type to singular/plural

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -135,7 +135,11 @@ module ActiveModel
     end
 
     def json_api_type
-      object.class.model_name.plural
+      if config.jsonapi_resource_type == :plural
+        object.class.model_name.plural
+      else
+        object.class.model_name.singular
+      end
     end
 
     def attributes(options = {})

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -7,6 +7,7 @@ module ActiveModel
       included do |base|
         base.config.array_serializer = ActiveModel::Serializer::ArraySerializer
         base.config.adapter = :flatten_json
+        base.config.jsonapi_resource_type = :plural
       end
     end
   end

--- a/test/adapter/json_api/resource_type_config_test.rb
+++ b/test/adapter/json_api/resource_type_config_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi
+        class ResourceTypeConfigTest < Minitest::Test
+          def setup
+            @author = Author.new(id: 1, name: 'Steve K.')
+            @author.bio = nil
+            @author.roles = []
+            @blog = Blog.new(id: 23, name: 'AMS Blog')
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @anonymous_post = Post.new(id: 43, title: 'Hello!!', body: 'Hello, world!!')
+            @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @post.comments = [@comment]
+            @post.blog = @blog
+            @anonymous_post.comments = []
+            @anonymous_post.blog = nil
+            @comment.post = @post
+            @comment.author = nil
+            @post.author = @author
+            @anonymous_post.author = nil
+            @blog = Blog.new(id: 1, name: "My Blog!!")
+            @blog.writer = @author
+            @blog.articles = [@post, @anonymous_post]
+            @author.posts = []
+          end
+
+          def with_jsonapi_resource_type type
+            old_type = ActiveModel::Serializer.config[:jsonapi_resource_type]
+            ActiveModel::Serializer.config[:jsonapi_resource_type] = type
+            yield
+          ensure
+            ActiveModel::Serializer.config[:jsonapi_resource_type] = old_type
+          end
+
+          def test_config_plural
+            with_jsonapi_resource_type :plural do
+              serializer = CommentSerializer.new(@comment)
+              adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
+              ActionController::Base.cache_store.clear
+              assert_equal('comments', adapter.serializable_hash[:data][:type])
+            end
+          end
+
+          def test_config_singular
+            with_jsonapi_resource_type :singular do
+              serializer = CommentSerializer.new(@comment)
+              adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
+              ActionController::Base.cache_store.clear
+              assert_equal('comment', adapter.serializable_hash[:data][:type])
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
JSONAPI spec (http://jsonapi.org/format/#document-resource-object-identification) does not specify whether the `type` should be singular or plural. By default, AMS makes it plural, while some client-side libraries default to singular. This PR adds a configuration option to globally set it to plural or singular. (c.f. #1080)