### PR TITLE
Add ActiveRecord-backed fixtures.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,11 @@ else
   gem 'actionpack', gem_version
 end
 
+group :test do
+  gem 'activerecord'
+  gem 'sqlite3', platform: :ruby
+  gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -37,7 +37,6 @@ module ARModels
 
   class PostSerializer < ActiveModel::Serializer
     attributes :id, :title, :body
-    params :title, :body
 
     has_many :comments
     belongs_to :author

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1,0 +1,58 @@
+require 'active_record'
+
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Schema.define do
+  create_table :posts, force: true do |t|
+    t.string :title
+    t.text :body
+    t.references :author
+    t.timestamps null: false
+  end
+  create_table :authors, force: true do |t|
+    t.string :name
+    t.timestamps null: false
+  end
+  create_table :comments, force: true do |t|
+    t.text :contents
+    t.references :author
+    t.references :post
+    t.timestamp null: false
+  end
+end
+
+module ARModels
+  class Post < ActiveRecord::Base
+    has_many :comments
+    belongs_to :author
+  end
+
+  class Comment < ActiveRecord::Base
+    belongs_to :post
+    belongs_to :author
+  end
+
+  class Author < ActiveRecord::Base
+    has_many :posts
+  end
+
+  class PostSerializer < ActiveModel::Serializer
+    attributes :id, :title, :body
+    params :title, :body
+
+    has_many :comments
+    belongs_to :author
+    url :comments
+  end
+
+  class CommentSerializer < ActiveModel::Serializer
+    attributes :id, :contents
+
+    belongs_to :author
+  end
+
+  class AuthorSerializer < ActiveModel::Serializer
+    attributes :id, :name
+
+    has_many :posts
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,8 @@ require 'support/stream_capture'
 
 require 'support/rails_app'
 
-require 'fixtures/poro'
-
 require 'support/test_case'
+
+require 'fixtures/active_record'
+
+require 'fixtures/poro'


### PR DESCRIPTION
They are namespaced inside `ARModels` to avoid conficts with PORO models (that we might want to namespace as well).