### PR TITLE
Having `attribute :name` in a serializer causes exceptions

### DIFF
--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -134,7 +134,8 @@ end
 
 AuthorSerializer = Class.new(ActiveModel::Serializer) do
   cache key:'writer', skip_digest: true
-  attributes :id, :name
+  attribute :id
+  attribute :name
 
   has_many :posts, embed: :ids
   has_many :roles, embed: :ids


### PR DESCRIPTION
Having `attribute :name` in a serializer breaks with `NoMethodError: undefined method 'name' for #<AuthorSerializer:0x007ffe5afe6810>`.
But `attributes :id, :name` works..

I've changed one of the test serializers to demonstrate the issue.

I'll try to find time later to investigate some more, unless there is not an obvious fix someone could point me to.