### PR TITLE
Namespace separator fix for type field in jsonapi adapter

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -71,11 +71,8 @@ module ActiveModel
         end
 
         def resource_identifier_type_for(serializer)
-          if ActiveModel::Serializer.config.jsonapi_resource_type == :singular
-            serializer.object.class.model_name.singular
-          else
-            serializer.object.class.model_name.plural
-          end
+          type = serializer.object.class.name.demodulize.underscore
+          ActiveModel::Serializer.config.jsonapi_resource_type == :singular ? type : type.pluralize
         end
 
         def resource_identifier_id_for(serializer)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -71,7 +71,7 @@ module ActiveModel
         end
 
         def resource_identifier_type_for(serializer)
-          type = serializer.object.class.name.demodulize.underscore
+          type = serializer.object.class.name.underscore.gsub('/', '--')
           ActiveModel::Serializer.config.jsonapi_resource_type == :singular ? type : type.pluralize
         end
 

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -203,7 +203,7 @@ module ActiveModel
             assert_equal expected, alt_adapter.serializable_hash[:included]
           end
 
-          def test_underscore_model_namespace_for_linked_resource_type
+          def test_remove_model_namespace_for_linked_resource_type
             spammy_post = Post.new(id: 123)
             spammy_post.related = [Spam::UnrelatedLink.new(id: 456)]
             serializer = SpammyPostSerializer.new(spammy_post)
@@ -212,7 +212,7 @@ module ActiveModel
             expected = {
               related: {
                 data: [{
-                  type: 'spam_unrelated_links',
+                  type: 'unrelated_links',
                   id: '456'
                 }]
               }

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -212,7 +212,7 @@ module ActiveModel
             expected = {
               related: {
                 data: [{
-                  type: 'unrelated_links',
+                  type: 'spam--unrelated_links',
                   id: '456'
                 }]
               }


### PR DESCRIPTION
This PR removes namespace from automatically generated `type` field.
Discussion's going on here:
http://discuss.jsonapi.org/t/convention-for-namespacing-type/99