### PR TITLE
Change default rake task to run test and rubocop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 
 script:
   - env CAPTURE_STDERR=false bundle exec rake
-  - bundle exec rake rubocop
 
 env:
   - "RAILS_VERSION=4.0"

--- a/Rakefile
+++ b/Rakefile
@@ -36,4 +36,4 @@ Rake::TestTask.new do |t|
   t.verbose = true
 end
 
-task :default => :test
+task default: [:test, :rubocop]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,6 @@ install:
   - bundle install --retry=3
 
 test_script:
-  - bundle exec rake
+  - bundle exec rake test
 
 build: off


### PR DESCRIPTION
The rubocop only runs in the CI this way a contributor probably will see a
rubocop offense only in the CI.

Running the rubocop in the default rake task we have more chance that a offense
be get in the local machine.