### PR TITLE
Nested associations for json adapter

### DIFF
--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -7,37 +7,13 @@ module ActiveModel
         def serializable_hash(options = nil)
           options ||= {}
           if serializer.respond_to?(:each)
-            @result = serializer.map { |s| FlattenJson.new(s).serializable_hash(options) }
+            @result = serialize_array_without_root(serializer, options)
           else
-            @hash = {}
+            @result = resource_object_for(serializer)
+            @result = add_resource_relationships(@result, serializer)
 
-            @core = cache_check(serializer) do
-              serializer.attributes(options)
-            end
 
-            serializer.associations.each do |association|
-              serializer = association.serializer
-              opts = association.options
-
-              if serializer.respond_to?(:each)
-                array_serializer = serializer
-                @hash[association.key] = array_serializer.map do |item|
-                  cache_check(item) do
-                    item.attributes(opts)
-                  end
-                end
-              else
-                @hash[association.key] =
-                  if serializer && serializer.object
-                    cache_check(serializer) do
-                      serializer.attributes(options)
-                    end
-                  elsif opts[:virtual_value]
-                    opts[:virtual_value]
-                  end
-              end
-            end
-            @result = @core.merge @hash
+            @result
           end
 
           { root => @result }
@@ -46,6 +22,111 @@ module ActiveModel
         def fragment_cache(cached_hash, non_cached_hash)
           Json::FragmentCache.new().fragment_cache(cached_hash, non_cached_hash)
         end
+
+        private
+
+        # iterate through the associations on the serializer,
+        # adding them to the parent as needed (as singular or plural)
+        #
+        # nested_associations is a list of symbols that governs what
+        # associations on the passed in seralizer to include
+        def add_resource_relationships(parent, serializer, nested_associations = [])
+          # have the include array normalized
+          nested_associations = ActiveModel::Serializer::Utils.include_array_to_hash(nested_associations)
+
+          included_associations = if nested_associations.present?
+            serializer.associations.select{ |association|
+              # nested_associations is a hash of:
+              #   key => nested association to include
+              nested_associations.has_key?(association.name)
+            }
+          else
+            serializer.associations
+          end
+
+          included_associations.each do |association|
+            serializer = association.serializer
+            opts = association.options
+            key = association.key
+
+            # sanity check if the association has nesting data
+            has_nesting = nested_associations[key].present?
+            if has_nesting
+              include_options_from_parent = { include: nested_associations[key] }
+              opts = opts.merge(include_options_from_parent)
+            end
+
+            if serializer.respond_to?(:each)
+              parent[key] = add_relationships(serializer, opts)
+            else
+              parent[key] = add_relationship(serializer, opts)
+            end
+          end
+
+          parent
+        end
+
+        # add a singular relationship
+        # the options should always belong to the serializer
+        def add_relationship(serializer, options)
+          serialized_relationship = serialized_or_virtual_of(serializer, options)
+
+          nested_associations_to_include = options[:include]
+          if nested_associations_to_include.present?
+            serialized_relationship = add_resource_relationships(
+              serialized_relationship,
+              serializer,
+              nested_associations_to_include)
+          end
+
+          serialized_relationship
+        end
+
+        # add a many relationship
+        def add_relationships(serializer, options)
+          serialize_array(serializer, options) do |serialized_item, item_serializer|
+            nested_associations_to_include = options[:include]
+
+            if nested_associations_to_include.present?
+              serialized_item = add_resource_relationships(
+                serialized_item,
+                item_serializer,
+                nested_associations_to_include)
+            end
+
+            serialized_item
+          end
+        end
+
+
+        def serialize_array_without_root(serializer, options)
+          serializer.map { |s| FlattenJson.new(s).serializable_hash(options) }
+        end
+
+        # a virtual value is something that doesn't need a serializer,
+        # such as a ruby array, or any other raw value
+        def serialized_or_virtual_of(serializer, options)
+          if serializer && serializer.object
+            resource_object_for(serializer)
+          elsif options[:virtual_value]
+            options[:virtual_value]
+          end
+        end
+
+        def serialize_array(serializer, options)
+          serializer.map do |item|
+            serialized_item = resource_object_for(item)
+            serialized_item = yield(serialized_item, item) if block_given?
+            serialized_item
+          end
+        end
+
+        def resource_object_for(serializer)
+          cache_check(serializer) do
+            serializer.attributes(serializer.options)
+          end
+        end
+
       end
     end
   end

