### PR TITLE
Move `meta`/`meta_key` handling inside adapter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Fixes:
 - [#1214](https://github.com/rails-api/active_model_serializers/pull/1214) retrieve the key from the reflection options when building associations (@NullVoxPopuli, @hut8)
 
 Misc:
+- [#1233](https://github.com/rails-api/active_model_serializers/pull/1233) Top-level meta and meta_key options no longer handled at serializer level (@beauby)
 - [#1232](https://github.com/rails-api/active_model_serializers/pull/1232) fields option no longer handled at serializer level (@beauby)
 - [#1178](https://github.com/rails-api/active_model_serializers/pull/1178) env CAPTURE_STDERR=false lets devs see hard failures (@bf4)
 - [#1177](https://github.com/rails-api/active_model_serializers/pull/1177) Remove Adapter autoloads in favor of require (@bf4)

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -1,7 +1,7 @@
 require 'set'
 module ActiveModel
   class SerializableResource
-    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter])
+    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key])
 
     # Primary interface to composing a resource with a serializer and adapter.
     # @return the serializable_resource, ready for #as_json/#to_json/#serializable_hash.

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -121,15 +121,13 @@ module ActiveModel
       end
     end
 
-    attr_accessor :object, :root, :meta, :meta_key, :scope
+    attr_accessor :object, :root, :scope
     class_attribute :_type, instance_writer: false
 
     def initialize(object, options = {})
       self.object = object
       self.instance_options = options
       self.root = instance_options[:root]
-      self.meta = instance_options[:meta]
-      self.meta_key = instance_options[:meta_key]
       self.scope = instance_options[:scope]
 
       scope_name = instance_options[:scope_name]

--- a/lib/active_model/serializer/adapter/base.rb
+++ b/lib/active_model/serializer/adapter/base.rb
@@ -37,11 +37,11 @@ module ActiveModel
         private
 
         def meta
-          serializer.meta if serializer.respond_to?(:meta)
+          instance_options.fetch(:meta, nil)
         end
 
         def meta_key
-          serializer.meta_key || 'meta'.freeze
+          instance_options.fetch(:meta_key, 'meta'.freeze)
         end
 
         def root

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -5,7 +5,7 @@ module ActiveModel
       include Enumerable
       delegate :each, to: :@serializers
 
-      attr_reader :object, :root, :meta, :meta_key
+      attr_reader :object, :root
 
       def initialize(resources, options = {})
         @root = options[:root]
@@ -21,8 +21,6 @@ module ActiveModel
             serializer_class.new(resource, options.except(:serializer))
           end
         end
-        @meta     = options[:meta]
-        @meta_key = options[:meta_key]
       end
 
       def json_key

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -41,14 +41,6 @@ module ActiveModel
         refute serializers.first.custom_options.key?(:serializer)
       end
 
-      def test_meta_and_meta_key_attr_readers
-        meta_content = { meta: 'the meta', meta_key: 'the meta key' }
-        @serializer = ArraySerializer.new([@comment, @post], meta_content)
-
-        assert_equal @serializer.meta, 'the meta'
-        assert_equal @serializer.meta_key, 'the meta key'
-      end
-
       def test_root_default
         @serializer = ArraySerializer.new([@comment, @post])
         assert_equal @serializer.root, nil


### PR DESCRIPTION
The (toplevel) `meta` handling is clearly an adapter concern.