### PR TITLE
Add inline syntax to override attributes/associations.

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -65,11 +65,8 @@ module ActiveModel
       serializer.class_attribute :_cache_digest # @api private : Generated
     end
 
-    # Serializers inherit _attributes, _attributes_keys and _reflections.
     # Generates a unique digest for each serializer at load.
     def self.inherited(base)
-      inherit_attributes(base)
-      inherit_associations(base)
       caller_line = caller.first
       base._cache_digest = digest_caller_file(caller_line)
       super

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -101,15 +101,25 @@ module ActiveModel
     #
     #     def recent_edits
     #       object.edits.last(5)
-    #     enr
-    def self.attribute(attr, options = {})
+    #     end
+    #
+    # @example
+    #   class AdminAuthorSerializer < ActiveModel::Serializer
+    #     attribute :name do
+    #       "#{object.first_name} #{object.last_name}"
+    #     end
+    def self.attribute(attr, options = {}, &block)
       key = options.fetch(:key, attr)
       _attributes_keys[attr] = { key: key } if key != attr
       _attributes << key unless _attributes.include?(key)
 
       ActiveModelSerializers.silence_warnings do
         define_method key do
-          object.read_attribute_for_serialization(attr)
+          if block_given?
+            instance_eval(&block)
+          else
+            object.read_attribute_for_serialization(attr)
+          end
         end unless method_defined?(key) || _fragmented.respond_to?(attr)
       end
     end

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -27,7 +27,9 @@ module ActiveModel
       end
 
       module ClassMethods
-        def inherit_associations(base)
+        # Serializers inherit _reflections.
+        def inherited(base)
+          super
           base._reflections = _reflections.dup
         end
 

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -1,0 +1,78 @@
+module ActiveModel
+  class Serializer
+    # Defines the attributes to be serialized.
+    #
+    module Attributes
+      extend ActiveSupport::Concern
+
+      included do |base|
+        base.class_attribute :_attributes      # @api private : names of attribute methods, @see #attribute
+        base._attributes ||= []
+        base.class_attribute :_attributes_keys # @api private : maps attribute value to explict key name, @see #attribute
+        base._attributes_keys ||= {}
+      end
+
+      module ClassMethods
+        def inherit_attributes(base)
+          base._attributes = _attributes.dup
+          base._attributes_keys = _attributes_keys.dup
+        end
+
+        # @example
+        #   class AdminAuthorSerializer < ActiveModel::Serializer
+        #     attributes :id, :name, :recent_edits
+        def attributes(*attrs)
+          attrs = attrs.first if attrs.first.class == Array
+
+          attrs.each do |attr|
+            attribute(attr)
+          end
+        end
+
+        # @example
+        #   class AdminAuthorSerializer < ActiveModel::Serializer
+        #     attributes :id, :recent_edits
+        #     attribute :name, key: :title
+        #
+        #     def recent_edits
+        #       object.edits.last(5)
+        #     end
+        #
+        # @example
+        #   class AdminAuthorSerializer < ActiveModel::Serializer
+        #     attribute :name do
+        #       "#{object.first_name} #{object.last_name}"
+        #     end
+        def attribute(attr, options = {}, &block)
+          key = options.fetch(:key, attr)
+          _attributes_keys[attr] = { key: key } if key != attr
+          _attributes << key unless _attributes.include?(key)
+
+          ActiveModelSerializers.silence_warnings do
+            define_method key do
+              if block_given?
+                instance_eval(&block)
+              else
+                object.read_attribute_for_serialization(attr)
+              end
+            end unless method_defined?(key) || _fragmented.respond_to?(attr)
+          end
+        end
+      end
+
+      # Return the +attributes+ of +object+ as presented
+      # by the serializer.
+      def attributes
+        attributes = self.class._attributes.dup
+
+        attributes.each_with_object({}) do |name, hash|
+          if self.class._fragmented
+            hash[name] = self.class._fragmented.public_send(name)
+          else
+            hash[name] = send(name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -13,7 +13,9 @@ module ActiveModel
       end
 
       module ClassMethods
-        def inherit_attributes(base)
+        # Serializers inherit _attributes and _attributes_keys.
+        def inherited(base)
+          super
           base._attributes = _attributes.dup
           base._attributes_keys = _attributes_keys.dup
         end

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -71,6 +71,21 @@ module ActiveModel
 
         assert_equal('custom', hash[:blog][:id])
       end
+
+      PostWithVirtualAttribute = Class.new(::Model)
+      class PostWithVirtualAttributeSerializer < ActiveModel::Serializer
+        attribute :name do
+          "#{object.first_name} #{object.last_name}"
+        end
+      end
+
+      def test_virtual_attribute_block
+        post = PostWithVirtualAttribute.new(first_name: 'Lucas', last_name: 'Hosseini')
+        hash = serializable(post).serializable_hash
+        expected = { name: 'Lucas Hosseini' }
+
+        assert_equal(expected, hash)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR brings the following syntax for overriding attributes/associations and declaring virtual attributes/associations in a serializer:
```ruby
class PostSerializer < ActiveModel::Serializer
  attribute :name do
    "#{object.first_name} #{object.last_name}"
  end

  has_many :comments do
    object.comments.limit(10)
  end
end
```
that is currently equivalent to the usual
```ruby
class PostSerializer < ActiveModel::Serializer
  attribute :name
  def name
    "#{object.first_name} #{object.last_name}"
  end

  has_many :comments
  def comments
    object.comments.limit(10)
  end
end
```
Note that this change is not only cosmetic, as it is a prerequisite to move away from the old way (defining methods on the serializer, which caused many issues when the attribute name was that of a reserved method name (ref #1261)), and refactor the way attributes are handled in a safer way.

Update: added overriding of associations as well + factoring out of the attributes logic.