### PR TITLE
Fix definition of serializer attributes with multiple calls to `attri…

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -70,7 +70,7 @@ module ActiveModel
       ActiveModelSerializers.silence_warnings do
         define_method key do
           object.read_attribute_for_serialization(attr)
-        end unless respond_to?(key, false) || _fragmented.respond_to?(attr)
+        end unless (key != :id && method_defined?(key)) || _fragmented.respond_to?(attr)
       end
     end
 

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -134,7 +134,8 @@ end
 
 AuthorSerializer = Class.new(ActiveModel::Serializer) do
   cache key:'writer', skip_digest: true
-  attributes :id, :name
+  attribute :id
+  attribute :name
 
   has_many :posts, embed: :ids
   has_many :roles, embed: :ids


### PR DESCRIPTION
…bute` instead of one single call to `attributes`.

Fixes #1094.