### PR TITLE
Attribute filtering for 0.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Features:
 - [#1158](https://github.com/rails-api/active_model_serializers/pull/1158) Add support for wildcards in `include` option (@beauby)
 - [#1127](https://github.com/rails-api/active_model_serializers/pull/1127) Add support for nested
     associations for JSON and Attributes adapters via the `include` option (@NullVoxPopuli, @beauby).
+- [#1141](https://github.com/rails-api/active_model_serializers/pull/1141) Add support for
+dynamically including or excluding attributes in serializers (@lautis).
 
 Fixes:
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ class PostSerializer < ActiveModel::Serializer
 end
 ```
 
+### Conditionally including or excluding attributes
+
+You can also dynamically include or exclude serialized attributes by defining a
+method named include_attributes. This is typically used to customize the output
+based on `current_user`. For example:
+
+```ruby
+class PostSerializer < ActiveModel::Serializer
+  attributes :id, :body, :author
+
+  def include_attributes(included)
+    if current_user.admin?
+      included
+    else
+      included - [:author]
+    end
+  end
+end
+```
+
 ### Built in Adapters
 
 #### Attributes

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -143,6 +143,10 @@ module ActiveModel
       root || object.class.model_name.to_s.underscore
     end
 
+    def include_attributes(included)
+      included
+    end
+
     def attributes(options = {})
       attributes =
         if options[:fields]
@@ -151,7 +155,7 @@ module ActiveModel
           self.class._attributes.dup
         end
 
-      attributes.each_with_object({}) do |name, hash|
+      include_attributes(attributes).each_with_object({}) do |name, hash|
         unless self.class._fragmented
           hash[name] = send(name)
         else

--- a/test/serializers/attributes_test.rb
+++ b/test/serializers/attributes_test.rb
@@ -18,9 +18,29 @@ module ActiveModel
           @profile_serializer.class._attributes)
       end
 
+      def test_attributes
+        assert_equal({ name: 'Name 1', description: 'Description 1' },
+          @profile_serializer.attributes)
+      end
+
       def test_attributes_with_fields_option
         assert_equal({ name: 'Name 1' },
           @profile_serializer.attributes(fields: [:name]))
+      end
+
+      def test_attributes_with_fields_method
+        @profile_serializer.define_singleton_method(:include_attributes) do |included|
+          included - [:name]
+        end
+        assert_equal({ description: 'Description 1' },
+          @profile_serializer.attributes)
+      end
+
+      def test_attributes_with_fields_option_and_method
+        @profile_serializer.define_singleton_method(:include_attributes) do |included|
+          included - [:name]
+        end
+        assert_equal({}, @profile_serializer.attributes(fields: [:name]))
       end
 
       def test_attributes_inheritance_definition


### PR DESCRIPTION
This is something I've (ab)used in 0.8.x quite frequently. Adds a method named filter that by default returns all fields. Actual serialised implementations can override this method to dynamically filter the list of attributes to be serialized.

Implementation based on #1058.