### PR TITLE
Rename Serializer subclasses to Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Windows Build Status -_ [![Build status](https://ci.appveyor.com/api/projects/s
 ActiveModel::Serializer brings convention over configuration to your JSON generation.
 
 AMS does this through two components: **serializers** and **adapters**.
-Serializers describe _which_ attributes and relationships should be serialized.
+Serializations describe _which_ attributes and relationships should be serialized.
 Adapters describe _how_ attributes and relationships should be serialized.
 
 By default AMS will use the **Flatten Json Adapter**. But we strongly advise you to use **JsonApi Adapter** that follows 1.0 of the format specified in [jsonapi.org/format](http://jsonapi.org/format).
@@ -31,7 +31,7 @@ Given two models, a `Post(title: string, body: text)` and a
 serializers:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerialization < ActiveModel::Serializer
   cache key: 'posts', expires_in: 3.hours
   attributes :title, :body
 
@@ -42,7 +42,7 @@ end
 and
 
 ```ruby
-class CommentSerializer < ActiveModel::Serializer
+class CommentSerialization < ActiveModel::Serializer
   attributes :name, :body
 
   belongs_to :post
@@ -75,7 +75,7 @@ ActiveModel::Serializer.config.adapter = :json
 If you would like the key in the outputted JSON to be different from its name in ActiveRecord, you can use the :key option to customize it:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerialization < ActiveModel::Serializer
   attributes :id, :body
 
   # look up :subject on the model, but use +title+ in the JSON
@@ -97,7 +97,7 @@ class PostsController < ApplicationController
 end
 ```
 
-In this case, Rails will look for a serializer named `PostSerializer`, and if
+In this case, Rails will look for a serializer named `PostSerialization`, and if
 it exists, use it to serialize the `Post`.
 
 ### Specify a serializer
@@ -107,7 +107,7 @@ If you wish to use a serializer other than the default, you can explicitly pass 
 #### 1. For a resource:
 
 ```ruby
-  render json: @post, serializer: PostPreviewSerializer
+  render json: @post, serializer: PostPreviewSerialization
 ```
 
 #### 2. For an array resource:
@@ -115,10 +115,10 @@ If you wish to use a serializer other than the default, you can explicitly pass 
 ```ruby
 # Use the default `ArraySerializer`, which will use `each_serializer` to
 # serialize each element
-render json: @posts, each_serializer: PostPreviewSerializer
+render json: @posts, each_serializer: PostPreviewSerialization
 
 # Or, you can explicitly provide the collection serializer as well
-render json: @posts, serializer: CollectionSerializer, each_serializer: PostPreviewSerializer
+render json: @posts, serializer: CollectionSerialization, each_serializer: PostPreviewSerialization
 ```
 
 ### Meta
@@ -160,7 +160,7 @@ end
 If you want to override any association, you can use:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerialization < ActiveModel::Serializer
   attributes :id, :body
 
   has_many :comments
@@ -176,7 +176,7 @@ end
 If you want to override any attribute, you can use:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerialization < ActiveModel::Serializer
   attributes :id, :body
 
   has_many :comments
@@ -226,7 +226,7 @@ And then execute:
 $ bundle
 ```
 
-## Creating a Serializer
+## Creating a Serialization
 
 The easiest way to create a new serializer is to generate a new resource, which
 will generate a serializer at the same time:
@@ -247,7 +247,7 @@ The generated seralizer will contain basic `attributes` and
 `has_many`/`has_one`/`belongs_to` declarations, based on the model. For example:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerialization < ActiveModel::Serializer
   attributes :title, :body
 
   has_many :comments
@@ -258,7 +258,7 @@ end
 and
 
 ```ruby
-class CommentSerializer < ActiveModel::Serializer
+class CommentSerialization < ActiveModel::Serializer
   attributes :name, :body
 
   belongs_to :post_id
@@ -274,7 +274,7 @@ as well.
 You may also use the `:serializer` option to specify a custom serializer class, for example:
 
 ```ruby
-  has_many :comments, serializer: CommentPreviewSerializer
+  has_many :comments, serializer: CommentPreviewSerialization
 ```
 
 And you can change the JSON key that the serializer should use for a particular association:
@@ -309,7 +309,7 @@ cache(options = nil) # options: ```{key, expires_in, compress, force, race_condi
 Take the example bellow:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerialization < ActiveModel::Serializer
   cache key: 'post', expires_in: 3.hours
   attributes :title, :body
 
@@ -332,7 +332,7 @@ You can define the attribute by using ```only``` or ```except``` option on cache
 Example:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerialization < ActiveModel::Serializer
   cache key: 'post', expires_in: 3.hours, only: [:title]
   attributes :title, :body
 

--- a/docs/general/adapters.md
+++ b/docs/general/adapters.md
@@ -1,7 +1,7 @@
 # Adapters
 
 AMS does this through two components: **serializers** and **adapters**.
-Serializers describe _which_ attributes and relationships should be serialized.
+Serializations describe _which_ attributes and relationships should be serialized.
 Adapters describe _how_ attributes and relationships should be serialized.
 You can use one of the built-in adapters (```FlattenJSON``` is the default one) or create one by yourself, but you won't need to implement an adapter unless you wish to use a new format or media type with AMS.
 

--- a/docs/general/getting_started.md
+++ b/docs/general/getting_started.md
@@ -16,7 +16,7 @@ And then execute:
 $ bundle
 ```
 
-## Creating a Serializer
+## Creating a Serialization
 
 The easiest way to create a new serializer is to generate a new resource, which
 will generate a serializer at the same time:
@@ -37,7 +37,7 @@ The generated seralizer will contain basic `attributes` and
 `has_many`/`has_one`/`belongs_to` declarations, based on the model. For example:
 
 ```ruby
-class PostSerializer < ActiveModel::Serializer
+class PostSerialization < ActiveModel::Serializer
   attributes :title, :body
 
   has_many :comments
@@ -49,7 +49,7 @@ end
 and
 
 ```ruby
-class CommentSerializer < ActiveModel::Serializer
+class CommentSerialization < ActiveModel::Serializer
   attributes :name, :body
 
   belongs_to :post_id

--- a/docs/howto/add_pagination_links.md
+++ b/docs/howto/add_pagination_links.md
@@ -67,12 +67,12 @@ If you are using `JSON` adapter, pagination links will not be included automatic
 
 In your action specify a custom serializer.
 ```ruby
-render json: @posts, serializer: PaginatedSerializer, each_serializer: PostPreviewSerializer
+render json: @posts, serializer: PaginatedSerialization, each_serializer: PostPreviewSerialization
 ```
 
 And then, you could do something like the following class.
 ```ruby
-class PaginatedSerializer < ActiveModel::Serializer::ArraySerializer
+class PaginatedSerialization < ActiveModel::Serializer::ArraySerializer
   def initialize(object, options={})
     meta_key = options[:meta_key] || :meta
     options[meta_key] ||= {}

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -157,7 +157,7 @@ module ActiveModel
 
     def self.get_serializer_for(klass)
       serializers_cache.fetch_or_store(klass) do
-        serializer_class_name = "#{klass.name}Serializer"
+        serializer_class_name = "#{klass.name}Serialization"
         serializer_class = serializer_class_name.safe_constantize
 
         if serializer_class

--- a/lib/active_model/serializer/adapter/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/fragment_cache.rb
@@ -37,21 +37,21 @@ class ActiveModel::Serializer::Adapter::FragmentCache
           cached_attributes.each do |attribute|
             options = serializer.class._attributes_keys[attribute]
             options ||= {}
-            # Add cached attributes to cached Serializer
+            # Add cached attributes to cached Serialization
             serializers[:cached].constantize.attribute(attribute, options)
           end
 
           non_cached_attributes.each do |attribute|
             options = serializer.class._attributes_keys[attribute]
             options ||= {}
-            # Add non-cached attributes to non-cached Serializer
+            # Add non-cached attributes to non-cached Serialization
             serializers[:non_cached].constantize.attribute(attribute, options)
           end
         end
 
         def fragment_serializer(name, klass)
-          cached     = "#{to_valid_const_name(name)}CachedSerializer"
-          non_cached = "#{to_valid_const_name(name)}NonCachedSerializer"
+          cached     = "#{to_valid_const_name(name)}CachedSerialization"
+          non_cached = "#{to_valid_const_name(name)}NonCachedSerialization"
 
           Object.const_set cached, Class.new(ActiveModel::Serializer) unless Object.const_defined?(cached)
           Object.const_set non_cached, Class.new(ActiveModel::Serializer) unless Object.const_defined?(non_cached)

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -1,7 +1,7 @@
 module ActiveModel
   class Serializer
     class ArraySerializer
-      NoSerializerError = Class.new(StandardError)
+      NoSerializationError = Class.new(StandardError)
       include Enumerable
       delegate :each, to: :@serializers
 
@@ -16,7 +16,7 @@ module ActiveModel
           }
 
           if serializer_class.nil?
-            fail NoSerializerError, "No serializer found for resource: #{resource.inspect}"
+            fail NoSerializationError, "No serialization found for resource: #{resource.inspect}"
           else
             serializer_class.new(resource, options.except(:serializer))
           end

--- a/lib/generators/serializer/serializer_generator.rb
+++ b/lib/generators/serializer/serializer_generator.rb
@@ -2,7 +2,7 @@ module Rails
   module Generators
     class SerializerGenerator < NamedBase
       source_root File.expand_path('../templates', __FILE__)
-      check_class_collision :suffix => 'Serializer'
+      check_class_collision :suffix => 'Serialization'
 
       argument :attributes, :type => :array, :default => [], :banner => 'field:type field:type'
 

--- a/lib/generators/serializer/templates/serializer.rb.erb
+++ b/lib/generators/serializer/templates/serializer.rb.erb
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= class_name %>Serializer < <%= parent_class_name %>
+class <%= class_name %>Serialization < <%= parent_class_name %>
   attributes <%= attributes_names.map(&:inspect).join(", ") %>
 <% association_names.each do |attribute| -%>
   has_one :<%= attribute %>

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -2,13 +2,13 @@ require 'test_helper'
 
 module ActionController
   module Serialization
-    class ExplicitSerializerTest < ActionController::TestCase
-      class ExplicitSerializerTestController < ActionController::Base
+    class ExplicitSerializationTest < ActionController::TestCase
+      class ExplicitSerializationTestController < ActionController::Base
         def render_using_explicit_serializer
           @profile = Profile.new(name: 'Name 1',
                                  description: 'Description 1',
                                  comments: 'Comments 1')
-          render json: @profile, serializer: ProfilePreviewSerializer
+          render json: @profile, serializer: ProfilePreviewSerialization
         end
 
         def render_array_using_explicit_serializer
@@ -21,8 +21,8 @@ module ActionController
                         comments: 'Comments 2')
           ]
           render json: array,