--- a/lib/active_model/serializer/utils.rb
+++ b/lib/active_model/serializer/utils.rb
@@ -1,0 +1,42 @@
+module ActiveModel::Serializer::Utils
+  module_function
+
+    # converts the include hash to a standard format
+    # for constrained serialization recursion
+    #
+    # converts
+    #  [:author, :comments => [:author]] to
+    #  {:author => [], :comments => [:author]}
+    #
+    # and
+    #  [:author, :comments => {:author => :bio}, :posts => [:comments]] to
+    #  {:author => [], :comments => {:author => :bio}, :posts => [:comments]}
+    #
+    # The data passed in to this method should be an array where the last
+    # parameter is a hash
+    #
+    # the point of this method is to normalize the include
+    # options for the child relationships.
+    # if a sub inclusion is still an array after this method,
+    # it will get converted during the next iteration
+    def include_array_to_hash(include_array)
+      # still don't trust input
+      # but this also allows
+      #  include: :author syntax
+      include_array = Array[*include_array].compact
+
+      result = {}
+
+      hashes = include_array.select{|a| a.is_a?(Hash)}
+      non_hashes = include_array - hashes
+
+      hashes += non_hashes.map{ |association_name| { association_name => [] } }
+
+      # now merge all the hashes
+      hashes.each{|hash| result.merge!(hash) }
+
+      result
+    end
+
+
+end

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -14,6 +14,7 @@ require 'active_model'
 require 'action_controller'
 
 require 'active_model/serializer'
+require 'active_model/serializer/utils'
 require 'active_model/serializable_resource'
 require 'active_model/serializer/version'
 

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -11,22 +11,22 @@ module ActionController
         end
 
         def render_using_default_adapter_root
-          @profile = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
+          @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           render json: @profile
         end
 
         def render_array_using_custom_root
-          @profile = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
-          render json: [@profile], root: 'custom_root'
+          @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+          render json: [@profile], root: "custom_root"
         end
 
         def render_array_that_is_empty_using_custom_root
-          render json: [], root: 'custom_root'
+          render json: [], root: "custom_root"
         end
 
         def render_object_using_custom_root
-          @profile = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
-          render json: @profile, root: 'custom_root'
+          @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+          render json: @profile, root: "custom_root"
         end
 
         def render_array_using_implicit_serializer
@@ -39,8 +39,9 @@ module ActionController
 
         def render_array_using_implicit_serializer_and_meta
           @profiles = [
-            Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
+            Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           ]
+
           render json: @profiles, meta: { total: 10 }
         end
 
@@ -178,7 +179,7 @@ module ActionController
         with_adapter :json do
           get :render_array_using_custom_root
         end
-        expected = { custom_roots: [{ name: 'Name 1', description: 'Description 1' }] }
+        expected =  {custom_roots: [{name: "Name 1", description: "Description 1"}]}
         assert_equal 'application/json', @response.content_type
         assert_equal expected.to_json, @response.body
       end

