### PR TITLE
[WIP] Refactor test infrastructure

### DIFF
--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -18,27 +18,37 @@ module ActiveModel
             @post.blog = @blog
             @anonymous_post.blog = nil
 
-            @serializer = CommentSerializer.new(@comment)
-            @adapter = ActiveModel::Serializer::Adapter::Json.new(@serializer)
             ActionController::Base.cache_store.clear
           end
 
           def test_includes_post
-            assert_equal({ id: 42, title: 'New Post', body: 'Body' }, @adapter.serializable_hash[:comment][:post])
+            resource = SerializableResource.new(@comment, adapter: :json, serializer: CommentSerializer)
+            expected = { id: 42, title: 'New Post', body: 'Body' }
+            actual = resource.serializable_hash[:comment][:post]
+
+            assert_equal expected, actual
           end
 
           def test_include_nil_author
-            serializer = PostSerializer.new(@anonymous_post)
-            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+            resource = SerializableResource.new(@anonymous_post, adapter: :json, serializer: PostSerializer)
+            expected = {
+              post: {
+                title: 'Hello!!', body: 'Hello, world!!', id: 43,
+                comments: [],
+                blog: { id: 999, name: 'Custom blog' }, author: nil
+              }
+            }
+            actual = resource.serializable_hash
 
-            assert_equal({ post: { title: 'Hello!!', body: 'Hello, world!!', id: 43, comments: [], blog: { id: 999, name: 'Custom blog' }, author: nil } }, adapter.serializable_hash)
+            assert_equal expected, actual
           end
 
           def test_include_nil_author_with_specified_serializer
-            serializer = PostPreviewSerializer.new(@anonymous_post)
-            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+            resource = SerializableResource.new(@anonymous_post, adapter: :json, serializer: PostPreviewSerializer)
+            expected = { post: { title: 'Hello!!', body: 'Hello, world!!', id: 43, comments: [], author: nil } }
+            actual = resource.serializable_hash
 
-            assert_equal({ post: { title: 'Hello!!', body: 'Hello, world!!', id: 43, comments: [], author: nil } }, adapter.serializable_hash)
+            assert_equal expected, actual
           end
         end
       end

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -26,7 +26,7 @@ module ActiveModel
             expected = { id: 42, title: 'New Post', body: 'Body' }
             actual = resource.serializable_hash[:comment][:post]
 
-            assert_equal expected, actual
+            assert_equal(expected, actual)
           end
 
           def test_include_nil_author
@@ -40,7 +40,7 @@ module ActiveModel
             }
             actual = resource.serializable_hash
 
-            assert_equal expected, actual
+            assert_equal(expected, actual)
           end
 
           def test_include_nil_author_with_specified_serializer
@@ -48,7 +48,7 @@ module ActiveModel
             expected = { post: { title: 'Hello!!', body: 'Hello, world!!', id: 43, comments: [], author: nil } }
             actual = resource.serializable_hash
 
-            assert_equal expected, actual
+            assert_equal(expected, actual)
           end
         end
       end

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -34,7 +34,7 @@ module ActiveModel
             ]
             actual = resource.serializable_hash[:post][:comments]
 
-            assert_equal expected, actual
+            assert_equal(expected, actual)
           end
 
           def test_has_many_with_no_serializer
@@ -52,7 +52,7 @@ module ActiveModel
             }.to_json
             actual = resource.serializable_hash[:post].to_json
 
-            assert_equal expected, actual
+            assert_equal(expected, actual)
           end
         end
       end

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -22,23 +22,37 @@ module ActiveModel
           end
 
           def test_has_many
-            serializer = PostSerializer.new(@post)
-            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
-            assert_equal([
-                           { id: 1, body: 'ZOMG A COMMENT' },
-                           { id: 2, body: 'ZOMG ANOTHER COMMENT' }
-                         ], adapter.serializable_hash[:post][:comments])
+            resource = SerializableResource.new(
+              @post,
+              adapter: :json,
+              serializer: PostSerializer
+            )
+
+            expected = [
+              { id: 1, body: 'ZOMG A COMMENT' },
+              { id: 2, body: 'ZOMG ANOTHER COMMENT' }
+            ]
+            actual = resource.serializable_hash[:post][:comments]
+
+            assert_equal expected, actual
           end
 
           def test_has_many_with_no_serializer
