### PR TITLE
Support nested associations for Json and Attributes adapters + Refactor Attributes adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Features:
   * adds support for `pagination links` at top level of JsonApi adapter [@bacarini]
   * adds extended format for `include` option to JsonApi adapter [@beauby]
   * adds support for wildcards in `include` option [@beauby]
+  * adds support for nested associations for JSON and Attributes adapters via the `include` option [@NullVoxPopuli, @beauby]
 
 Fixes:
 

--- a/test/action_controller/json/include_test.rb
+++ b/test/action_controller/json/include_test.rb
@@ -1,0 +1,167 @@
+require 'test_helper'
+
+module ActionController
+  module Serialization
+    class Json
+      class IncludeTest < ActionController::TestCase
+        class IncludeTestController < ActionController::Base
+          def setup_data
+            ActionController::Base.cache_store.clear
+
+            @author = Author.new(id: 1, name: 'Steve K.')
+
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @first_comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
+            @second_comment = Comment.new(id: 2, body: 'ZOMG ANOTHER COMMENT')
+
+            @post.comments = [@first_comment, @second_comment]
+            @post.author = @author
+
+            @first_comment.post = @post
+            @second_comment.post = @post
+
+            @blog = Blog.new(id: 1, name: 'My Blog!!')
+            @post.blog = @blog
+            @author.posts = [@post]
+
+            @first_comment.author = @author
+            @second_comment.author = @author
+            @author.comments = [@first_comment, @second_comment]
+            @author.roles = []
+            @author.bio = {}
+          end
+
+          def render_without_include
+            setup_data
+            render json: @author, adapter: :json
+          end
+
+          def render_resource_with_include_hash
+            setup_data
+            render json: @author, include: { posts: :comments }, adapter: :json
+          end
+
+          def render_resource_with_include_string
+            setup_data
+            render json: @author, include: 'posts.comments', adapter: :json
+          end
+
+          def render_resource_with_deep_include
+            setup_data
+            render json: @author, include: 'posts.comments.author', adapter: :json
+          end
+        end
+
+        tests IncludeTestController
+
+        def test_render_without_include
+          get :render_without_include
+          response = JSON.parse(@response.body)
+          expected = {
+            'author' => {
+              'id' => 1,
+              'name' => 'Steve K.',
+              'posts' => [
+                {
+                  'id' => 42, 'title' => 'New Post', 'body' => 'Body'
+                }
+              ],
+              'roles' => [],
+              'bio' => {}
+            }
+          }
+
+          assert_equal(expected, response)
+        end
+
+        def test_render_resource_with_include_hash
+          get :render_resource_with_include_hash
+          response = JSON.parse(@response.body)
+          expected = {
+            'author' => {
+              'id' => 1,
+              'name' => 'Steve K.',
+              'posts' => [
+                {
+                  'id' => 42, 'title' => 'New Post', 'body' => 'Body',
+                  'comments' => [
+                    {
+                      'id' => 1, 'body' => 'ZOMG A COMMENT'
+                    },
+                    {
+                      'id' => 2, 'body' => 'ZOMG ANOTHER COMMENT'
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+
+          assert_equal(expected, response)
+        end
+
+        def test_render_resource_with_include_string
+          get :render_resource_with_include_string
+
+          response = JSON.parse(@response.body)
+          expected = {
+            'author' => {
+              'id' => 1,
+              'name' => 'Steve K.',
+              'posts' => [
+                {
+                  'id' => 42, 'title' => 'New Post', 'body' => 'Body',
+                  'comments' => [
+                    {
+                      'id' => 1, 'body' => 'ZOMG A COMMENT'
+                    },
+                    {
+                      'id' => 2, 'body' => 'ZOMG ANOTHER COMMENT'
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+
+          assert_equal(expected, response)
+        end
+
+        def test_render_resource_with_deep_include
+          get :render_resource_with_deep_include
+
+          response = JSON.parse(@response.body)
+          expected = {
+            'author' => {
+              'id' => 1,
+              'name' => 'Steve K.',
+              'posts' => [
+                {
+                  'id' => 42, 'title' => 'New Post', 'body' => 'Body',
+                  'comments' => [
+                    {
+                      'id' => 1, 'body' => 'ZOMG A COMMENT',
+                      'author' => {
+                        'id' => 1,
+                        'name' => 'Steve K.'
+                      }
+                    },
+                    {
+                      'id' => 2, 'body' => 'ZOMG ANOTHER COMMENT',
+                      'author' => {
+                        'id' => 1,
+                        'name' => 'Steve K.'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+
+          assert_equal(expected, response)
+        end
+      end
+    end
+  end
+end

--- a/test/include_tree/include_args_to_hash_test.rb
+++ b/test/include_tree/include_args_to_hash_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class IncludeTree
+      module Parsing
+        class IncludeArgsToHashTest < MiniTest::Test
+          def test_include_args_to_hash_from_symbol
+            expected = { author: {} }
+            input = :author
+            actual = Parsing.include_args_to_hash(input)
+
+            assert_equal(expected, actual)
+          end
+
+          def test_include_args_to_hash_from_array
+            expected = { author: {}, comments: {} }
+            input = [:author, :comments]
+            actual = Parsing.include_args_to_hash(input)
+
+            assert_equal(expected, actual)
+          end
+
+          def test_include_args_to_hash_from_nested_array
+            expected = { author: {}, comments: { author: {} } }
+            input = [:author, comments: [:author]]
+            actual = Parsing.include_args_to_hash(input)
+
+            assert_equal(expected, actual)
+          end
+
+          def test_include_args_to_hash_from_array_of_hashes
+            expected = {
+              author: {},
+              blogs: { posts: { contributors: {} } },
+              comments: { author: { blogs: { posts: {} } } }
+            }
+            input = [
+              :author,
+              blogs: [posts: :contributors],
+              comments: { author: { blogs: :posts } }
+            ]
+            actual = Parsing.include_args_to_hash(input)
+
+            assert_equal(expected, actual)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Originally #1114 (I messed up the history because I merged instead of rebased)

This PR is based off of #1111, cause I needed the refactoring.

Discussion of idea here: #1113

Relates to:
#921
#1073

Basically:

```ruby
BlogSerializer < #...
  has_many :posts, include: { author: [:bio], comments: [:author]] }
end
```
resulting json may look like:

```
{
  blog: {
    posts: [
      {
        author: {
          bio: {...}
        },
        comments: [
          {  author: {...} }
        ]
      }
    ]
  }
}
```

See the included tests for more examples.