### PR TITLE
Fix typo in fieldset exception

### DIFF
--- a/lib/active_model/serializer/fieldset.rb
+++ b/lib/active_model/serializer/fieldset.rb
@@ -26,7 +26,7 @@ module ActiveModel
           raw_fields.inject({}) { |h, (k, v)| h[k.to_sym] = v.map(&:to_sym); h }
         elsif raw_fields.is_a?(Array)
           if root.nil?
-            raise ArgumentError, 'The root argument must be specified if the fileds argument is an array.'
+            raise ArgumentError, 'The root argument must be specified if the fields argument is an array.'
           end
           hash = {}
           hash[root.to_sym] = raw_fields.map(&:to_sym)


### PR DESCRIPTION
Error message has a typo: should be fields, not fileds.