--- a/test/adapter/json/nested_relationships_test.rb
+++ b/test/adapter/json/nested_relationships_test.rb
@@ -1,0 +1,250 @@
+require 'test_helper'
+
+NestedPostSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id, :title
+
+  has_many :comments, include: :author
+end
+
+NestedCommentBelongsToSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id, :body
+
+  belongs_to :author, include: [:posts]
+end
+
+NestedAuthorSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id, :name
+
+  has_many :posts, include: [:comments]
+end
+
+ComplexNestedAuthorSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id, :name
+
+  # it would normally be silly to have this in production code, cause a post's
+  # author in this case is always going to be your root object
+  has_many :posts, include: [:author, comments: [:author]]
+end
+
+MultipleRelationshipAuthorSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id, :name
+
+  has_many :posts, include: [{comments: [:author]}]
+  has_many :comments
+end
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class Json
+        class NestedRelationShipsTestTest < Minitest::Test
+          def setup
+            ActionController::Base.cache_store.clear
+            @author = Author.new(id: 1, name: 'Steve K.')
+
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+
+            @post.comments = [@first_comment, @second_comment]
+            @post.author = @author
+
+            @first_comment.post = @post
+            @second_comment.post = @post
+
+            @blog = Blog.new(id: 1, name: "My Blog!!")
+            @post.blog = @blog
+            @author.posts = [@post]
+          end
+
+          def test_multiple_relationships_has_many
+            @first_comment.author = @author
+            @second_comment.author = @author
+            @author.comments = [@first_comment, @second_comment]
+
+
+            serializer = MultipleRelationshipAuthorSerializer.new(@author)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            expected = {
+              author: {
+                id: 1,
+                name: 'Steve K.',
+                posts: [
+                  {
+                    id: 42, title: 'New Post', body: 'Body',
+                    comments: [
+                      {
+                        id: 1, body: 'ZOMG A COMMENT',
+                        author: {
+                          id: 1,
+                          name: 'Steve K.'
+                        }
+                      },
+                      {
+                        id: 2, body: 'ZOMG ANOTHER COMMENT',
+                        author: {
+                          id: 1,
+                          name: 'Steve K.'
+                        }
+                      }
+                    ]
+                  }
+                ],
+                comments: [
+                  {
+                    id: 1, body: 'ZOMG A COMMENT'
+                  },
+                  {
+                    id: 2, body: 'ZOMG ANOTHER COMMENT'
+                  }
+                ]
+              }
+            }
+
+            actual = adapter.serializable_hash
+
+            assert_equal(expected, actual)
+
+          end
+
+          def test_complex_nested_has_many
+            @first_comment.author = @author
+            @second_comment.author = @author
+
+            serializer = ComplexNestedAuthorSerializer.new(@author)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            expected = {
+              author: {
+                id: 1,
+                name: 'Steve K.',
+                posts: [
+                  {
+                    id: 42, title: 'New Post', body: 'Body',
+                    author: {
+                      id: 1,
+                      name: 'Steve K.'
+                    },
+                    comments: [
+                      {
+                        id: 1, body: 'ZOMG A COMMENT',
+                        author: {
+                          id: 1,
+                          name: 'Steve K.'
+                        }
+                      },
+                      {
+                        id: 2, body: 'ZOMG ANOTHER COMMENT',
+                        author: {
+                          id: 1,
+                          name: 'Steve K.'
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+
+            actual = adapter.serializable_hash
+
+            assert_equal(expected, actual)
+          end
+
+          def test_nested_has_many
+            serializer = NestedAuthorSerializer.new(@author)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            expected = {
+              author: {
+                id: 1,
+                name: 'Steve K.',
+                posts: [
+                  {
+                    id: 42, title: 'New Post', body: 'Body',
+                    comments: [
+                      {
+                        id: 1, body: 'ZOMG A COMMENT'
+                      },
+                      {
+                        id: 2, body: 'ZOMG ANOTHER COMMENT'
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+
+            actual = adapter.serializable_hash
+
+            assert_equal(expected, actual)
+          end
+
+          def test_belongs_to_on_a_has_many
+            @first_comment.author = @author
+            @second_comment.author = @author
+
+            serializer = NestedPostSerializer.new(@post)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            expected = {
+              post: {
+                id: 42, title: 'New Post',
+                comments: [
+                  {
+                    id: 1, body: 'ZOMG A COMMENT',
+                    author: {
+                      id: 1,
+                      name: 'Steve K.'
+                    }
+                  },
+                  {
+                    id: 2, body: 'ZOMG ANOTHER COMMENT',
+                    author: {
+                      id: 1,
+                      name: 'Steve K.'
+                    }
+                  }
+                ]
+              },
+            }
+
+            actual = adapter.serializable_hash
+
+            assert_equal(expected, actual)
+          end
+
+          def test_belongs_to_with_a_has_many
+            @author.roles = []
+            @author.bio = {}
+            @first_comment.author = @author
+            @second_comment.author = @author
+
+            serializer = NestedCommentBelongsToSerializer.new(@first_comment)
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+
+            expected = {
+              comment: {
+                id: 1, body: 'ZOMG A COMMENT',
+                author: {
+                  id: 1,
+                  name: 'Steve K.',
+                  posts: [
+                    {
+                      id: 42, title: 'New Post', body: 'Body'
+                    }
+                  ]
+                }
+              }
+            }
+
+            actual = adapter.serializable_hash
+
+            assert_equal(expected, actual)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json_api/resource_type_config_test.rb
+++ b/test/adapter/json_api/resource_type_config_test.rb
@@ -38,7 +38,7 @@ module ActiveModel
           def test_config_plural
             with_adapter :json_api do
               with_jsonapi_resource_type :plural do
-                hash = ActiveModel::SerializableResource.new(@comment).serializable_hash
+                hash = ActiveModel::SerializableResource.serialize(@comment).serializable_hash
                 assert_equal('comments', hash[:data][:type])
               end
             end
@@ -47,7 +47,7 @@ module ActiveModel
           def test_config_singular
             with_adapter :json_api do
               with_jsonapi_resource_type :singular do
-                hash = ActiveModel::SerializableResource.new(@comment).serializable_hash
+                hash = ActiveModel::SerializableResource.serialize(@comment).serializable_hash
                 assert_equal('comment', hash[:data][:type])
               end
             end

--- a/test/serializers/utils_test.rb
+++ b/test/serializers/utils_test.rb
@@ -1,0 +1,16 @@
+module ActiveModel
+  class Serializer
+    module Utils
+      class UtilsTest < MiniTest::Test
+        def test_include_array_to_hash
+          expected = {author: [], comments: {author: :bio}, posts: [:comments]}
+          input = [:author, comments: {author: :bio}, posts: [:comments]]
+          actual = ActiveModel::Serializer::Utils.include_array_to_hash(input)
+
+          assert_equal(expected, actual)
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Originally #1114 (I messed up the history because I merged instead of rebased)

This PR is based off of #1111, cause I needed the refactoring.

Discussion of idea here: #1113

Basically:

```ruby
BlogSerializer < #...
  has_many :posts, include: { author: [:bio], comments: [:author]] }
end
```
resulting json may look like:

```
{
  blog: {
    posts: [
      {
        author: {
          bio: {...}
        },
        comments: [
          {  author: {...} }
        ]
      }
    ]
  }
}
```

See the included tests for more examples.