### PR TITLE
Fix options passing in Json and Attributes adapters

### DIFF
--- a/lib/active_model/serializer/adapter/attributes.rb
+++ b/lib/active_model/serializer/adapter/attributes.rb
@@ -10,7 +10,7 @@ module ActiveModel
         def serializable_hash(options = nil)
           options ||= {}
           if serializer.respond_to?(:each)
-            result = serializer.map { |s| Attributes.new(s).serializable_hash(options) }
+            result = serializer.map { |s| Attributes.new(s, instance_options).serializable_hash(options) }
           else
             hash = {}
 

--- a/lib/active_model/serializer/adapter/json.rb
+++ b/lib/active_model/serializer/adapter/json.rb
@@ -7,7 +7,7 @@ module ActiveModel
 
         def serializable_hash(options = nil)
           options ||= {}
-          { root => Attributes.new(serializer).serializable_hash(options) }
+          { root => Attributes.new(serializer, instance_options).serializable_hash(options) }
         end
 
         private

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -75,6 +75,16 @@ module ActiveModel
 
             assert_equal 1, adapter.serializable_hash[:virtual_values].length
           end
+
+          def test_include_option
+            serializer = ArraySerializer.new([@first_post, @second_post])
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, include: '')
+            actual = adapter.serializable_hash
+            expected = { posts: [{ id: 1, title: 'Hello!!', body: 'Hello, world!!' },
+                                 { id: 2, title: 'New Post', body: 'Body' }] }
+
+            assert_equal(expected, actual)
+          end
         end
       end
     end


### PR DESCRIPTION
As mentioned in #1184, there are issues with the way options are passed between adapters. This PR adds a failing test and provides fixes.