### PR TITLE
Remove Adapter autoloads in favor of require

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,39 +8,6 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-Style/IndentationConsistency:
-  Exclude:
-    - lib/active_model/serializer/adapter/attributes.rb
-    - lib/active_model/serializer/adapter/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json.rb
-    - lib/active_model/serializer/adapter/json/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json_api.rb
-    - lib/active_model/serializer/adapter/json_api/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json_api/pagination_links.rb
-    - lib/active_model/serializer/adapter/null.rb
-
-Style/IndentationWidth:
-  Exclude:
-    - lib/active_model/serializer/adapter/attributes.rb
-    - lib/active_model/serializer/adapter/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json.rb
-    - lib/active_model/serializer/adapter/json/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json_api.rb
-    - lib/active_model/serializer/adapter/json_api/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json_api/pagination_links.rb
-    - lib/active_model/serializer/adapter/null.rb
-
-Style/AccessModifierIndentation:
-  Exclude:
-    - lib/active_model/serializer/adapter/attributes.rb
-    - lib/active_model/serializer/adapter/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json.rb
-    - lib/active_model/serializer/adapter/json/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json_api.rb
-    - lib/active_model/serializer/adapter/json_api/fragment_cache.rb
-    - lib/active_model/serializer/adapter/json_api/pagination_links.rb
-    - lib/active_model/serializer/adapter/null.rb
-
 Lint/NestedMethodDefinition:
   Enabled: false
   Exclude:

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -9,8 +9,6 @@ require 'active_model/serializer/utils'
 
 module ActiveModel
   class Serializer
-    extend ActiveSupport::Autoload
-
     include Configuration
     include Associations
 

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -4,13 +4,8 @@ module ActiveModel
       UnknownAdapterError = Class.new(ArgumentError)
       ADAPTER_MAP = {}
       private_constant :ADAPTER_MAP if defined?(private_constant)
-      extend ActiveSupport::Autoload
-      autoload :Attributes
-      autoload :Null
-      autoload :FragmentCache
-      autoload :Json
-      autoload :JsonApi
-      autoload :CachedSerializer
+      require 'active_model/serializer/adapter/fragment_cache'
+      require 'active_model/serializer/adapter/cached_serializer'
 
       def self.create(resource, options = {})
         override = options.delete(:adapter)
@@ -131,6 +126,12 @@ module ActiveModel
         json[meta_key] = meta if meta
         json
       end
+
+      # Gotta be at the bottom to use the code above it :(
+      require 'active_model/serializer/adapter/null'
+      require 'active_model/serializer/adapter/attributes'
+      require 'active_model/serializer/adapter/json'
+      require 'active_model/serializer/adapter/json_api'
     end
   end
 end

--- a/lib/active_model/serializer/adapter/attributes.rb
+++ b/lib/active_model/serializer/adapter/attributes.rb
@@ -1,4 +1,7 @@
-class ActiveModel::Serializer::Adapter::Attributes < ActiveModel::Serializer::Adapter
+module ActiveModel
+  class Serializer
+    class Adapter
+      class Attributes < Adapter
         def serializable_hash(options = nil)
           options ||= {}
           if serializer.respond_to?(:each)
@@ -47,4 +50,7 @@ class ActiveModel::Serializer::Adapter::Attributes < ActiveModel::Serializer::Ad
         def include_meta(json)
           json
         end
+      end
+    end
+  end
 end

--- a/lib/active_model/serializer/adapter/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/fragment_cache.rb
@@ -1,4 +1,7 @@
-class ActiveModel::Serializer::Adapter::FragmentCache
+module ActiveModel
+  class Serializer
+    class Adapter
+      class FragmentCache
         attr_reader :serializer
 
         def initialize(adapter, serializer, options)
@@ -76,4 +79,7 @@ class ActiveModel::Serializer::Adapter::FragmentCache
         def to_valid_const_name(name)
           name.gsub('::', '_')
         end
+      end
+    end
+  end
 end

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -1,4 +1,7 @@
-class ActiveModel::Serializer::Adapter::Json < ActiveModel::Serializer::Adapter
+module ActiveModel
+  class Serializer
+    class Adapter
+      class Json < Adapter
         extend ActiveSupport::Autoload
         autoload :FragmentCache
 
@@ -12,4 +15,7 @@ class ActiveModel::Serializer::Adapter::Json < ActiveModel::Serializer::Adapter
         def fragment_cache(cached_hash, non_cached_hash)
           ActiveModel::Serializer::Adapter::Json::FragmentCache.new.fragment_cache(cached_hash, non_cached_hash)
         end
+      end
+    end
+  end
 end

