### PR TITLE
[WIP] Fix extra db hit with belongs_to association

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -54,27 +54,61 @@ module ActiveModel
 
         private
 
-        def resource_identifier_type_for(serializer)
-          if ActiveModel::Serializer.config.jsonapi_resource_type == :singular
-            serializer.object.class.model_name.singular
+        def formatted_type(type)
+          type = if ActiveModel::Serializer.config.jsonapi_resource_type == :singular
+                   type.singularize
+                 else
+                   type.pluralize
+                 end
+          type.underscore
+        end
+
+        def resource_identifier_type_for_association(serializer, association)
+          if association.serializer.respond_to?(:type)
+            formatted_type(association.serializer.type)
+          elsif serializer.object.class.respond_to?(:reflections)
+            reflection = serializer.object.class.reflections[association.key.to_s]
+            formatted_type(reflection.class_name)
           else
-            serializer.object.class.model_name.plural
+            resource_identifier_type_for(association.serializer)
           end
         end
 
-        def resource_identifier_id_for(serializer)
-          if serializer.respond_to?(:id)
-            serializer.id
+        def resource_identifier_type_for(serializer, association = nil)
+          if association
+            resource_identifier_type_for_association(serializer, association)
           else
+            if serializer.respond_to?(:type)
+              serializer.type
+            elsif serializer && serializer.object
+              if serializer.object.class.respond_to?(:model_name)
+                formatted_type(serializer.object.class.model_name.singular)
+              else
+                formatted_type(serializer.object.class_name)
+              end
+            end
+          end
+        end
+
+        def resource_identifier_id_for(serializer, association = nil)
+          if association
+            if serializer.respond_to?("#{association.key}_id")
+              serializer.send("#{association.key}_id")
+            else
+              resource_identifier_id_for(association.serializer)
+            end
+          elsif serializer.respond_to?(:id)
+            serializer.id
+          elsif serializer && serializer.object
             serializer.object.id
           end
         end
 
-        def resource_identifier_for(serializer)
-          type = resource_identifier_type_for(serializer)
-          id   = resource_identifier_id_for(serializer)
+        def resource_identifier_for(serializer, association = nil)
+          type = resource_identifier_type_for(serializer, association)
+          id   = resource_identifier_id_for(serializer, association)
 
-          { id: id.to_s, type: type }
+          { id: id.to_s, type: type } unless id.nil?
         end
 
         def resource_object_for(serializer, options = {})
@@ -96,20 +130,22 @@ module ActiveModel
           end
         end
 
-        def relationship_value_for(serializer, options = {})
-          if serializer.respond_to?(:each)
-            serializer.map { |s| resource_identifier_for(s) }
+        def relationship_value_for(serializer, association)
+          if association.serializer.respond_to?(:each)
+            association.serializer.map { |s| resource_identifier_for(s) }
           else
-            if options[:virtual_value]
-              options[:virtual_value]
-            elsif serializer && serializer.object
-              resource_identifier_for(serializer)
+            if association.options[:virtual_value]
+              association.options[:virtual_value]
+            elsif serializer.class._reflections.find { |r| r.name == association.key }.is_a? BelongsToReflection
+              resource_identifier_for(serializer, association)
+            elsif association.serializer && association.serializer.object
+              resource_identifier_for(association.serializer)
             end
           end
         end
 
         def relationships_for(serializer)
-          Hash[serializer.associations.map { |association| [association.key, { data: relationship_value_for(association.serializer, association.options) }] }]
+          Hash[serializer.associations.map { |association| [association.key, { data: relationship_value_for(serializer, association) }] }]
         end
 
         def included_for(serializer)

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -150,6 +150,27 @@ module ActiveModel
             ]
             assert_equal expected, linked
           end
+
+          def test_ar_belongs_to_doesnt_load_record
+            author = ARModels::User.create(name: 'Name 1')
+            post = ARModels::Post.create(author_id: author.id)
+
+            class << post
+              def author
+                fail "should use author_id"
+              end
+            end
+
+            hash = ActiveModel::SerializableResource.new(post, adapter: :json_api).serializable_hash
+            assert_equal({ data: { id: author.id.to_s, type: 'users' } }, hash[:data][:relationships][:author])
+          end
+
+          def test_ar_belongs_to_empty
+            post = ARModels::Post.create
+
+            hash = ActiveModel::SerializableResource.new(post, adapter: :json_api).serializable_hash
+            assert_equal({ data: nil }, hash[:data][:relationships][:author])
+          end
         end
       end
     end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -8,7 +8,7 @@ ActiveRecord::Schema.define do
     t.references :author
     t.timestamps null: false
   end
-  create_table :authors, force: true do |t|
+  create_table :users, force: true do |t|
     t.string :name
     t.timestamps null: false
   end
@@ -23,15 +23,15 @@ end
 module ARModels
   class Post < ActiveRecord::Base
     has_many :comments
-    belongs_to :author
+    belongs_to :author, class_name: 'User'
   end
 
   class Comment < ActiveRecord::Base
     belongs_to :post
-    belongs_to :author
+    belongs_to :author, class_name: 'User'
   end
 
-  class Author < ActiveRecord::Base
+  class User < ActiveRecord::Base
     has_many :posts
   end
 
@@ -49,7 +49,7 @@ module ARModels
     belongs_to :author
   end
 
-  class AuthorSerializer < ActiveModel::Serializer
+  class UserSerializer < ActiveModel::Serializer
     attributes :id, :name
 
     has_many :posts


### PR DESCRIPTION
As mentioned in #1100, `belongs_to` associations currently load the record instead of using the `association_name_id` attribute when available (i.e. with ActiveRecord).
The explicit calls have been fixed, but the way things are, the records are actually loaded when building the associations anyways. A satisfying fix would be to lazify that part.

This PR is built on top of #1103 (which was initially intended to provide an easy way to fix #1100).