-                 serializer: PaginatedSerializer,
-                 each_serializer: ProfilePreviewSerializer
+                 serializer: PaginatedSerialization,
+                 each_serializer: ProfilePreviewSerialization
         end
 
         def render_array_using_implicit_serializer
@@ -35,7 +35,7 @@ module ActionController
                         comments: 'Comments 2')
           ]
           render json: array,
-                 each_serializer: ProfilePreviewSerializer
+                 each_serializer: ProfilePreviewSerialization
         end
 
         def render_array_using_explicit_serializer_and_custom_serializers
@@ -53,18 +53,18 @@ module ActionController
           @blog = Blog.new(id: 23, name: 'AMS Blog')
           @post.blog = @blog
 
-          render json: [@post], each_serializer: PostPreviewSerializer
+          render json: [@post], each_serializer: PostPreviewSerialization
         end
 
         def render_using_explicit_each_serializer
           location       = Location.new(id: 42, lat: '-23.550520', lng: '-46.633309')
           place          = Place.new(id: 1337, name: 'Amazing Place', locations: [location])
 
-          render json: place, each_serializer: PlaceSerializer
+          render json: place, each_serializer: PlaceSerialization
         end
       end
 
-      tests ExplicitSerializerTestController
+      tests ExplicitSerializationTestController
 
       def test_render_using_explicit_serializer
         get :render_using_explicit_serializer