--- a/lib/active_model/serializer/adapter/json/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/json/fragment_cache.rb
@@ -1,5 +1,13 @@
-class ActiveModel::Serializer::Adapter::Json::FragmentCache
+module ActiveModel
+  class Serializer
+    class Adapter
+      class Json
+        class FragmentCache
           def fragment_cache(cached_hash, non_cached_hash)
             non_cached_hash.merge cached_hash
           end
+        end
+      end
+    end
+  end
 end

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -1,4 +1,7 @@
-class ActiveModel::Serializer::Adapter::JsonApi < ActiveModel::Serializer::Adapter
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi < Adapter
         extend ActiveSupport::Autoload
         autoload :PaginationLinks
         autoload :FragmentCache
@@ -157,4 +160,7 @@ class ActiveModel::Serializer::Adapter::JsonApi < ActiveModel::Serializer::Adapt
         def links_for(serializer, options)
           JsonApi::PaginationLinks.new(serializer.object, options[:context]).serializable_hash(options)
         end
+      end
+    end
+  end
 end

--- a/lib/active_model/serializer/adapter/json_api/fragment_cache.rb
+++ b/lib/active_model/serializer/adapter/json_api/fragment_cache.rb
@@ -1,4 +1,8 @@
-class ActiveModel::Serializer::Adapter::JsonApi::FragmentCache
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi
+        class FragmentCache
           def fragment_cache(root, cached_hash, non_cached_hash)
             hash              = {}
             core_cached       = cached_hash.first
@@ -10,4 +14,8 @@ class ActiveModel::Serializer::Adapter::JsonApi::FragmentCache
 
             hash.deep_merge no_root_non_cache.deep_merge no_root_cache
           end
+        end
+      end
+    end
+  end
 end

--- a/lib/active_model/serializer/adapter/json_api/pagination_links.rb
+++ b/lib/active_model/serializer/adapter/json_api/pagination_links.rb
@@ -1,4 +1,8 @@
-class ActiveModel::Serializer::Adapter::JsonApi::PaginationLinks
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi < Adapter
+        class PaginationLinks
           FIRST_PAGE = 1
 
           attr_reader :collection, :context
@@ -47,4 +51,8 @@ class ActiveModel::Serializer::Adapter::JsonApi::PaginationLinks
           def query_parameters
             @query_parameters ||= context.query_parameters
           end
+        end
+      end
+    end
+  end
 end

--- a/lib/active_model/serializer/adapter/null.rb
+++ b/lib/active_model/serializer/adapter/null.rb
@@ -1,5 +1,11 @@
-class ActiveModel::Serializer::Adapter::Null < ActiveModel::Serializer::Adapter
+module ActiveModel
+  class Serializer
+    class Adapter
+      class Null < Adapter
         def serializable_hash(options = nil)
           {}
         end
+      end
+    end
+  end
 end

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -15,6 +15,7 @@ module ActiveModel
           attr_accessor :_reflections
         end
 
+        extend ActiveSupport::Autoload
         autoload :Association
         autoload :Reflection
         autoload :SingularReflection

--- a/test/serializers/adapter_for_test.rb
+++ b/test/serializers/adapter_for_test.rb
@@ -5,11 +5,6 @@ module ActiveModel
 
       def setup
         @previous_adapter = ActiveModel::Serializer.config.adapter
-        # Eager load adapters
-        ActiveModel::Serializer::Adapter.eager_load!
-        [:json_api, :attributes, :null, :json].each do |adapter_name|
-          ActiveModel::Serializer::Adapter.lookup(adapter_name)
-        end
       end
 
       def teardown
@@ -66,12 +61,13 @@ module ActiveModel
 
       def test_adapter_map
         expected_adapter_map = {
+          'null'.freeze              => ActiveModel::Serializer::Adapter::Null,
           'json'.freeze              => ActiveModel::Serializer::Adapter::Json,
-          'json_api'.freeze          => ActiveModel::Serializer::Adapter::JsonApi,
           'attributes'.freeze => ActiveModel::Serializer::Adapter::Attributes,
-          'null'.freeze => ActiveModel::Serializer::Adapter::Null
+          'json_api'.freeze => ActiveModel::Serializer::Adapter::JsonApi
         }
-        assert_equal ActiveModel::Serializer::Adapter.adapter_map, expected_adapter_map
+        actual = ActiveModel::Serializer::Adapter.adapter_map
+        assert_equal actual, expected_adapter_map
       end
 
       def test_adapters


### PR DESCRIPTION
Adapters must be eager loaded to ensure they are defined
before they are used as namespacing.

https://github.com/rails-api/active_model_serializers/commit/cf6a074a1c62e3f5a30f90a0987b8cf049272953#diff-41f2b3509d33e1c65bb70ee0ec7a2eea

Follows https://github.com/rails-api/active_model_serializers/pull/1171/