### PR TITLE
Add ActiveModelSerializers.logger with default null device

### DIFF
--- a/lib/active_model/serializer/railtie.rb
+++ b/lib/active_model/serializer/railtie.rb
@@ -1,6 +1,12 @@
 require 'rails/railtie'
 module ActiveModel
   class Railtie < Rails::Railtie
+    initializer 'active_model_serializers.logger' do
+      ActiveSupport.on_load(:action_controller) do
+        ActiveModelSerializers.logger = ActionController::Base.logger
+      end
+    end
+
     initializer 'generators' do |app|
       app.load_generators
       require 'generators/serializer/resource_override'

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -1,4 +1,12 @@
+require 'logger'
+require 'active_model'
+require "active_support/railtie"
+require 'action_controller'
+require "action_controller/railtie"
 module ActiveModelSerializers
+  mattr_accessor :logger
+  self.logger = Rails.logger || Logger.new(IO::NULL)
+
   module_function
 
   def silence_warnings
@@ -10,9 +18,6 @@ module ActiveModelSerializers
   end
 
 end
-
-require 'active_model'
-require 'action_controller'
 
 require 'active_model/serializer'
 require 'active_model/serializable_resource'

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ActiveModelSerializers::LoggerTest < Minitest::Test
+
+  def test_logger_is_set_to_action_controller_logger_when_initializer_runs
+    assert_equal ActiveModelSerializers.logger, ActionController::Base.logger
+  end
+
+  def test_logger_can_be_set
+    original_logger = ActiveModelSerializers.logger
+    logger = Logger.new(STDOUT)
+
+    ActiveModelSerializers.logger = logger
+
+    assert_equal ActiveModelSerializers.logger, logger
+  ensure
+    ActiveModelSerializers.logger = original_logger
+  end
+end


### PR DESCRIPTION
Based on a discussion in the amserializers slack
It's not used anywhere in this PR, but it could be...