### PR TITLE
Improve jsonapi include

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -166,6 +166,26 @@ module ActiveModel
       end
     end
 
+    # Transforms an inclusion hash into an array of corresponding existing associations,
+    # and corresponding inclusion hashes.
+    # @param [Hash] includes
+    # @return [Array] an array of pairs [association, include_hash] for matching associations
+    def expand_includes(includes = {})
+      if includes.size == 1 && includes.each_key.first == :*
+        associations.map { |assoc| [assoc, includes.each_value.first] }
+      elsif includes.size == 1 && includes.each_key.first == :**
+        associations.map { |assoc| [assoc, { :** => nil }] }
+      else
+        expanded_associations = includes.map do |inc|
+          association = associations.find { |assoc| assoc.key == inc.first }
+          [association, inc.second] if association
+        end
+        expanded_associations.delete(nil)
+
+        expanded_associations
+      end
+    end
+
     private # rubocop:disable Lint/UselessAccessModifier
 
     ActiveModelSerializers.silence_warnings do

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -2,10 +2,15 @@ class ActiveModel::Serializer::Adapter::Json < ActiveModel::Serializer::Adapter
         extend ActiveSupport::Autoload
         autoload :FragmentCache
 
+        def initialize(serializer, options = {})
+          super
+          @included = ActiveModel::Serializer::Utils.include_args_to_hash(instance_options[:include] || '*')
+        end
+
         def serializable_hash(options = nil)
           options ||= {}
           if serializer.respond_to?(:each)
-            result = serializer.map { |s| FlattenJson.new(s).serializable_hash(options) }
+            result = serializer.map { |s| FlattenJson.new(s, include: @included).serializable_hash(options) }
           else
             hash = {}
 
@@ -13,27 +18,15 @@ class ActiveModel::Serializer::Adapter::Json < ActiveModel::Serializer::Adapter
               serializer.attributes(options)
             end
 
-            serializer.associations.each do |association|
-              serializer = association.serializer
-              association_options = association.options
-
-              if serializer.respond_to?(:each)
-                array_serializer = serializer
-                hash[association.key] = array_serializer.map do |item|
-                  cache_check(item) do
-                    item.attributes(association_options)
-                  end
+            included_associations = serializer.expand_includes(@included)
+            included_associations.each do |association, assoc_includes|
+              hash[association.key] =
+                if association.options[:virtual_value]
+                  association.options[:virtual_value]
+                elsif association.serializer && association.serializer.object
+                  FlattenJson.new(association.serializer, association.options.merge(include: assoc_includes))
+                    .serializable_hash(options)
                 end
-              else
-                hash[association.key] =
-                  if serializer && serializer.object
-                    cache_check(serializer) do
-                      serializer.attributes(options)
-                    end
-                  elsif association_options[:virtual_value]
-                    association_options[:virtual_value]
-                  end
-              end
             end
             result = core.merge hash
           end
@@ -42,6 +35,6 @@ class ActiveModel::Serializer::Adapter::Json < ActiveModel::Serializer::Adapter
         end
 
         def fragment_cache(cached_hash, non_cached_hash)
-          ActiveModel::Serializer::Adapter::Json::FragmentCache.new().fragment_cache(cached_hash, non_cached_hash)
+          ActiveModel::Serializer::Adapter::Json::FragmentCache.new.fragment_cache(cached_hash, non_cached_hash)
         end
 end

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -124,9 +124,9 @@ class ActiveModel::Serializer::Adapter::JsonApi < ActiveModel::Serializer::Adapt
         end
 
         def included_for(serializer)
-          included.flat_map { |inc|
-            association = serializer.associations.find { |assoc| assoc.key == inc.first }
-            _included_for(association.serializer, inc.second) if association
+          included_associations = serializer.expand_includes(@included)
+          included_associations.flat_map { |association, assoc_includes|
+            _included_for(association.serializer, assoc_includes)
           }.uniq
         end
 
@@ -142,12 +142,10 @@ class ActiveModel::Serializer::Adapter::JsonApi < ActiveModel::Serializer::Adapt
 
             included = [primary_data]
 
-            includes.each do |inc|
-              association = serializer.associations.find { |assoc| assoc.key == inc.first }
-              if association
-                included.concat(_included_for(association.serializer, inc.second))
-                included.uniq!
-              end
+            included_associations = serializer.expand_includes(includes)
+            included_associations.each do |association, assoc_includes|
+              included.concat(_included_for(association.serializer, assoc_includes))
+              included.uniq!
             end
 
             included

--- a/test/action_controller/json_api/linked_test.rb
+++ b/test/action_controller/json_api/linked_test.rb
@@ -51,9 +51,9 @@ module ActionController
             render json: @post, include: [comments: [:author]], adapter: :json_api
           end
 
-          def render_resource_with_nested_has_many_include
+          def render_resource_with_nested_has_many_include_wildcard
             setup_post
-            render json: @post, include: 'author.roles', adapter: :json_api
+            render json: @post, include: 'author.*', adapter: :json_api
           end
 
           def render_resource_with_missing_nested_has_many_include
@@ -96,7 +96,7 @@ module ActionController
         end
 
         def test_render_resource_with_nested_has_many_include
-          get :render_resource_with_nested_has_many_include
+          get :render_resource_with_nested_has_many_include_wildcard
           response = JSON.parse(@response.body)
           expected_linked = [
             {


### PR DESCRIPTION
Building the `included` array in place, in order to save some temporary allocations and lots of `uniq!` calls. Plus, this prevents infinite include loops.

This is based on #1158.