### PR TITLE
env CAPTURE_STDERR=false lets devs see hard failures

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,8 +38,14 @@ else
   end
 end
 
-require 'capture_warnings'
-CaptureWarnings.new(_fail_build = true).execute!
+# If there's no failure info, try disabling capturing stderr:
+# `env CAPTURE_STDERR=false rake`
+# This is way easier than writing a Minitest plugin
+# for 4.x and 5.x.
+if ENV['CAPTURE_STDERR'] !~ /false|1/i
+  require 'capture_warnings'
+  CaptureWarnings.new(_fail_build = true).execute!
+end
 
 require 'active_model_serializers'
 


### PR DESCRIPTION
I noticed that if I had runtime errors, I wouldn't see the stacktrace
or exception message.

Turns out, this is something about the at_exit resolution of io
capturing between capture_errors and Minitest.

I couldn't figure out how to modify the io for Minitest without a lot of
code, so this is a safety valve for devs :) :(

MiniTest 4

- MiniTest::Unit.output = my_thing

Minitest 5

- Make a plugin can makes a reporter that holds onto a special io