### PR TITLE
Add support for inline serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Breaking changes:
 
 Features:
 
+- [#1226](https://github.com/rails-api/active_model_serializers/pull/1126) Add inline syntax for nested serializers (@beauby)
 - [#1225](https://github.com/rails-api/active_model_serializers/pull/1125) Better serializer lookup, use nested serializer when it exists (@beauby)
 - [#1172](https://github.com/rails-api/active_model_serializers/pull/1172) Better serializer registration, get more than just the first module (@bf4)
 - [#1158](https://github.com/rails-api/active_model_serializers/pull/1158) Add support for wildcards in `include` option (@beauby)

--- a/docs/general/getting_started.md
+++ b/docs/general/getting_started.md
@@ -61,7 +61,7 @@ end
 
 When serializing a model inside a namespace, such as `Api::V1::Post`, AMS will expect the corresponding serializer to be inside the same namespace (namely `Api::V1::PostSerializer`).
 
-### Model Associations and Nested Serializers
+### Model Associations and Inline serializers
 
 When declaring a serializer for a model with associations, such as:
 ```ruby
@@ -69,24 +69,19 @@ class PostSerializer < ActiveModel::Serializer
   has_many :comments
 end
 ```
-AMS will look for `PostSerializer::CommentSerializer` in priority, and fall back to `::CommentSerializer` in case the former does not exist. This allows for more control over the way a model gets serialized as an association of an other model.
-
-For example, in the following situation:
-
+AMS offers the possibility to define a single-purpose inline serializer as follows:
 ```ruby
-class CommentSerializer < ActiveModel::Serializer
-  attributes :body, :date, :nb_likes
-end
-
 class PostSerializer < ActiveModel::Serializer
-  has_many :comments
-  class CommentSerializer < ActiveModel::Serializer
-    attributes :body_short
+  has_many :comments do
+    ...
   end
 end
 ```
+The block given to the association is then used to define a serializer that will be used only when serializing a `Comment` as an association of a `Post`.
 
-AMS will use `PostSerializer::CommentSerializer` (thus including only the `:body_short` attribute) when serializing a `Comment` as part of a `Post`, but use `::CommentSerializer` when serializing a `Comment` directly (thus including `:body, :date, :nb_likes`).
+In case no block is given, AMS will look for a serializer for `Comment`s in the usual way (i.e. in the namespace of the resource).
+
+This allows for finer control over the way associations as serialized.
 
 ## Rails Integration
 

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -34,53 +34,92 @@ module ActiveModel
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional inline definition of the serializer for this association
         # @return [void]
         #
         # @example
         #  has_many :comments, serializer: CommentSummarySerializer
+        #  has_many :comments do
+        #    attributes :id, :content
+        #  end
         #
-        def has_many(name, options = {})
-          associate HasManyReflection.new(name, options)
+        def has_many(name, options = {}, &block)
+          associate(HasManyReflection.new(name, options), &block)
         end
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional inline definition of the serializer for this association
         # @return [void]
         #
         # @example
         #  belongs_to :author, serializer: AuthorSerializer
+        #  belongs_to :author do
+        #    attributes :id, :name
+        #  end
         #
-        def belongs_to(name, options = {})
-          associate BelongsToReflection.new(name, options)
+        def belongs_to(name, options = {}, &block)
+          associate(BelongsToReflection.new(name, options), &block)
         end
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional inline definition of the serializer for this association
         # @return [void]
         #
         # @example
         #  has_one :author, serializer: AuthorSerializer
+        #  has_one :author do
+        #    attributes :id, :name
+        #  end
         #
-        def has_one(name, options = {})
-          associate HasOneReflection.new(name, options)
+        def has_one(name, options = {}, &block)
+          associate(HasOneReflection.new(name, options), &block)
         end
 
         private
 
-        # Add reflection and define {name} accessor.
+        # Add reflection and define {name} accessor and nested serializer.
         # @param [ActiveModel::Serializer::Reflection] reflection
+        # @param [Block] optional inline definition of the serializer for this association
         # @return [void]
         #
         # @api private
         #
-        def associate(reflection)
+        def associate(reflection, &block)
           self._reflections = _reflections.dup
 
           define_method reflection.name do
             object.send reflection.name
           end unless method_defined?(reflection.name)
 
-          self._reflections << reflection
+          _reflections << reflection
+
+          define_nested_serializer(reflection.name.to_s.singularize, &block) if block_given?
+        end
+
+        # Define a nested serializer
+        # @param [String] resource_name The name of the association
+        # @param [Block] inline definition of the serializer for this association
+        # @return [void]
+        #
+        # @example
+        #  Namespace::PostSerializer.define_nested_serializer("comment") do
+        #    attributes :id, :content
+        #  end
+        #
+        # is equivalent to
+        #  class Namespace::PostSerializer::CommentSerializer < ActiveModel::Serializer
+        #    attributes :id, :content
+        #  end
+        #
+        # @api private
+        #
+        def define_nested_serializer(resource_name, &block)
+          serializer_name = "#{resource_name.camelize}Serializer"
+          serializer = Class.new(ActiveModel::Serializer)
+          serializer.class_eval(&block)
+          const_set(serializer_name, serializer)
         end
       end
 

--- a/test/serializers/inline_serializers_test.rb
+++ b/test/serializers/inline_serializers_test.rb
@@ -1,0 +1,25 @@
+module ActiveModel
+  class Serializer
+    class InlineSerializersTest < Minitest::Test
+      class PostSerializer < ActiveModel::Serializer
+        attributes :title, :body
+        belongs_to :author
+        has_many :comments do
+          attributes :body
+          belongs_to :author
+        end
+      end
+
+      def test_inline_serializer_defined_if_block_given
+        refute_nil("#{self.class}::PostSerializer::CommentSerializer".safe_constantize)
+        assert_equal(ActiveModel::Serializer, PostSerializer::CommentSerializer.superclass)
+        assert_equal([:author], PostSerializer::CommentSerializer._reflections.map(&:name))
+        assert_equal([:body], PostSerializer::CommentSerializer._attributes)
+      end
+
+      def test_inline_serializer_not_defined_unless_block_given
+        assert_nil("#{self.class}::PostSerializer::AuthorSerializer".safe_constantize)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the second part of #1193, and is based on top of #1225. This PR allows for defining nested serializers with a block syntax as follows:

```ruby
class PostSerializer
  attributes ...
  has_many :comments do
    attributes ...
  end
end
```