### PR TITLE
Inheritance of serializer inheriting the cache configuration

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -30,13 +30,16 @@ module ActiveModel
     class << self
       attr_accessor :_attributes
       attr_accessor :_attributes_keys
-      attr_accessor :_cache
-      attr_accessor :_fragmented
-      attr_accessor :_cache_key
-      attr_accessor :_cache_only
-      attr_accessor :_cache_except
-      attr_accessor :_cache_options
-      attr_accessor :_cache_digest
+    end
+
+    with_options instance_writer: false, instance_reader: false do |serializer|
+      serializer.class_attribute :_cache
+      serializer.class_attribute :_fragmented
+      serializer.class_attribute :_cache_key
+      serializer.class_attribute :_cache_only
+      serializer.class_attribute :_cache_except
+      serializer.class_attribute :_cache_options
+      serializer.class_attribute :_cache_digest
     end
 
     def self.inherited(base)

--- a/test/serializers/cache_test.rb
+++ b/test/serializers/cache_test.rb
@@ -34,6 +34,22 @@ module ActiveModel
         @blog_serializer     = BlogSerializer.new(@blog)
       end
 
+      def test_inherited_cache_configuration
+        inherited_serializer = Class.new(PostSerializer)
+
+        assert_equal PostSerializer._cache_key, inherited_serializer._cache_key
+        assert_equal PostSerializer._cache_options, inherited_serializer._cache_options
+      end
+
+      def test_override_cache_configuration
+        inherited_serializer = Class.new(PostSerializer) do
+          cache key: 'new-key'
+        end
+
+        assert PostSerializer._cache_key == 'post'
+        assert inherited_serializer._cache_key == 'new-key'
+      end
+
       def test_cache_definition
         assert_equal(ActionController::Base.cache_store, @post_serializer.class._cache)
         assert_equal(ActionController::Base.cache_store, @author_serializer.class._cache)


### PR DESCRIPTION
Hi all!

This PR resolves #1219 declaring the cache related fields with `class_attribute`.

Please, check if the two tests cases are relevant to this change. I felt I was testing the `class_attribute` behavior :confused:.