@@ -122,7 +122,7 @@ module ActionController
               id: 42,
               lat: '-23.550520',
               lng: '-46.633309',
-              place: 'Nowhere' # is a virtual attribute on LocationSerializer
+              place: 'Nowhere' # is a virtual attribute on LocationSerialization
             }
           ]
         }

--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'pathname'
 
 class DefaultScopeNameTest < ActionController::TestCase
-  class UserSerializer < ActiveModel::Serializer
+  class UserSerialization < ActiveModel::Serializer
     attributes :admin?
     ActiveModelSerializers.silence_warnings do
       def admin?
@@ -21,7 +21,7 @@ class DefaultScopeNameTest < ActionController::TestCase
     end
 
     def render_new_user
-      render json: User.new(id: 1, name: 'Pete', admin: false), serializer: UserSerializer, adapter: :json_api
+      render json: User.new(id: 1, name: 'Pete', admin: false), serializer: UserSerialization, adapter: :json_api
     end
   end
 
@@ -34,7 +34,7 @@ class DefaultScopeNameTest < ActionController::TestCase
 end
 
 class SerializationScopeNameTest < ActionController::TestCase
-  class AdminUserSerializer < ActiveModel::Serializer
+  class AdminUserSerialization < ActiveModel::Serializer
     attributes :admin?
     ActiveModelSerializers.silence_warnings do
       def admin?
@@ -54,7 +54,7 @@ class SerializationScopeNameTest < ActionController::TestCase
     end
 
     def render_new_user
-      render json: User.new(id: 1, name: 'Pete', admin: false), serializer: AdminUserSerializer, adapter: :json_api
+      render json: User.new(id: 1, name: 'Pete', admin: false), serializer: AdminUserSerialization, adapter: :json_api
     end
   end
 

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActionController
   module Serialization
-    class ImplicitSerializerTest < ActionController::TestCase
+    class ImplicitSerializationTest < ActionController::TestCase
       include ActiveSupport::Testing::Stream
       class ImplicitSerializationTestController < ActionController::Base
         include SerializationTesting

--- a/test/adapter/fragment_cache_test.rb
+++ b/test/adapter/fragment_cache_test.rb
@@ -8,10 +8,10 @@ module ActiveModel
           @author          = Author.new(name: 'Joao M. D. Moura')
           @role            = Role.new(name: 'Great Author', description: nil)
           @role.author     = [@author]
-          @role_serializer = RoleSerializer.new(@role)
-          @spam_serializer = Spam::UnrelatedLinkSerializer.new(@spam)
-          @role_hash       = FragmentCache.new(RoleSerializer.adapter.new(@role_serializer), @role_serializer, {})
-          @spam_hash       = FragmentCache.new(Spam::UnrelatedLinkSerializer.adapter.new(@spam_serializer), @spam_serializer, {})
+          @role_serializer = RoleSerialization.new(@role)
+          @spam_serializer = Spam::UnrelatedLinkSerialization.new(@spam)
+          @role_hash       = FragmentCache.new(RoleSerialization.adapter.new(@role_serializer), @role_serializer, {})
+          @spam_hash       = FragmentCache.new(Spam::UnrelatedLinkSerialization.adapter.new(@spam_serializer), @spam_serializer, {})
         end
 
         def test_fragment_fetch_with_virtual_attributes

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -18,7 +18,7 @@ module ActiveModel
             @post.blog = @blog
             @anonymous_post.blog = nil
 
-            @serializer = CommentSerializer.new(@comment)
+            @serializer = CommentSerialization.new(@comment)
             @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
             ActionController::Base.cache_store.clear
           end
@@ -28,14 +28,14 @@ module ActiveModel
           end
 
           def test_include_nil_author
-            serializer = PostSerializer.new(@anonymous_post)
+            serializer = PostSerialization.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
             assert_equal({ post: { title: 'Hello!!', body: 'Hello, world!!', id: 43, comments: [], blog: { id: 999, name: 'Custom blog' }, author: nil } }, adapter.serializable_hash)
           end
 
           def test_include_nil_author_with_specified_serializer
-            serializer = PostPreviewSerializer.new(@anonymous_post)
+            serializer = PostPreviewSerialization.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
             assert_equal({ post: { title: 'Hello!!', body: 'Hello, world!!', id: 43, comments: [], author: nil } }, adapter.serializable_hash)

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -23,7 +23,7 @@ module ActiveModel
           def test_with_serializer_option
             @blog.special_attribute = 'Special'
             @blog.articles = [@first_post, @second_post]
