### PR TITLE
Sideloading associations

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "kaminari"
   spec.add_development_dependency "will_paginate"
-  spec.add_development_dependency "pry-byebug"
 end

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "kaminari"
   spec.add_development_dependency "will_paginate"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -86,7 +86,11 @@ module ActiveModel
       end
 
       def root
-        serializer.json_key.to_sym if serializer.json_key
+        if serializer.json_key
+          serializer.json_key.to_sym
+        else
+          serializer.root
+        end
       end
 
       def include_meta(json)

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -8,6 +8,7 @@ module ActiveModel
         base.config.array_serializer = ActiveModel::Serializer::ArraySerializer
         base.config.adapter = :flatten_json
         base.config.jsonapi_resource_type = :plural
+        base.config.sideload_associations = false
       end
     end
   end

--- a/test/adapter/json/sideload_test.rb
+++ b/test/adapter/json/sideload_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+class ParentBlog < Blog; end
+class ParentBlogSerializer < BlogSerializer; end
+class HasOnePostSerializer < PostSerializer
+  attributes :id, :title, :body
+
+  has_many :comments
+  belongs_to :blog
+  belongs_to :author
+  has_one :parent_blog
+  url :comments
+end
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class Json
+        class SideloadTestTest < Minitest::Test
+          def setup
+            ActiveModel::Serializer.config.sideload_associations = true
+            ActionController::Base.cache_store.clear
+            @author = Author.new(id: 1, name: 'Steve K.')
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+            @post.comments = [@first_comment, @second_comment]
+            @post.author = @author
+            @first_comment.post = @post
+            @second_comment.post = @post
+            @blog = Blog.new(id: 1, name: "My Blog!!")
+            @parent_blog = ParentBlog.new(id: 2, name: "Parent Blog!!")
+            @post.blog = @blog
+            @post.parent_blog = @parent_blog
+            @tag = Tag.new(id: 1, name: "#hash_tag")
+            @post.tags = [@tag]
+          end
+
+          def teardown
+            ActiveModel::Serializer.config.sideload_associations = false
+          end
+
+          def test_associations_not_present_in_base_model
+            serializer = PostSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+            assert_equal(nil, adapter.serializable_hash[:post][:comments])
+          end
+
+          def test_associations_replaced_with_association_ids
+            serializer = PostSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+            assert_equal([1, 2], adapter.serializable_hash[:post][:comment_ids])
+          end
+
+          def test_relevant_associated_objects_in_json_root
+            serializer = PostSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+            assert_equal([
+                           {id: 1, body: 'ZOMG A COMMENT'},
+                           {id: 2, body: 'ZOMG ANOTHER COMMENT'}
+                         ], adapter.serializable_hash[:comments])
+          end
+
+          def test_has_one_has_a_singular_key
+            serializer = HasOnePostSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            assert_equal({
+                id: 2, name: "Parent Blog!!"
+              }, adapter.serializable_hash[:parent_blog])
+          end
+
+          def test_belongs_to_has_a_singular_key
+            serializer = PostSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            assert_equal({
+                id: 1, name: "Steve K."
+              }, adapter.serializable_hash[:author])
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/serializers/configuration_test.rb
+++ b/test/serializers/configuration_test.rb
@@ -10,6 +10,11 @@ module ActiveModel
       def test_default_adapter
         assert_equal :flatten_json, ActiveModel::Serializer.config.adapter
       end
+
+      def test_default_sideload_associations
+        assert_equal false, ActiveModel::Serializer.config.sideload_associations
+      end
+
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require 'action_controller/test_case'
 require 'action_controller/railtie'
 require 'active_support/json'
 require 'fileutils'
+
 FileUtils.mkdir_p(File.expand_path('../../tmp/cache', __FILE__))
 
 require 'minitest/autorun'


### PR DESCRIPTION
Hey all, since this is a highly requested feature, I figured I'd take a stab at it since I need it for my own ember work.

Thoughts on the implementation?

The goal of this is to address needs of #938 and #899 

Usage

    #config/initializers/active_model_serializers.rb
    ActiveModel::Serializer.config.adapter = :json
    ActiveModel::Serializer.config.sideload_associations = true


And that's it. :-)
No need to have embed: :ids on all the associations.