### PR TITLE
WIP: Serializer doesn't behave well with an attribute called `options`

### DIFF
--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -68,6 +68,10 @@ class ProfilePreviewSerializer < ActiveModel::Serializer
   attributes :name
 end
 
+class ProfileWithOptionsSerializer < ActiveModel::Serializer
+  attributes :name, :description, :options
+end
+
 Post     = Class.new(Model)
 Like     = Class.new(Model)
 Author   = Class.new(Model)

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 module ActiveModel
   class SerializableResourceTest < Minitest::Test
     def setup
-      @resource = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
-      @serializer = ProfileSerializer.new(@resource)
+      @resource = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1', options: 'one' })
+      @serializer = ProfileWithOptionsSerializer.new(@resource)
       @adapter = ActiveModel::Serializer::Adapter.create(@serializer)
       @serializable_resource = ActiveModel::SerializableResource.new(@resource)
     end


### PR DESCRIPTION
I have an attribute called options being serialized, but it causes a
`stack level too deep` on my controller and it started on 0.10.0.rc3.

Using AMS test suit I checked it happens because of `options` attribute.

The expected is:
`{:name=>"Name 1", :description=>"Description 1", :options=>'one'}`

but with @adapter.serializable_hash(options) I get:
`{:name=>"Name 1", :description=>"Description 1", :options=>{}}`

and with @serializable_resource.serializable_hash(options) I get:
`{:name=>"Name 1", :description=>"Description 1"}`