-            serializer = ArraySerializer.new([@blog], serializer: CustomBlogSerializer)
+            serializer = ArraySerializer.new([@blog], serializer: CustomBlogSerialization)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
             expected = { blogs: [{

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -22,7 +22,7 @@ module ActiveModel
           end
 
           def test_has_many
-            serializer = PostSerializer.new(@post)
+            serializer = PostSerialization.new(@post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
             assert_equal([
                            { id: 1, body: 'ZOMG A COMMENT' },
@@ -31,7 +31,7 @@ module ActiveModel
           end
 
           def test_has_many_with_no_serializer
-            serializer = PostWithTagsSerializer.new(@post)
+            serializer = PostWithTagsSerialization.new(@post)
             adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
             assert_equal({
               id: 42,

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -26,7 +26,7 @@ module ActiveModel
             @blog.articles = [@post, @anonymous_post]
             @author.posts = []
 
-            @serializer = CommentSerializer.new(@comment)
+            @serializer = CommentSerialization.new(@comment)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
             ActionController::Base.cache_store.clear
           end
@@ -73,14 +73,14 @@ module ActiveModel
           end
 
           def test_include_nil_author
-            serializer = PostSerializer.new(@anonymous_post)
+            serializer = PostSerialization.new(@anonymous_post)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
 
             assert_equal({ comments: { data: [] }, blog: { data: { type: 'blogs', id: '999' } }, author: { data: nil } }, adapter.serializable_hash[:data][:relationships])
           end
 
           def test_include_type_for_association_when_different_than_name
-            serializer = BlogSerializer.new(@blog)
+            serializer = BlogSerialization.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
             relationships = adapter.serializable_hash[:data][:relationships]
             expected = {
@@ -107,7 +107,7 @@ module ActiveModel
           end
 
           def test_include_linked_resources_with_type_name
-            serializer = BlogSerializer.new(@blog)
+            serializer = BlogSerialization.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer, include: [:writer, :articles])
             linked = adapter.serializable_hash[:included]
             expected = [

--- a/test/adapter/json_api/has_many_embed_ids_test.rb
+++ b/test/adapter/json_api/has_many_embed_ids_test.rb
@@ -20,7 +20,7 @@ module ActiveModel
             @first_post.blog = @blog
             @second_post.blog = nil
 
-            @serializer = AuthorSerializer.new(@author)
+            @serializer = AuthorSerialization.new(@author)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
           end
 

--- a/test/adapter/json_api/has_many_explicit_serializer_test.rb
+++ b/test/adapter/json_api/has_many_explicit_serializer_test.rb
@@ -4,8 +4,8 @@ module ActiveModel
   class Serializer
     class Adapter
       class JsonApi
-        # Test 'has_many :assocs, serializer: AssocXSerializer'
-        class HasManyExplicitSerializerTest < Minitest::Test
+        # Test 'has_many :assocs, serializer: AssocXSerialization'
+        class HasManyExplicitSerializationTest < Minitest::Test
           def setup
             @post = Post.new(title: 'New Post', body: 'Body')
             @author = Author.new(name: 'Jane Blogger')
@@ -21,7 +21,7 @@ module ActiveModel
             @blog = Blog.new(id: 23, name: 'AMS Blog')
             @post.blog = @blog
 
-            @serializer = PostPreviewSerializer.new(@post)
+            @serializer = PostPreviewSerialization.new(@post)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(
               @serializer,
               include: [:comments, :author]
@@ -40,7 +40,7 @@ module ActiveModel
           end
 
           def test_includes_linked_data
-            # If CommentPreviewSerializer is applied correctly the body text will not be present in the output
+            # If CommentPreviewSerialization is applied correctly the body text will not be present in the output
             expected = [
               {
                 id: '1',

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -29,7 +29,7 @@ module ActiveModel
             @post_without_comments.blog = nil
             @tag = Tag.new(id: 1, name: '#hash_tag')
             @post.tags = [@tag]
-            @serializer = PostSerializer.new(@post)
+            @serializer = PostSerialization.new(@post)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
 
             @virtual_value = VirtualValue.new(id: 1)
@@ -88,14 +88,14 @@ module ActiveModel
           end
 
           def test_no_include_linked_if_comments_is_empty
-            serializer = PostSerializer.new(@post_without_comments)
+            serializer = PostSerialization.new(@post_without_comments)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
 
             assert_nil adapter.serializable_hash[:linked]
           end
 
           def test_include_type_for_association_when_different_than_name
-            serializer = BlogSerializer.new(@blog)
+            serializer = BlogSerialization.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
             actual = adapter.serializable_hash[:data][:relationships][:articles]
 
@@ -109,7 +109,7 @@ module ActiveModel
           end
 
           def test_has_many_with_no_serializer
-            serializer = PostWithTagsSerializer.new(@post)
+            serializer = PostWithTagsSerialization.new(@post)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
 
             assert_equal({
@@ -124,7 +124,7 @@ module ActiveModel
           end
 
           def test_has_many_with_virtual_value
-            serializer = VirtualValueSerializer.new(@virtual_value)
+            serializer = VirtualValueSerialization.new(@virtual_value)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
 
             assert_equal({

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -27,7 +27,7 @@ module ActiveModel
 
             @virtual_value = VirtualValue.new(id: 1)
 
-            @serializer = AuthorSerializer.new(@author)
+            @serializer = AuthorSerialization.new(@author)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: [:bio, :posts])
           end
 
@@ -58,7 +58,7 @@ module ActiveModel
           end
 
           def test_has_one_with_virtual_value
-            serializer = VirtualValueSerializer.new(@virtual_value)
+            serializer = VirtualValueSerialization.new(@virtual_value)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
 
             expected = {

--- a/test/adapter/json_api/json_api_test.rb
+++ b/test/adapter/json_api/json_api_test.rb
@@ -19,7 +19,7 @@ module ActiveModel
         end
 
         def test_custom_keys
-          serializer = PostWithCustomKeysSerializer.new(@post)
+          serializer = PostWithCustomKeysSerialization.new(@post)
           adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
 
           assert_equal({

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -150,7 +150,7 @@ module ActiveModel
           end
 
           def test_include_multiple_posts_and_linked
-            serializer = BioSerializer.new @bio1
+            serializer = BioSerialization.new @bio1
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(
               serializer,
               include: [author: [:posts]]
@@ -206,7 +206,7 @@ module ActiveModel
           def test_underscore_model_namespace_for_linked_resource_type
             spammy_post = Post.new(id: 123)
             spammy_post.related = [Spam::UnrelatedLink.new(id: 456)]
-            serializer = SpammyPostSerializer.new(spammy_post)
+            serializer = SpammyPostSerialization.new(spammy_post)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
             relationships = adapter.serializable_hash[:data][:relationships]
             expected = {
@@ -254,7 +254,7 @@ module ActiveModel
 
           def test_nil_link_with_specified_serializer
             @first_post.author = nil
-            serializer = PostPreviewSerializer.new(@first_post)
+            serializer = PostPreviewSerialization.new(@first_post)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(
               serializer,
               include: [:author]

--- a/test/adapter/json_test.rb
+++ b/test/adapter/json_test.rb
@@ -17,7 +17,7 @@ module ActiveModel
           @blog = Blog.new(id: 1, name: 'My Blog!!')
           @post.blog = @blog
 
-          @serializer = PostSerializer.new(@post)
+          @serializer = PostSerialization.new(@post)
           @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
         end
 
@@ -29,7 +29,7 @@ module ActiveModel
         end
 
         def test_custom_keys
-          serializer = PostWithCustomKeysSerializer.new(@post)
+          serializer = PostWithCustomKeysSerialization.new(@post)
           adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
 
           assert_equal({

--- a/test/adapter/null_test.rb
+++ b/test/adapter/null_test.rb
@@ -6,7 +6,7 @@ module ActiveModel
       class NullTest < Minitest::Test
         def setup
           profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
-          serializer = ProfileSerializer.new(profile)
+          serializer = ProfileSerialization.new(profile)
 
           @adapter = Null.new(serializer)
         end

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -5,7 +5,7 @@ module ActiveModel
     class AdapterTest < Minitest::Test
       def setup
         profile = Profile.new
-        @serializer = ProfileSerializer.new(profile)
+        @serializer = ProfileSerialization.new(profile)
         @adapter = ActiveModel::Serializer::Adapter.new(@serializer)
       end
 

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -26,17 +26,17 @@ module ActiveModel
       def test_each_object_should_be_serialized_with_appropriate_serializer
         serializers =  @serializer.to_a
 
-        assert_kind_of CommentSerializer, serializers.first
+        assert_kind_of CommentSerialization, serializers.first
         assert_kind_of Comment, serializers.first.object
 
-        assert_kind_of PostSerializer, serializers.last
+        assert_kind_of PostSerialization, serializers.last
         assert_kind_of Post, serializers.last.object
 
         assert_equal serializers.last.custom_options[:some], :options
       end
 
       def test_serializer_option_not_passed_to_each_serializer
-        serializers = ArraySerializer.new([@post], { serializer: PostSerializer }).to_a
+        serializers = ArraySerializer.new([@post], { serializer: PostSerialization }).to_a
 
         refute serializers.first.custom_options.key?(:serializer)
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -35,20 +35,20 @@ module ARModels
     has_many :posts
   end
 
-  class PostSerializer < ActiveModel::Serializer
+  class PostSerialization < ActiveModel::Serializer
     attributes :id, :title, :body
 
     has_many :comments
     belongs_to :author
   end
 
-  class CommentSerializer < ActiveModel::Serializer
+  class CommentSerialization < ActiveModel::Serializer
     attributes :id, :contents
 
     belongs_to :author
   end
 
-  class AuthorSerializer < ActiveModel::Serializer
+  class AuthorSerialization < ActiveModel::Serializer
     attributes :id, :name
 
     has_many :posts

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -56,7 +56,7 @@ end
 class Profile < Model
 end
 
-class ProfileSerializer < ActiveModel::Serializer
+class ProfileSerialization < ActiveModel::Serializer
   attributes :name, :description
 
   def arguments_passed_in?
@@ -64,7 +64,7 @@ class ProfileSerializer < ActiveModel::Serializer
   end
 end
 
-class ProfilePreviewSerializer < ActiveModel::Serializer
+class ProfilePreviewSerialization < ActiveModel::Serializer
   attributes :name
 end
 
@@ -89,7 +89,7 @@ end
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
 
-PostSerializer = Class.new(ActiveModel::Serializer) do
+PostSerialization = Class.new(ActiveModel::Serializer) do
   cache key: 'post', expires_in: 0.1, skip_digest: true
   attributes :id, :title, :body
 
@@ -106,7 +106,7 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
+SpammyPostSerialization = Class.new(ActiveModel::Serializer) do
   attributes :id
   has_many :related
 
@@ -115,7 +115,7 @@ SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-CommentSerializer = Class.new(ActiveModel::Serializer) do
+CommentSerialization = Class.new(ActiveModel::Serializer) do
   cache expires_in: 1.day, skip_digest: true
   attributes :id, :body
 
@@ -127,7 +127,7 @@ CommentSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-AuthorSerializer = Class.new(ActiveModel::Serializer) do
+AuthorSerialization = Class.new(ActiveModel::Serializer) do
   cache key: 'writer', skip_digest: true
   attribute :id
   attribute :name
@@ -137,7 +137,7 @@ AuthorSerializer = Class.new(ActiveModel::Serializer) do
   has_one :bio
 end
 
-RoleSerializer = Class.new(ActiveModel::Serializer) do
+RoleSerialization = Class.new(ActiveModel::Serializer) do
   cache only: [:name], skip_digest: true
   attributes :id, :name, :description, :slug
 
@@ -148,13 +148,13 @@ RoleSerializer = Class.new(ActiveModel::Serializer) do
   belongs_to :author
 end
 
-LikeSerializer = Class.new(ActiveModel::Serializer) do
+LikeSerialization = Class.new(ActiveModel::Serializer) do
   attributes :id, :time
 
   belongs_to :likeable
 end
 
-LocationSerializer = Class.new(ActiveModel::Serializer) do
+LocationSerialization = Class.new(ActiveModel::Serializer) do
   cache only: [:place], skip_digest: true
   attributes :id, :lat, :lng
 
@@ -165,20 +165,20 @@ LocationSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-PlaceSerializer = Class.new(ActiveModel::Serializer) do
+PlaceSerialization = Class.new(ActiveModel::Serializer) do
   attributes :id, :name
 
   has_many :locations
 end
 
-BioSerializer = Class.new(ActiveModel::Serializer) do
+BioSerialization = Class.new(ActiveModel::Serializer) do
   cache except: [:content], skip_digest: true
   attributes :id, :content, :rating
 
   belongs_to :author
 end
 
-BlogSerializer = Class.new(ActiveModel::Serializer) do
+BlogSerialization = Class.new(ActiveModel::Serializer) do
   cache key: 'blog'
   attributes :id, :name
 
@@ -186,54 +186,54 @@ BlogSerializer = Class.new(ActiveModel::Serializer) do
   has_many :articles
 end
 
-PaginatedSerializer = Class.new(ActiveModel::Serializer::ArraySerializer) do
+PaginatedSerialization = Class.new(ActiveModel::Serializer::ArraySerializer) do
   def json_key
     'paginated'
   end
 end
 
-AlternateBlogSerializer = Class.new(ActiveModel::Serializer) do
+AlternateBlogSerialization = Class.new(ActiveModel::Serializer) do
   attribute :id
   attribute :name, key: :title
 end
 
-CustomBlogSerializer = Class.new(ActiveModel::Serializer) do
+CustomBlogSerialization = Class.new(ActiveModel::Serializer) do
   attribute :id
   attribute :special_attribute
 
   has_many :articles
 end
 
-CommentPreviewSerializer = Class.new(ActiveModel::Serializer) do
+CommentPreviewSerialization = Class.new(ActiveModel::Serializer) do
   attributes :id
 
   belongs_to :post
 end
 
-AuthorPreviewSerializer = Class.new(ActiveModel::Serializer) do
+AuthorPreviewSerialization = Class.new(ActiveModel::Serializer) do
   attributes :id
 
   has_many :posts
 end
 
-PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
+PostPreviewSerialization = Class.new(ActiveModel::Serializer) do
   def self.root_name
     'posts'
   end
 
   attributes :title, :body, :id
 
-  has_many :comments, serializer: CommentPreviewSerializer
-  belongs_to :author, serializer: AuthorPreviewSerializer
+  has_many :comments, serializer: CommentPreviewSerialization
+  belongs_to :author, serializer: AuthorPreviewSerialization
 end
 
-PostWithTagsSerializer = Class.new(ActiveModel::Serializer) do
+PostWithTagsSerialization = Class.new(ActiveModel::Serializer) do
   attributes :id
 
   has_many :tags
 end
 
-PostWithCustomKeysSerializer = Class.new(ActiveModel::Serializer) do
+PostWithCustomKeysSerialization = Class.new(ActiveModel::Serializer) do
   attributes :id
 
   has_many :comments, key: :reviews
@@ -241,7 +241,7 @@ PostWithCustomKeysSerializer = Class.new(ActiveModel::Serializer) do
   has_one :blog, key: :site
 end
 
-VirtualValueSerializer = Class.new(ActiveModel::Serializer) do
+VirtualValueSerialization = Class.new(ActiveModel::Serializer) do
   attributes :id
 
   has_many :reviews, virtual_value: [{ id: 1 }, { id: 2 }]
@@ -254,7 +254,7 @@ VirtualValueSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do
+Spam::UnrelatedLinkSerialization = Class.new(ActiveModel::Serializer) do
   cache only: [:id]
   attributes :id
 end

--- a/test/generators/scaffold_controller_generator_test.rb
+++ b/test/generators/scaffold_controller_generator_test.rb
@@ -10,7 +10,7 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
   def test_serializer_file_is_generated
     run_generator
 
-    assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < ActiveModel::Serializer/
+    assert_file 'app/serializers/account_serializer.rb', /class AccountSerialization < ActiveModel::Serializer/
   end
 
   private

--- a/test/generators/serializer_generator_test.rb
+++ b/test/generators/serializer_generator_test.rb
@@ -5,33 +5,33 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
   destination File.expand_path('../../../tmp/generators', __FILE__)
   setup :prepare_destination
 
-  tests Rails::Generators::SerializerGenerator
+  tests Rails::Generators::SerializationGenerator
   arguments %w(account name:string description:text business:references)
 
   def test_generates_a_serializer
     run_generator
-    assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < ActiveModel::Serializer/
+    assert_file 'app/serializers/account_serializer.rb', /class AccountSerialization < ActiveModel::Serializer/
   end
 
   def test_generates_a_namespaced_serializer
     run_generator ['admin/account']
-    assert_file 'app/serializers/admin/account_serializer.rb', /class Admin::AccountSerializer < ActiveModel::Serializer/
+    assert_file 'app/serializers/admin/account_serializer.rb', /class Admin::AccountSerialization < ActiveModel::Serializer/
   end
 
   def test_uses_application_serializer_if_one_exists
-    Object.const_set(:ApplicationSerializer, Class.new)
+    Object.const_set(:ApplicationSerialization, Class.new)
     run_generator
-    assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < ApplicationSerializer/
+    assert_file 'app/serializers/account_serializer.rb', /class AccountSerialization < ApplicationSerialization/
   ensure
-    Object.send :remove_const, :ApplicationSerializer
+    Object.send :remove_const, :ApplicationSerialization
   end
 
   def test_uses_given_parent
-    Object.const_set(:ApplicationSerializer, Class.new)
-    run_generator ['Account', '--parent=MySerializer']
-    assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < MySerializer/
+    Object.const_set(:ApplicationSerialization, Class.new)
+    run_generator ['Account', '--parent=MySerialization']
+    assert_file 'app/serializers/account_serializer.rb', /class AccountSerialization < MySerialization/
   ensure
-    Object.send :remove_const, :ApplicationSerializer
+    Object.send :remove_const, :ApplicationSerialization
   end
 
   def test_generates_attributes_and_associations

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class SerializableResourceTest < Minitest::Test
     def setup
       @resource = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
-      @serializer = ProfileSerializer.new(@resource)
+      @serializer = ProfileSerialization.new(@resource)
       @adapter = ActiveModel::Serializer::Adapter.create(@serializer)
       @serializable_resource = ActiveModel::SerializableResource.new(@resource)
     end

--- a/test/serializers/association_macros_test.rb
+++ b/test/serializers/association_macros_test.rb
@@ -3,15 +3,15 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class AssociationMacrosTest < Minitest::Test
-      AuthorSummarySerializer = Class.new
-      class AssociationsTestSerializer < Serializer
-        belongs_to :author, serializer: AuthorSummarySerializer
+      AuthorSummarySerialization = Class.new
+      class AssociationsTestSerialization < ActiveModel::Serializer
+        belongs_to :author, serializer: AuthorSummarySerialization
         has_many :comments
         has_one :category
       end
 
       def before_setup
-        @reflections = AssociationsTestSerializer._reflections
+        @reflections = AssociationsTestSerialization._reflections
       end
 
       def test_has_one_defines_reflection
@@ -27,7 +27,7 @@ module ActiveModel
       end
 
       def test_belongs_to_defines_reflection
-        belongs_to_reflection = BelongsToReflection.new(:author, serializer: AuthorSummarySerializer)
+        belongs_to_reflection = BelongsToReflection.new(:author, serializer: AuthorSummarySerialization)
 
         assert_includes(@reflections, belongs_to_reflection)
       end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -39,9 +39,9 @@ module ActiveModel
         @post.author = @author
         @author.posts = [@post]
 
-        @post_serializer = PostSerializer.new(@post, { custom_options: true })
-        @author_serializer = AuthorSerializer.new(@author)
-        @comment_serializer = CommentSerializer.new(@comment)
+        @post_serializer = PostSerialization.new(@post, { custom_options: true })
+        @author_serializer = AuthorSerialization.new(@author)
+        @comment_serializer = CommentSerialization.new(@comment)
       end
 
       def test_has_many_and_has_one
@@ -67,7 +67,7 @@ module ActiveModel
       end
 
       def test_has_many_with_no_serializer
-        PostWithTagsSerializer.new(@post).associations.each do |association|
+        PostWithTagsSerialization.new(@post).associations.each do |association|
           key = association.key
           serializer = association.serializer
           options = association.options
@@ -93,7 +93,7 @@ module ActiveModel
 
           case key
           when :post
-            assert_kind_of(PostSerializer, serializer)
+            assert_kind_of(PostSerialization, serializer)
           when :author
             assert_nil serializer
           else
@@ -113,18 +113,18 @@ module ActiveModel
       end
 
       def test_associations_inheritance
-        inherited_klass = Class.new(PostSerializer)
+        inherited_klass = Class.new(PostSerialization)
 
-        assert_equal(PostSerializer._reflections, inherited_klass._reflections)
+        assert_equal(PostSerialization._reflections, inherited_klass._reflections)
       end
 
       def test_associations_inheritance_with_new_association
-        inherited_klass = Class.new(PostSerializer) do
-          has_many :top_comments, serializer: CommentSerializer
+        inherited_klass = Class.new(PostSerialization) do
+          has_many :top_comments, serializer: CommentSerialization
         end
 
         assert(
-          PostSerializer._reflections.all? do |reflection|
+          PostSerialization._reflections.all? do |reflection|
             inherited_klass._reflections.include?(reflection)
           end
         )
@@ -137,7 +137,7 @@ module ActiveModel
       end
 
       def test_associations_custom_keys
-        serializer = PostWithCustomKeysSerializer.new(@post)
+        serializer = PostWithCustomKeysSerialization.new(@post)
 
         expected_association_keys = serializer.associations.map(&:key)
 

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -5,7 +5,7 @@ module ActiveModel
     class AttributeTest < Minitest::Test
       def setup
         @blog = Blog.new({ id: 1, name: 'AMS Hints', type: 'stuff' })
-        @blog_serializer = AlternateBlogSerializer.new(@blog)
+        @blog_serializer = AlternateBlogSerialization.new(@blog)
       end
 
       def test_attributes_definition
@@ -19,7 +19,7 @@ module ActiveModel
       end
 
       def test_attribute_inheritance_with_key
-        inherited_klass = Class.new(AlternateBlogSerializer)
+        inherited_klass = Class.new(AlternateBlogSerialization)
         blog_serializer = inherited_klass.new(@blog)
         adapter = ActiveModel::Serializer::Adapter::FlattenJson.new(blog_serializer)
         assert_equal({ :id => 1, :title => 'AMS Hints' }, adapter.serializable_hash)

--- a/test/serializers/attributes_test.rb
+++ b/test/serializers/attributes_test.rb
@@ -5,10 +5,10 @@ module ActiveModel
     class AttributesTest < Minitest::Test
       def setup
         @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
-        @profile_serializer = ProfileSerializer.new(@profile)
+        @profile_serializer = ProfileSerialization.new(@profile)
         @comment = Comment.new(id: 1, body: 'ZOMG!!', date: '2015')
-        @serializer_klass = Class.new(CommentSerializer)
-        @serializer_klass_with_new_attributes = Class.new(CommentSerializer) do
+        @serializer_klass = Class.new(CommentSerialization)
+        @serializer_klass_with_new_attributes = Class.new(CommentSerialization) do
           attributes :date, :likes
         end
       end
@@ -35,7 +35,7 @@ module ActiveModel
 
       def test_attribute_inheritance_with_new_attribute_definition
         assert_equal([:id, :body, :date, :likes], @serializer_klass_with_new_attributes._attributes)
-        assert_equal([:id, :body], CommentSerializer._attributes)
+        assert_equal([:id, :body], CommentSerialization._attributes)
       end
 
       def test_attribute_inheritance_with_new_attribute

--- a/test/serializers/cache_test.rb
+++ b/test/serializers/cache_test.rb
@@ -25,13 +25,13 @@ module ActiveModel
         @post.blog      = @blog
         @location.place = @place
 
-        @location_serializer = LocationSerializer.new(@location)
-        @bio_serializer      = BioSerializer.new(@bio)
-        @role_serializer     = RoleSerializer.new(@role)
-        @post_serializer     = PostSerializer.new(@post)
-        @author_serializer   = AuthorSerializer.new(@author)
-        @comment_serializer  = CommentSerializer.new(@comment)
-        @blog_serializer     = BlogSerializer.new(@blog)
+        @location_serializer = LocationSerialization.new(@location)
+        @bio_serializer      = BioSerialization.new(@bio)
+        @role_serializer     = RoleSerialization.new(@role)
+        @post_serializer     = PostSerialization.new(@post)
+        @author_serializer   = AuthorSerialization.new(@author)
+        @comment_serializer  = CommentSerialization.new(@comment)
+        @blog_serializer     = BlogSerialization.new(@blog)
       end
 
       def test_cache_definition
@@ -95,7 +95,7 @@ module ActiveModel
 
           # Simulating update on comments relationship with Post
           new_comment            = Comment.new(id: 2, body: 'ZOMG A NEW COMMENT')
-          new_comment_serializer = CommentSerializer.new(new_comment)
+          new_comment_serializer = CommentSerialization.new(new_comment)
           @post.comments         = [new_comment]
 
           # Ask for the serialized object

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -12,7 +12,7 @@ module ActiveModel
       end
 
       def test_meta_is_present_with_root
-        serializer = AlternateBlogSerializer.new(@blog, meta: { total: 10 })
+        serializer = AlternateBlogSerialization.new(@blog, meta: { total: 10 })
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
         expected = {
           blog: {
@@ -37,7 +37,7 @@ module ActiveModel
       end
 
       def test_meta_key_is_used
-        serializer = AlternateBlogSerializer.new(@blog, meta: { total: 10 }, meta_key: 'haha_meta')
+        serializer = AlternateBlogSerialization.new(@blog, meta: { total: 10 }, meta_key: 'haha_meta')
         adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
         expected = {
           blog: {
@@ -52,7 +52,7 @@ module ActiveModel
       end
 
       def test_meta_key_is_used_with_json_api
-        serializer = AlternateBlogSerializer.new(@blog, meta: { total: 10 }, meta_key: 'haha_meta')
+        serializer = AlternateBlogSerialization.new(@blog, meta: { total: 10 }, meta_key: 'haha_meta')
         adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
         expected = {
           data: {
@@ -113,7 +113,7 @@ module ActiveModel
       private
 
       def load_adapter(options)
-        options = options.merge(adapter: :flatten_json, serializer: AlternateBlogSerializer)
+        options = options.merge(adapter: :flatten_json, serializer: AlternateBlogSerialization)
         ActiveModel::SerializableResource.new(@blog, options)
       end
     end

--- a/test/serializers/options_test.rb
+++ b/test/serializers/options_test.rb
@@ -8,12 +8,12 @@ module ActiveModel
       end
 
       def test_options_are_accessible
-        @profile_serializer = ProfileSerializer.new(@profile, my_options: :accessible)
+        @profile_serializer = ProfileSerialization.new(@profile, my_options: :accessible)
         assert @profile_serializer.arguments_passed_in?
       end
 
       def test_no_option_is_passed_in
-        @profile_serializer = ProfileSerializer.new(@profile)
+        @profile_serializer = ProfileSerialization.new(@profile)
         refute @profile_serializer.arguments_passed_in?
       end
     end

--- a/test/serializers/root_test.rb
+++ b/test/serializers/root_test.rb
@@ -8,12 +8,12 @@ module ActiveModel
       end
 
       def test_overwrite_root
-        serializer = VirtualValueSerializer.new(@virtual_value, { root: 'smth' })
+        serializer = VirtualValueSerialization.new(@virtual_value, { root: 'smth' })
         assert_equal('smth', serializer.json_key)
       end
 
       def test_underscore_in_root
-        serializer = VirtualValueSerializer.new(@virtual_value)
+        serializer = VirtualValueSerialization.new(@virtual_value)
         assert_equal('virtual_value', serializer.json_key)
       end
     end

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -30,7 +30,7 @@ module ActiveModel
         class MyProfile < Profile
         end
         class CustomProfile
-          def serializer_class; ProfileSerializer; end
+          def serializer_class; ProfileSerialization; end
         end
 
         def setup
@@ -42,7 +42,7 @@ module ActiveModel
 
         def test_serializer_for_existing_serializer
           serializer = ActiveModel::Serializer.serializer_for(@profile)
-          assert_equal ProfileSerializer, serializer
+          assert_equal ProfileSerialization, serializer
         end
 
         def test_serializer_for_not_existing_serializer
@@ -52,12 +52,12 @@ module ActiveModel
 
         def test_serializer_inherited_serializer
           serializer = ActiveModel::Serializer.serializer_for(@my_profile)
-          assert_equal ProfileSerializer, serializer
+          assert_equal ProfileSerialization, serializer
         end
 
         def test_serializer_custom_serializer
           serializer = ActiveModel::Serializer.serializer_for(@custom_profile)
-          assert_equal ProfileSerializer, serializer
+          assert_equal ProfileSerialization, serializer
         end
       end
     end


### PR DESCRIPTION
ref:
- https://github.com/joaomdmoura/active_model_serializers/commit/0d2ef9a3c0efc0552f7a22aaf8dd80b51e39617c
- https://github.com/rails-api/active_model_serializers/pull/950#discussion_r36134401

- [ ] Fix the build
- [ ] Discuss naming of files and superclasses, esp with respect to https://github.com/rails/rails/blob/4-2-stable/activemodel/lib/active_model/serialization.rb