### PR TITLE
Inline nested serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Breaking changes:
 
 Features:
 
+- [#1193](https://github.com/rails-api/active_model_serializers/pull/1193) Add support for inline nested serializers (@beauby)
 - [#1172](https://github.com/rails-api/active_model_serializers/pull/1172) Better serializer registration, get more than just the first module (@bf4)
 - [#1158](https://github.com/rails-api/active_model_serializers/pull/1158) Add support for wildcards in `include` option (@beauby)
 - [#1127](https://github.com/rails-api/active_model_serializers/pull/1127) Add support for nested

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -112,10 +112,26 @@ module ActiveModel
       Digest::MD5.hexdigest(serializer_file_contents)
     end
 
+    # TODO(beauby): Cache this.
+    def self.serializer_lookup_chain_for(klass)
+      chain = []
+
+      resource_class_name = klass.name.demodulize
+      resource_namespace = klass.name.deconstantize
+      serializer_class_name = "#{resource_class_name}Serializer"
+
+      chain.push("#{name}::#{serializer_class_name}")
+      chain.push("#{resource_namespace}::#{serializer_class_name}")
+      chain.push(serializer_class_name)
+
+      chain
+    end
+
     def self.get_serializer_for(klass)
       serializers_cache.fetch_or_store(klass) do
-        serializer_class_name = "#{klass.name}Serializer"
-        serializer_class = serializer_class_name.safe_constantize
+
+        # NOTE(beauby): When we drop 1.9.3 support we can lazify the map for perfs.
+        serializer_class = serializer_lookup_chain_for(klass).map(&:safe_constantize).find { |x| x }
 
         if serializer_class
           serializer_class

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -129,7 +129,6 @@ module ActiveModel
 
     def self.get_serializer_for(klass)
       serializers_cache.fetch_or_store(klass) do
-
         # NOTE(beauby): When we drop 1.9.3 support we can lazify the map for perfs.
         serializer_class = serializer_lookup_chain_for(klass).map(&:safe_constantize).find { |x| x }
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -152,10 +152,9 @@ module ActiveModel
       self.scope = instance_options[:scope]
 
       scope_name = instance_options[:scope_name]
-      if scope_name && !respond_to?(scope_name)
-        self.class.class_eval do
-          define_method scope_name, lambda { scope }
-        end
+      return unless scope_name && !respond_to?(scope_name)
+      self.class.class_eval do
+        define_method scope_name, -> { scope }
       end
     end
 
@@ -172,10 +171,10 @@ module ActiveModel
         end
 
       attributes.each_with_object({}) do |name, hash|
-        unless self.class._fragmented
-          hash[name] = send(name)
-        else
+        if self.class._fragmented
           hash[name] = self.class._fragmented.public_send(name)
+        else
+          hash[name] = send(name)
         end
       end
     end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -129,7 +129,7 @@ module ActiveModel
 
     def self.get_serializer_for(klass)
       serializers_cache.fetch_or_store(klass) do
-        # NOTE(beauby): When we drop 1.9.3 support we can lazify the map for perfs.
+        # NOTE(beauby): Once we drop 1.9.3 support, we can lazify the map for better perfs.
         serializer_class = serializer_lookup_chain_for(klass).map(&:safe_constantize).find { |x| x }
 
         if serializer_class

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -10,9 +10,10 @@ module ActiveModel
       def initialize(resources, options = {})
         @root = options[:root]
         @object = resources
+        parent_serializer = options.fetch(:_parent_serializer, ActiveModel::Serializer)
         @serializers = resources.map do |resource|
           serializer_class = options.fetch(:serializer) do
-            ActiveModel::Serializer.serializer_for(resource)
+            parent_serializer.serializer_for(resource)
           end
 
           if serializer_class.nil?

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -34,10 +34,14 @@ module ActiveModel
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional inline definition of the serializer for this association
         # @return [void]
         #
         # @example
         #  has_many :comments, serializer: CommentSummarySerializer
+        #  has_many :comments do
+        #    attributes :id, :content
+        #  end
         #
         def has_many(name, options = {}, &block)
           associate(HasManyReflection.new(name, options), &block)
@@ -45,10 +49,14 @@ module ActiveModel
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional inline definition of the serializer for this association
         # @return [void]
         #
         # @example
         #  belongs_to :author, serializer: AuthorSerializer
+        #  belongs_to :author do
+        #    attributes :id, :name
+        #  end
         #
         def belongs_to(name, options = {}, &block)
           associate(BelongsToReflection.new(name, options), &block)
@@ -56,10 +64,14 @@ module ActiveModel
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional inline definition of the serializer for this association
         # @return [void]
         #
         # @example
         #  has_one :author, serializer: AuthorSerializer
+        #  has_one :author do
+        #    attributes :id, :name
+        #  end
         #
         def has_one(name, options = {}, &block)
           associate(HasOneReflection.new(name, options), &block)
@@ -69,6 +81,7 @@ module ActiveModel
 
         # Add reflection and define {name} accessor and nested serializer.
         # @param [ActiveModel::Serializer::Reflection] reflection
+        # @param [Block] optional inline definition of the serializer for this association
         # @return [void]
         #
         # @api private
@@ -87,6 +100,7 @@ module ActiveModel
 
         # Define a nested serializer
         # @param [String] resource_name The name of the association
+        # @param [Block] inline definition of the serializer for this association
         # @return [void]
         #
         # @api private

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -1,4 +1,3 @@
-# 2420012eliyel - popincool - 22 cite popincourt - 4e premiere droite
 module ActiveModel
   class Serializer
     # Defines an association in the object should be rendered.

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -103,6 +103,16 @@ module ActiveModel
         # @param [Block] inline definition of the serializer for this association
         # @return [void]
         #
+        # @example
+        #  Namespace::PostSerializer.define_nested_serializer("comment") do
+        #    attributes :id, :content
+        #  end
+        #
+        # is equivalent to
+        #  class Namespace::PostSerializer::CommentSerializer < ActiveModel::Serializer
+        #    attributes :id, :content
+        #  end
+        #
         # @api private
         #
         def define_nested_serializer(resource_name, &block)

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -42,13 +42,13 @@ module ActiveModel
       def build_association(subject, parent_serializer_options)
         association_value = subject.send(name)
         reflection_options = options.dup
-        serializer_class = ActiveModel::Serializer.serializer_for(association_value, reflection_options)
+        serializer_class = subject.class.serializer_for(association_value, reflection_options)
 
         if serializer_class
           begin
             serializer = serializer_class.new(
               association_value,
-              serializer_options(parent_serializer_options, reflection_options)
+              serializer_options(parent_serializer_options, reflection_options).merge(_parent_serializer: subject.class)
             )
           rescue ActiveModel::Serializer::ArraySerializer::NoSerializerError
             reflection_options[:virtual_value] = association_value.try(:as_json) || association_value

--- a/test/adapter/json/nested_serializers_test.rb
+++ b/test/adapter/json/nested_serializers_test.rb
@@ -19,7 +19,14 @@ module ActiveModel
 
           def test_nested_serializers
             actual = ActiveModel::SerializableResource.new(@tweet, adapter: :json).serializable_hash
-            expected = { tweet: { id: 1, body: 'Tweet 1', date: 'Jan 15', author: { id: 1 }, shares: [{ id: 1, platform: 'facebook' }] } }
+            expected = {
+              tweet: { id: 1,
+                       body: 'Tweet 1',
+                       date: 'Jan 15',
+                       author: { id: 1 },
+                       shares: [{ id: 1, platform: 'facebook' }]
+                     }
+            }
             assert_equal(expected, actual)
           end
         end

--- a/test/adapter/json/nested_serializers_test.rb
+++ b/test/adapter/json/nested_serializers_test.rb
@@ -18,14 +18,8 @@ module ActiveModel
           end
 
           def test_nested_serializers
-            actual = ActiveModel::SerializableResource.new(@tweet, adapter: :json_api).serializable_hash
-            expected = {
-              data: {
-                id: '1', type: 'tweets', attributes: { body: 'Tweet 1', date: 'Jan 15' },
-                relationships: { author: { data: { id: '1', type: 'authors' } },
-                                 shares: { data: [{ id: '1', type: 'shares' }] } }
-              }
-            }
+            actual = ActiveModel::SerializableResource.new(@tweet, adapter: :json).serializable_hash
+            expected = { tweet: { id: 1, body: 'Tweet 1', date: 'Jan 15', author: { id: 1 }, shares: [{ id: 1, platform: 'facebook' }] } }
             assert_equal(expected, actual)
           end
         end

--- a/test/adapter/json/nested_serializers_test.rb
+++ b/test/adapter/json/nested_serializers_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    module Adapter
+      class Json
+        class NestedSerializersTest < Minitest::Test
+          def setup
+            @tweet = Tweet.new(id: 1, body: 'Tweet 1', date: 'Jan 15')
+            @share1 = Share.new(id: 1, platform: 'facebook', date: 'Jan 16')
+            @author = Author.new(id: 1, name: 'Lucas H.')
+            @tweet.author = @author
+            @tweet.shares = [@share1]
+            @share1.author = @author
+            @author.posts = []
+            @author.roles = []
+            @author.bio = nil
+          end
+
+          def test_nested_serializers
+            actual = ActiveModel::SerializableResource.new(@tweet, adapter: :json_api).serializable_hash
+            expected = {
+              data: {
+                id: '1', type: 'tweets', attributes: { body: 'Tweet 1', date: 'Jan 15' },
+                relationships: { author: { data: { id: '1', type: 'authors' } },
+                                 shares: { data: [{ id: '1', type: 'shares' }] } }
+              }
+            }
+            assert_equal(expected, actual)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -85,6 +85,8 @@ Comment = Class.new(Model) do
     "#{self.class.name.downcase}/#{self.id}"
   end
 end
+Tweet = Class.new(Model)
+Share = Class.new(Model)
 
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
@@ -258,4 +260,30 @@ Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do
   cache only: [:id]
   attributes :id
 end
+
+class TweetSerializer < ActiveModel::Serializer
+  attributes :id, :body, :date
+
+  belongs_to :author do
+    attributes :id
+  end
+
+  has_many :shares do
+    attributes :id, :platform
+
+    belongs_to :author do
+      attributes :id, :name
+    end
+  end
+end
+
+class ShareSerializer < ActiveModel::Serializer
+  attributes :id, :platform, :date
+
+  belongs_to :author do
+    attributes :id, :name, :email
+  end
+  belongs_to :post
+end
+
 $VERBOSE = verbose

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -38,6 +38,8 @@ module ActiveModel
           @my_profile = MyProfile.new
           @custom_profile = CustomProfile.new
           @model = ::Model.new
+          @tweet = Tweet.new
+          @share1 = Share.new
         end
 
         def test_serializer_for_existing_serializer
@@ -58,6 +60,11 @@ module ActiveModel
         def test_serializer_custom_serializer
           serializer = ActiveModel::Serializer.serializer_for(@custom_profile)
           assert_equal ProfileSerializer, serializer
+        end
+
+        def test_serializer_for_nested_resource
+          serializer = TweetSerializer.serializer_for(@share1)
+          assert_equal(TweetSerializer::ShareSerializer, serializer)
         end
       end
     end


### PR DESCRIPTION
Allows people to do stuff like:
```ruby
class PostSerializer < ActiveModel::Serializer
  attributes :id, :name, :body
  has_many :comments do
    attributes :id, :body
    belongs_to :author do
      attributes :name
  end
end
```

I'd really love for people to submit tests to try and break the implementation.

ref #1190 #1157 #1113