### PR TITLE
Add basic support for xml

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -6,6 +6,12 @@ module ActionController
 
     include ActionController::Renderers
 
+    RENDERER_METHODS = [
+      :_render_option_json,
+      :_render_with_renderer_json,
+      :_render_option_xml,
+      :_render_with_renderer_xml
+    ]
     # Deprecated
     ADAPTER_OPTION_KEYS = ActiveModel::SerializableResource::ADAPTER_OPTION_KEYS
 
@@ -45,7 +51,7 @@ module ActionController
       true
     end
 
-    [:_render_option_json, :_render_with_renderer_json].each do |renderer_method|
+    RENDERER_METHODS.each do |renderer_method|
       define_method renderer_method do |resource, options|
         options.fetch(:context) { options[:context] = request }
         serializable_resource = get_serializer(resource, options)

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -36,6 +36,10 @@ module ActiveModel
         hash
       end
 
+      def to_xml(options = nil)
+        as_json(options).to_xml
+      end
+
       def fragment_cache(*args)
         raise NotImplementedError, 'This is an abstract method. Should be implemented at the concrete adapter.'
       end

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -136,6 +136,13 @@ module ActionController
           render json: like
         end
 
+        def render_object_xml
+          profile = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
+          with_adapter :flatten_json do
+            render xml: profile
+          end
+        end
+
         private
 
         def generate_cached_serializer(obj)
@@ -419,6 +426,14 @@ module ActionController
         assert_equal '', (capture(:stderr) {
           controller.get_serializer(Profile.new)
         })
+      end
+
+      def test_render_object_xml
+        get :render_object_xml
+
+        hash = Hash.from_xml(@response.body).each_value.first
+        assert_equal('application/xml', @response.content_type)
+        assert_equal({ 'name' => 'Name 1', 'description' => 'Description 1' }, hash)
       end
     end
   end


### PR DESCRIPTION
It's all in the title: do `render xml: resource` instead of `render json: resource`, and you get xml (the actual format will depend on the adapter used).