### PR TITLE
Fix id override

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -62,7 +62,7 @@ module ActiveModel
       ActiveModelSerializers.silence_warnings do
         define_method key do
           object.read_attribute_for_serialization(attr)
-        end unless (key != :id && method_defined?(key)) || _fragmented.respond_to?(attr)
+        end unless method_defined?(key) || _fragmented.respond_to?(attr)
       end
     end
 

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -57,6 +57,20 @@ module ActiveModel
         adapter = ActiveModel::Serializer::Adapter::Json.new(attributes_serializer.new(@blog))
         assert_equal({ blog: { type: 'stuff' } }, adapter.serializable_hash)
       end
+
+      def test_id_attribute_override_before
+        serializer = Class.new(ActiveModel::Serializer) do
+          def id
+            'custom'
+          end
+
+          attribute :id
+        end
+
+        hash = ActiveModel::SerializableResource.new(@blog, adapter: :json, serializer: serializer).serializable_hash
+
+        assert_equal('custom', hash[:blog][:id])
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, the `id` attribute is [handled in a special way](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer.rb#L65), which leads to the impossibility to override it *before* the `attribute :id` call.
I believe this special treatment is just legacy code. @bf4, @joaomdmoura?