### PR TITLE
Namespaced serializer lookup for associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Features:
 - [#1172](https://github.com/rails-api/active_model_serializers/pull/1172) Better serializer registration, get more than just the first module (@bf4)
 - [#1158](https://github.com/rails-api/active_model_serializers/pull/1158) Add support for wildcards in `include` option (@beauby)
 - [#1127](https://github.com/rails-api/active_model_serializers/pull/1127) Add support for nested
-    associations for JSON and Attributes adapters via the `include` option (@NullVoxPopuli, @beauby).
+    associations for JSON and Attributes adapters via the `include` option (@NullVoxPopuli, @beauby)
+- [#1193](https://github.com/rails-api/active_model_serializers/pull/1193) Add support for inline nested serializers (@beauby)
 
 Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Features:
 - [#1127](https://github.com/rails-api/active_model_serializers/pull/1127) Add support for nested
     associations for JSON and Attributes adapters via the `include` option (@NullVoxPopuli, @beauby)
 - [#1193](https://github.com/rails-api/active_model_serializers/pull/1193) Add support for inline nested serializers (@beauby)
+- [#1196](https://github.com/rails-api/active_model_serializers/pull/1196) Add support for namespaced serializers (@beauby)
 
 Fixes:
 

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -25,7 +25,8 @@ module ActionController
           "Please pass 'adapter: false' or see ActiveSupport::SerializableResource.new"
         options[:adapter] = false
       end
-      serializable_resource = ActiveModel::SerializableResource.new(resource, options)
+      serializable_options = options.merge(controller: self)
+      serializable_resource = ActiveModel::SerializableResource.new(resource, serializable_options)
       if serializable_resource.serializer?
         serializable_resource.serialization_scope ||= serialization_scope
         serializable_resource.serialization_scope_name = _serialization_scope

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -87,7 +87,7 @@ module ActiveModel
       elsif options.key?(:serializer)
         options[:serializer]
       else
-        get_serializer_for(resource.class, options[:parent_serializer])
+        get_serializer_for(resource.class, options[:parent_serializer], options[:controller])
       end
     end
 
@@ -110,7 +110,7 @@ module ActiveModel
       Digest::MD5.hexdigest(serializer_file_contents)
     end
 
-    def self.get_serializer_for(klass, parent_serializer)
+    def self.get_serializer_for(klass, parent_serializer, controller)
       serializers_cache.fetch_or_store(klass) do
         serializer_class_name = "#{klass.name}Serializer"
 
@@ -120,6 +120,9 @@ module ActiveModel
         if parent_serializer
           namespaced_serializer_class_name = "#{parent_serializer.root_serializer.class.name.deconstantize}::#{serializer_class_name}"
           serializer_class ||= namespaced_serializer_class_name.safe_constantize
+        elsif controller
+          controller_namespaced_serializer_class_name = "#{controller.class.name.deconstantize}::#{serializer_class_name}"
+          serializer_class ||= controller_namespaced_serializer_class_name.safe_constantize
         end
 
         serializer_class ||= serializer_class_name.safe_constantize
@@ -127,7 +130,7 @@ module ActiveModel
         if serializer_class
           serializer_class
         elsif klass.superclass
-          get_serializer_for(klass.superclass, parent_serializer)
+          get_serializer_for(klass.superclass, parent_serializer, controller)
         end
       end
     end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -111,12 +111,10 @@ module ActiveModel
     def self.get_serializer_for(klass)
       serializers_cache.fetch_or_store(klass) do
         serializer_class_name = "#{klass.name}Serializer"
-        serializer_class =
-          if const_defined?(serializer_class_name)
-            const_get(serializer_class_name)
-          else
-            serializer_class_name.safe_constantize
-          end
+        global_serializer_class = serializer_class_name.safe_constantize
+        nested_serializer_class = "#{self}::#{serializer_class_name}".safe_constantize
+        serializer_class = nested_serializer_class || global_serializer_class
+
         if serializer_class
           serializer_class
         elsif klass.superclass

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -117,7 +117,6 @@ module ActiveModel
           else
             serializer_class_name.safe_constantize
           end
-
         if serializer_class
           serializer_class
         elsif klass.superclass
@@ -137,10 +136,9 @@ module ActiveModel
       self.scope = instance_options[:scope]
 
       scope_name = instance_options[:scope_name]
-      if scope_name && !respond_to?(scope_name)
-        self.class.class_eval do
-          define_method scope_name, lambda { scope }
-        end
+      return unless scope_name && !respond_to?(scope_name)
+      self.class.class_eval do
+        define_method scope_name, -> { scope }
       end
     end
 
@@ -157,10 +155,10 @@ module ActiveModel
         end
 
       attributes.each_with_object({}) do |name, hash|
-        unless self.class._fragmented
-          hash[name] = send(name)
-        else
+        if self.class._fragmented
           hash[name] = self.class._fragmented.public_send(name)
+        else
+          hash[name] = send(name)
         end
       end
     end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -111,7 +111,12 @@ module ActiveModel
     def self.get_serializer_for(klass)
       serializers_cache.fetch_or_store(klass) do
         serializer_class_name = "#{klass.name}Serializer"
-        serializer_class = serializer_class_name.safe_constantize
+        serializer_class =
+          if const_defined?(serializer_class_name)
+            const_get(serializer_class_name)
+          else
+            serializer_class_name.safe_constantize
+          end
 
         if serializer_class
           serializer_class

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -10,10 +10,9 @@ module ActiveModel
       def initialize(resources, options = {})
         @root = options[:root]
         @object = resources
+        parent_serializer = options.fetch(:_parent_serializer, ActiveModel::Serializer)
         @serializers = resources.map do |resource|
-          serializer_class = options.fetch(:serializer) do
-            ActiveModel::Serializer.serializer_for(resource)
-          end
+          serializer_class = options.fetch(:serializer) { parent_serializer.serializer_for(resource) }
 
           if serializer_class.nil?
             fail NoSerializerError, "No serializer found for resource: #{resource.inspect}"

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -42,7 +42,7 @@ module ActiveModel
       def build_association(subject, parent_serializer_options)
         association_value = subject.send(name)
         reflection_options = options.dup
-        serializer_class = subject.class.serializer_for(association_value, reflection_options)
+        serializer_class = subject.class.serializer_for(association_value, reflection_options.merge(parent_serializer: subject))
 
         if serializer_class
           begin
@@ -67,7 +67,7 @@ module ActiveModel
 
         serializer_options = parent_serializer_options.except(:serializer)
         serializer_options[:serializer] = serializer if serializer
-        serializer_options[:_parent_serializer] = subject.class
+        serializer_options[:parent_serializer] = subject
         serializer_options
       end
     end

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -42,13 +42,13 @@ module ActiveModel
       def build_association(subject, parent_serializer_options)
         association_value = subject.send(name)
         reflection_options = options.dup
-        serializer_class = ActiveModel::Serializer.serializer_for(association_value, reflection_options)
+        serializer_class = subject.class.serializer_for(association_value, reflection_options)
 
         if serializer_class
           begin
             serializer = serializer_class.new(
               association_value,
-              serializer_options(parent_serializer_options, reflection_options)
+              serializer_options(subject, parent_serializer_options, reflection_options)
             )
           rescue ActiveModel::Serializer::ArraySerializer::NoSerializerError
             reflection_options[:virtual_value] = association_value.try(:as_json) || association_value
@@ -62,11 +62,12 @@ module ActiveModel
 
       private
 
-      def serializer_options(parent_serializer_options, reflection_options)
+      def serializer_options(subject, parent_serializer_options, reflection_options)
         serializer = reflection_options.fetch(:serializer, nil)
 
         serializer_options = parent_serializer_options.except(:serializer)
         serializer_options[:serializer] = serializer if serializer
+        serializer_options[:_parent_serializer] = subject.class
         serializer_options
       end
     end

--- a/test/adapter/json/nested_serializers_test.rb
+++ b/test/adapter/json/nested_serializers_test.rb
@@ -18,14 +18,8 @@ module ActiveModel
           end
 
           def test_nested_serializers
-            actual = ActiveModel::SerializableResource.new(@tweet, adapter: :json_api).serializable_hash
-            expected = {
-              data: {
-                id: '1', type: 'tweets', attributes: { body: 'Tweet 1', date: 'Jan 15' },
-                relationships: { author: { data: { id: '1', type: 'authors' } },
-                                 shares: { data: [{ id: '1', type: 'shares' }] } }
-              }
-            }
+            actual = ActiveModel::SerializableResource.new(@tweet, adapter: :json).serializable_hash
+            expected = { tweet: { id: 1, body: 'Tweet 1', date: 'Jan 15', author: { id: 1 }, shares: [{ id: 1, platform: 'facebook' }] } }
             assert_equal(expected, actual)
           end
         end

--- a/test/adapter/json/nested_serializers_test.rb
+++ b/test/adapter/json/nested_serializers_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    module Adapter
+      class Json
+        class NestedSerializersTest < Minitest::Test
+          def setup
+            @tweet = Tweet.new(id: 1, body: 'Tweet 1', date: 'Jan 15')
+            @share1 = Share.new(id: 1, platform: 'facebook', date: 'Jan 16')
+            @author = Author.new(id: 1, name: 'Lucas H.')
+            @tweet.author = @author
+            @tweet.shares = [@share1]
+            @share1.author = @author
+            @author.posts = []
+            @author.roles = []
+            @author.bio = nil
+          end
+
+          def test_nested_serializers
+            actual = ActiveModel::SerializableResource.new(@tweet, adapter: :json_api).serializable_hash
+            expected = {
+              data: {
+                id: '1', type: 'tweets', attributes: { body: 'Tweet 1', date: 'Jan 15' },
+                relationships: { author: { data: { id: '1', type: 'authors' } },
+                                 shares: { data: [{ id: '1', type: 'shares' }] } }
+              }
+            }
+            assert_equal(expected, actual)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -85,6 +85,8 @@ Comment = Class.new(Model) do
     "#{self.class.name.downcase}/#{self.id}"
   end
 end
+Tweet = Class.new(Model)
+Share = Class.new(Model)
 
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
@@ -258,4 +260,30 @@ Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do
   cache only: [:id]
   attributes :id
 end
+
+class TweetSerializer < ActiveModel::Serializer
+  attributes :id, :body, :date
+
+  belongs_to :author do
+    attributes :id
+  end
+
+  has_many :shares do
+    attributes :id, :platform
+
+    belongs_to :author do
+      attributes :id, :name
+    end
+  end
+end
+
+class ShareSerializer < ActiveModel::Serializer
+  attributes :id, :platform, :date
+
+  belongs_to :author do
+    attributes :id, :name, :email
+  end
+  belongs_to :post
+end
+
 $VERBOSE = verbose

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -38,6 +38,8 @@ module ActiveModel
           @my_profile = MyProfile.new
           @custom_profile = CustomProfile.new
           @model = ::Model.new
+          @tweet = Tweet.new
+          @share1 = Share.new
         end
 
         def test_serializer_for_existing_serializer
@@ -58,6 +60,11 @@ module ActiveModel
         def test_serializer_custom_serializer
           serializer = ActiveModel::Serializer.serializer_for(@custom_profile)
           assert_equal ProfileSerializer, serializer
+        end
+
+        def test_serializer_for_nested_resource
+          serializer = TweetSerializer.serializer_for(@share1)
+          assert_equal(TweetSerializer::ShareSerializer, serializer)
         end
       end
     end


### PR DESCRIPTION
Given the following situation:
```ruby
module MyNamespace
  class MyModel < ActiveRecord::Base
    has_many :my_related_models
  end
  class MyRelatedModel < ActiveRecord::Base
    ...
  end
end

module MyNamespace
  class MyModelSerializer < ActiveModel::Serializer
    has_many :my_related_models
    ...
  end
  class MyRelatedModelSerializer < ActiveModel::Serializer
    ...
  end
end
```
AMS currently has troubles inferring the right serializer class for `MyRelatedModel` (it should be `MyNamespace::MyRelatedModelSerializer`, but it only looks up `MyRelatedModelSerializer`). This PR fixes that by keeping trace of the "root" serializer, that is the first non-`ArraySerializer` serializer in the chain of nested serializers, and looking up for a serializer in that "root serializer"'s namespace. Especially cool nor polymorphic associations in the namespaced scenario. 

Solves stuff such as #886, #916, #879 but without having to manually specify the namespace.

Based on #1193 because it sort of paved the way.

[TODO] Add some tests.