### PR TITLE
Cannot override `id` with JsonApi.

### DIFF
--- a/test/adapter/json_api/json_api_test.rb
+++ b/test/adapter/json_api/json_api_test.rb
@@ -32,6 +32,23 @@ module ActiveModel
             site: { data: {type: "blogs", id: "1" } }
             }, adapter.serializable_hash[:data][:relationships])
         end
+
+        def test_id_attribute_method_override
+          serializer = Class.new(ActiveModel::Serializer) do
+            attributes :id, :name
+
+            def id
+              "override"
+            end
+          end
+          adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer.new(@blog))
+
+          assert_equal({ data: {
+                           id: 'override',
+                           type: 'blogs',
+                           attributes: { name: 'AMS Hints' }
+                         } }, adapter.serializable_hash)
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, `id` cannot be overriden with the JsonApi adapter (although it can be with other adapters).
Here is a test to prove it/make sure the situation gets fixed.