### PR TITLE
Remove remains of `embed` option.

### DIFF
--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -7,7 +7,7 @@ module ActiveModel
     # @param [Hash{Symbol => Object}] options
     #
     # @example
-    #  Association.new(:comments, CommentSummarySerializer, embed: :ids)
+    #  Association.new(:comments, CommentSummarySerializer)
     #
     Association = Struct.new(:name, :serializer, :options) do
 

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -136,8 +136,8 @@ AuthorSerializer = Class.new(ActiveModel::Serializer) do
   cache key:'writer', skip_digest: true
   attributes :id, :name
 
-  has_many :posts, embed: :ids
-  has_many :roles, embed: :ids
+  has_many :posts
+  has_many :roles
   has_one :bio
 end
 

--- a/test/serializers/association_macros_test.rb
+++ b/test/serializers/association_macros_test.rb
@@ -6,7 +6,7 @@ module ActiveModel
       AuthorSummarySerializer = Class.new
       class AssociationsTestSerializer < Serializer
         belongs_to :author, serializer: AuthorSummarySerializer
-        has_many :comments, embed: :ids
+        has_many :comments
         has_one :category
       end
 
@@ -21,7 +21,7 @@ module ActiveModel
       end
 
       def test_has_many_defines_reflection
-        has_many_reflection = HasManyReflection.new(:comments, embed: :ids)
+        has_many_reflection = HasManyReflection.new(:comments, {})
 
         assert_includes(@reflections, has_many_reflection)
       end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -52,13 +52,13 @@ module ActiveModel
 
           case key
           when :posts
-            assert_equal({ embed: :ids }, options)
+            assert_equal({}, options)
             assert_kind_of(ActiveModel::Serializer.config.array_serializer, serializer)
           when :bio
             assert_equal({}, options)
             assert_nil serializer
           when :roles
-            assert_equal({ embed: :ids }, options)
+            assert_equal({}, options)
             assert_kind_of(ActiveModel::Serializer.config.array_serializer, serializer)
           else
             flunk "Unknown association: #{key}"


### PR DESCRIPTION
As stated in #1100, the `embed` association option is only mentioned in a comment and in tests, but nowhere else in the codebase.