### PR TITLE
move model_name into serializer, so it can get overwritten by serializer, similar to 'root'

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -122,8 +122,12 @@ module ActiveModel
       end
     end
 
+    def object_model_name
+      object.class.model_name
+    end
+
     def json_key
-      @root || object.class.model_name.to_s.underscore
+      @root || object_model_name.to_s.underscore
     end
 
     def attributes(options = {})

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -62,10 +62,11 @@ class ActiveModel::Serializer::Adapter::JsonApi < ActiveModel::Serializer::Adapt
         end
 
         def resource_identifier_type_for(serializer)
+          model_name = serializer.object_model_name
           if ActiveModel::Serializer.config.jsonapi_resource_type == :singular
-            serializer.object.class.model_name.singular
+            model_name.singular
           else
-            serializer.object.class.model_name.plural
+            model_name.plural
           end
         end
 


### PR DESCRIPTION
I'm actually no quite sure why json_api uses `serializer.object.class.model_name` directly, instead of `serializer.json_key`. Then `resource_identifier_type_for` could be implemented like this:

    def resource_identifier_type_for(serializer)
      if ActiveModel::Serializer.config.jsonapi_resource_type == :singular
        serializer.json_key
      else
        ActiveSupport::Inflector.pluralize(serializer.json_key)
      end
    end

The `json_key` is further used in json api adapter, line 11: https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer/adapter/json_api.rb#L11 - shouldn't this be unified?
