### PR TITLE
Comment private accessor warnings

### DIFF
--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -9,6 +9,27 @@ module ActiveModelSerializers
 
   module_function
 
+  # @note
+  #   ```ruby
+  #   private
+  #
+  #   attr_reader :resource, :adapter_opts, :serializer_opts
+  #   ```
+  #
+  #   Will generate a warning, though it shouldn't.
+  #   There's a bug in Ruby for this: https://bugs.ruby-lang.org/issues/10967
+  #
+  #   We can use +ActiveModelSerializers.silence_warnings+ as a
+  #   'safety valve' for unfixable or not-worth-fixing warnings,
+  #   and keep our app warning-free.
+  #
+  #   ```ruby
+  #   private
+  #
+  #   ActiveModelSerializers.silence_warnings do
+  #     attr_reader :resource, :adapter_opts, :serializer_opts
+  #   end
+  #   ```
   def silence_warnings
     verbose = $VERBOSE
     $VERBOSE = nil


### PR DESCRIPTION
Adapting commet in https://github.com/rails-api/active_model_serializers/pull/1067#discussion-diff-38027334
where ActiveModelSerializers.silence_warnings was added.

In response to discussion in https://github.com/rails-api/active_model_serializers/pull/1166