-            serializer = PostWithTagsSerializer.new(@post)
-            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
-            assert_equal({
+            resource = SerializableResource.new(
+              @post,
+              adapter: :json,
+              serializer: PostWithTagsSerializer
+            )
+
+            expected = {
               id: 42,
               tags: [
                 { 'attributes' => { 'id' => 1, 'name' => '#hash_tag' } }
               ]
-            }.to_json, adapter.serializable_hash[:post].to_json)
+            }.to_json
+            actual = resource.serializable_hash[:post].to_json
+
+            assert_equal expected, actual
           end
         end
       end

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -2,11 +2,12 @@ require 'test_helper'
 
 module ActiveModel
   class SerializableResourceTest < Minitest::Test
-    class Profile < ::Model
-    end
+    Profile = Class.new(::Model)
+
     class ProfileSerializer < ActiveModel::Serializer
       attributes :name, :description, :comments
     end
+
     def setup
       @resource = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
       @serializer = ProfileSerializer.new(@resource)

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -2,8 +2,13 @@ require 'test_helper'
 
 module ActiveModel
   class SerializableResourceTest < Minitest::Test
+    class Profile < ::Model
+    end
+    class ProfileSerializer < ActiveModel::Serializer
+      attributes :name, :description, :comments
+    end
     def setup
-      @resource = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
+      @resource = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
       @serializer = ProfileSerializer.new(@resource)
       @adapter = ActiveModel::Serializer::Adapter.create(@serializer)
       @serializable_resource = ActiveModel::SerializableResource.new(@resource)

--- a/test/serializers/association_macros_test.rb
+++ b/test/serializers/association_macros_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class AssociationMacrosTest < Minitest::Test
-      AuthorSummarySerializer = Class.new
-      class AssociationsTestSerializer < Serializer
+      class AuthorSummarySerializer
+      end
+      class AssociationsTestSerializer < ActiveModel::Serializer
         belongs_to :author, serializer: AuthorSummarySerializer
         has_many :comments
         has_one :category

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -3,14 +3,57 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class AssociationsTest < Minitest::Test
+      Post    = Class.new(::Model)
+      Author  = Class.new(::Model)
+      Tag     = Class.new(::Model)
+      Comment = Class.new(::Model)
+      Blog    = Class.new(::Model)
+
+      class PostSerializer < ActiveModel::Serializer
+        attributes :id, :title, :body
+
+        has_many :comments
+        belongs_to :blog
+        belongs_to :author
+      end
+
+      class PostWithTagsSerializer < ActiveModel::Serializer
+        attributes :id
+
+        has_many :tags
+      end
+
+      class PostWithCustomKeysSerializer < ActiveModel::Serializer
+        attributes :id
+
+        has_many :comments, key: :reviews
+        belongs_to :author, key: :writer
+        has_one :blog, key: :site
+      end
+
+      class AuthorSerializer < ActiveModel::Serializer
+        attributes :id, :name
+        has_many :posts
+        has_many :roles
+        has_one :bio
+      end
+
+      class CommentSerializer < ActiveModel::Serializer
+        attributes :id, :body
+
+        def custom_options
+          instance_options
+        end
+      end
+
       def setup
         @author = Author.new(name: 'Steve K.')
         @author.bio = nil
         @author.roles = []
-        @blog = Blog.new({ name: 'AMS Blog' })
-        @post = Post.new({ title: 'New Post', body: 'Body' })
-        @tag = Tag.new({ name: '#hashtagged' })
-        @comment = Comment.new({ id: 1, body: 'ZOMG A COMMENT' })
+        @blog = Blog.new(name: 'AMS Blog')
+        @post = Post.new(title: 'New Post', body: 'Body')
+        @tag = Tag.new(name: '#hashtagged')
+        @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
         @post.comments = [@comment]
         @post.tags = [@tag]
         @post.blog = @blog
