### PR TITLE
[WIP] Add config option to globally format JSONAPI type.

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -59,7 +59,7 @@ module ActiveModel
             serializer.type
           else
             type = serializer.object.class.model_name.singular
-            ActiveModel::Serializer.config.jsonapi_type_transformer.call(type)
+            ActiveModel::Serializer.config.jsonapi_type_formatter.call(type)
           end
         end
 

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -55,12 +55,12 @@ module ActiveModel
         private
 
         def resource_identifier_type_for(serializer)
-          type = if serializer.respond_to?(:type)
-                   serializer.type
-                 else
-                   serializer.object.class.model_name.singular
-                 end
-          ActiveModel::Serializer.config.jsonapi_type_transformer.call(type)
+          if serializer.respond_to?(:type)
+            serializer.type
+          else
+            type = serializer.object.class.model_name.singular
+            ActiveModel::Serializer.config.jsonapi_type_transformer.call(type)
+          end
         end
 
         def resource_identifier_id_for(serializer)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -55,11 +55,12 @@ module ActiveModel
         private
 
         def resource_identifier_type_for(serializer)
-          if ActiveModel::Serializer.config.jsonapi_resource_type == :singular
-            serializer.object.class.model_name.singular
-          else
-            serializer.object.class.model_name.plural
-          end
+          type = if serializer.respond_to?(:type)
+                   serializer.type
+                 else
+                   serializer.object.class.model_name.singular
+                 end
+          ActiveModel::Serializer.config.jsonapi_type_transformer.call(type)
         end
 
         def resource_identifier_id_for(serializer)

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -7,7 +7,6 @@ module ActiveModel
       included do |base|
         base.config.array_serializer = ActiveModel::Serializer::ArraySerializer
         base.config.adapter = :flatten_json
-        base.config.jsonapi_resource_type = :plural
         base.config.jsonapi_type_formatter = -> (type) { type.pluralize }
       end
     end

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -8,7 +8,7 @@ module ActiveModel
         base.config.array_serializer = ActiveModel::Serializer::ArraySerializer
         base.config.adapter = :flatten_json
         base.config.jsonapi_resource_type = :plural
-        base.config.jsonapi_type_transformer = -> (type) { type.pluralize }
+        base.config.jsonapi_type_formatter = -> (type) { type.pluralize }
       end
     end
   end

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -8,6 +8,7 @@ module ActiveModel
         base.config.array_serializer = ActiveModel::Serializer::ArraySerializer
         base.config.adapter = :flatten_json
         base.config.jsonapi_resource_type = :plural
+        base.config.jsonapi_type_transformer = -> (type) { type.pluralize }
       end
     end
   end

--- a/test/adapter/json_api/json_api_test.rb
+++ b/test/adapter/json_api/json_api_test.rb
@@ -31,6 +31,17 @@ module ActiveModel
             site: { data: { type: 'blogs', id: '1' } }
             }, adapter.serializable_hash[:data][:relationships])
         end
+
+        def test_override_type
+          post_override_serializer = Class.new(PostSerializer) do
+            def type
+              'override'
+            end
+          end
+          hash = ActiveModel::SerializableResource.new(@post, adapter: :json_api, serializer: post_override_serializer).serializable_hash
+
+          assert_equal('override', hash[:data][:type])
+        end
       end
     end
   end

--- a/test/adapter/json_api/resource_type_config_test.rb
+++ b/test/adapter/json_api/resource_type_config_test.rb
@@ -27,16 +27,16 @@ module ActiveModel
             @author.posts = []
           end
 
-          def with_jsonapi_resource_type type
-            old_type = ActiveModel::Serializer.config[:jsonapi_resource_type]
-            ActiveModel::Serializer.config[:jsonapi_resource_type] = type
+          def with_jsonapi_type_formatter formatter
+            old_formatter = ActiveModel::Serializer.config.jsonapi_type_formatter
+            ActiveModel::Serializer.config.jsonapi_type_formatter = formatter
             yield
           ensure
-            ActiveModel::Serializer.config[:jsonapi_resource_type] = old_type
+            ActiveModel::Serializer.config.jsonapi_type_formatter = old_formatter
           end
 
           def test_config_plural
-            with_jsonapi_resource_type :plural do
+            with_jsonapi_type_formatter -> (type) { type.pluralize } do
               serializer = CommentSerializer.new(@comment)
               adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
               ActionController::Base.cache_store.clear
@@ -45,7 +45,7 @@ module ActiveModel
           end
 
           def test_config_singular
-            with_jsonapi_resource_type :singular do
+            with_jsonapi_type_formatter -> (type) { type.singularize } do
               serializer = CommentSerializer.new(@comment)
               adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
               ActionController::Base.cache_store.clear


### PR DESCRIPTION
This is a response to #974. The idea is that client-side libraries have different conventions on the format of the `type` attribute, which this PR offers to set globally as a lambda.
I'm interested in opinions on the best way to offer a good experience with this. A few leads:
+ Having a few available lambdas (like `pluralize_dasherize`, `singularize_camelize`, etc)
+ Offering the possibility to chain some provided "formatters", possibly with a mix of lambdas as well (like `[ :pluralize, :underscore, -> (x) { ... } ]`

This is also related to #1029 (although the solution here is to globally handle the formatting, where #1029 offers to set it at the serializer level).