### PR TITLE
`type` directive for serializer to control type field with json-api adapter

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -46,6 +46,10 @@ module ActiveModel
       super
     end
 
+    def self.type(type)
+      self._type = type
+    end
+
     def self.attributes(*attrs)
       attrs = attrs.first if attrs.first.class == Array
 
@@ -122,6 +126,7 @@ module ActiveModel
     end
 
     attr_accessor :object, :root, :meta, :meta_key, :scope
+    class_attribute :_type, instance_writer: false
 
     def initialize(object, options = {})
       self.object = object

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -71,6 +71,7 @@ module ActiveModel
         end
 
         def resource_identifier_type_for(serializer)
+          return serializer._type if serializer._type
           if ActiveModel::Serializer.config.jsonapi_resource_type == :singular
             serializer.object.class.model_name.singular
           else

--- a/test/adapter/json_api/resource_type_config_test.rb
+++ b/test/adapter/json_api/resource_type_config_test.rb
@@ -5,6 +5,11 @@ module ActiveModel
     module Adapter
       class JsonApi
         class ResourceTypeConfigTest < Minitest::Test
+          class ProfileTypeSerializer < ActiveModel::Serializer
+            attributes :name
+            type 'profile'
+          end
+
           def setup
             @author = Author.new(id: 1, name: 'Steve K.')
             @author.bio = nil
@@ -36,21 +41,28 @@ module ActiveModel
           end
 
           def test_config_plural
-            with_adapter :json_api do
-              with_jsonapi_resource_type :plural do
-                hash = ActiveModel::SerializableResource.new(@comment).serializable_hash
-                assert_equal('comments', hash[:data][:type])
-              end
+            with_jsonapi_resource_type :plural do
+              hash = serializable(@comment, adapter: :json_api).serializable_hash
+              assert_equal('comments', hash[:data][:type])
             end
           end
 
           def test_config_singular
-            with_adapter :json_api do
-              with_jsonapi_resource_type :singular do
-                hash = ActiveModel::SerializableResource.new(@comment).serializable_hash
-                assert_equal('comment', hash[:data][:type])
-              end
+            with_jsonapi_resource_type :singular do
+              hash = serializable(@comment, adapter: :json_api).serializable_hash
+              assert_equal('comment', hash[:data][:type])
             end
+          end
+
+          def test_explicit_type_value
+            hash = serializable(@author, serializer: ProfileTypeSerializer, adapter: :json_api).serializable_hash
+            assert_equal('profile', hash.fetch(:data).fetch(:type))
+          end
+
+          private
+
+          def serializable(resource, options = {})
+            ActiveModel::SerializableResource.new(resource, options)
           end
         end
       end


### PR DESCRIPTION
This pull-requests implements `type` directive for serializer declaration. Which sets type attribute while using json-api adapter. So it's possible to use ProfileSerializer with User model and set type field to 'profile', like this:
```
class ProfileSerializer < ActiveModel::Serializer
  attributes :name
  type 'profile'
end
```