@@ -19,7 +62,7 @@ module ActiveModel
         @post.author = @author
         @author.posts = [@post]
 
-        @post_serializer = PostSerializer.new(@post, { custom_options: true })
+        @post_serializer = PostSerializer.new(@post, custom_options: true)
         @author_serializer = AuthorSerializer.new(@author)
         @comment_serializer = CommentSerializer.new(@comment)
       end
@@ -52,9 +95,12 @@ module ActiveModel
           serializer = association.serializer
           options = association.options
 
-          assert_equal key, :tags
-          assert_equal serializer, nil
-          assert_equal [{ attributes: { name: '#hashtagged' } }].to_json, options[:virtual_value].to_json
+          assert_equal(key, :tags)
+          assert_nil(serializer)
+
+          expected = [{ attributes: { name: '#hashtagged' } }].to_json
+          actual = options[:virtual_value].to_json
+          assert_equal(expected, actual)
         end
       end
 
@@ -63,7 +109,7 @@ module ActiveModel
                         .associations
                         .detect { |assoc| assoc.key == :comments }
 
-        assert association.serializer.first.custom_options[:custom_options]
+        assert(association.serializer.first.custom_options[:custom_options])
       end
 
       def test_belongs_to
@@ -121,9 +167,9 @@ module ActiveModel
 
         expected_association_keys = serializer.associations.map(&:key)
 
-        assert expected_association_keys.include? :reviews
-        assert expected_association_keys.include? :writer
-        assert expected_association_keys.include? :site
+        assert_includes(expected_association_keys, :reviews)
+        assert_includes(expected_association_keys, :writer)
+        assert_includes(expected_association_keys, :site)
       end
     end
   end

--- a/test/serializers/root_test.rb
+++ b/test/serializers/root_test.rb
@@ -20,7 +20,9 @@ module ActiveModel
 
       def test_underscore_in_root
         serializer = VirtualValueSerializer.new(@virtual_value)
-        assert_equal('active_model/serializer/root_test/virtual_value', serializer.json_key)
+
+        namespace_path = self.class.to_s.underscore
+        assert_equal("#{namespace_path}/virtual_value", serializer.json_key)
       end
     end
   end

--- a/test/serializers/root_test.rb
+++ b/test/serializers/root_test.rb
@@ -3,11 +3,12 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class RootTest < Minitest::Test
-      class VirtualValue < ::Model
-      end
+      VirtualValue = Class.new(::Model)
+
       class VirtualValueSerializer < ActiveModel::Serializer
         attributes :id
       end
+
       def setup
         @virtual_value = VirtualValue.new(id: 1)
       end

--- a/test/serializers/root_test.rb
+++ b/test/serializers/root_test.rb
@@ -3,18 +3,23 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class RootTest < Minitest::Test
+      class VirtualValue < ::Model
+      end
+      class VirtualValueSerializer < ActiveModel::Serializer
+        attributes :id
+      end
       def setup
         @virtual_value = VirtualValue.new(id: 1)
       end
 
       def test_overwrite_root
-        serializer = VirtualValueSerializer.new(@virtual_value, { root: 'smth' })
+        serializer = VirtualValueSerializer.new(@virtual_value, root: 'smth')
         assert_equal('smth', serializer.json_key)
       end
 
       def test_underscore_in_root
         serializer = VirtualValueSerializer.new(@virtual_value)
-        assert_equal('virtual_value', serializer.json_key)
+        assert_equal('active_model/serializer/root_test/virtual_value', serializer.json_key)
       end
     end
   end


### PR DESCRIPTION
This PR aims to refactor the test infrastructure so that models and serializers are defined where they are used instead of having a big mess into `fixtures/poro.rb`/`fixtures/active_record.rb`.

Ref: #1206.