### PR TITLE
Add support for toplevel JSON API links.

### DIFF
--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -1,7 +1,7 @@
 require 'set'
 module ActiveModel
   class SerializableResource
-    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key])
+    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links])
 
     # Primary interface to composing a resource with a serializer and adapter.
     # @return the serializable_resource, ready for #as_json/#to_json/#serializable_hash.

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -65,6 +65,11 @@ module ActiveModel
 
           ApiObjects::JsonApi.add!(hash)
 
+          if instance_options[:links]
+            hash[:links] ||= {}
+            hash[:links].update(instance_options[:links])
+          end
+
           hash
         end
 

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    module Adapter
+      class JsonApi
+        class LinksTest < Minitest::Test
+          def setup
+            @post = Post.new(id: 1337, comments: [], author: nil)
+          end
+
+          def test_toplevel_links
+            hash = ActiveModel::SerializableResource.new(
+              @post,
+              adapter: :json_api,
+              links: {
+                self: {
+                  href: '//posts'
+                }
+              }).serializable_hash
+            expected = {
+              self: {
+                href: '//posts'
+              }
+            }
+            assert_equal(expected, hash[:links])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As an adapter option:
```ruby
render json: posts, links: { self: { href: "http//api.domain.com/posts" } }
```