### PR TITLE
Add controller lookup.

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -25,6 +25,7 @@ module ActionController
           "Please pass 'adapter: false' or see ActiveSupport::SerializableResource.new"
         options[:adapter] = false
       end
+      options[:_controller_class_name] = self.class.name
       serializable_resource = ActiveModel::SerializableResource.new(resource, options)
       if serializable_resource.serializer?
         serializable_resource.serialization_scope ||= serialization_scope

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -41,7 +41,7 @@ module ActiveModel
       @serializer ||=
         begin
           @serializer = serializer_opts.delete(:serializer)
-          @serializer ||= ActiveModel::Serializer.serializer_for(resource)
+          @serializer ||= ActiveModel::Serializer.serializer_for(resource, serializer_opts.slice(:_controller_class_name))
 
           if serializer_opts.key?(:each_serializer)
             serializer_opts[:serializer] = serializer_opts.delete(:each_serializer)

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -12,7 +12,7 @@ module ActiveModel
         @object = resources
         @serializers = resources.map do |resource|
           serializer_context_class = options.fetch(:serializer_context_class, ActiveModel::Serializer)
-          serializer_class = options.fetch(:serializer) { serializer_context_class.serializer_for(resource) }
+          serializer_class = options.fetch(:serializer) { serializer_context_class.serializer_for(resource, options.slice(:_controller_class_name)) }
 
           if serializer_class.nil?
             fail NoSerializerError, "No serializer found for resource: #{resource.inspect}"


### PR DESCRIPTION
This PR adds the controller's namespace to the lookup chain, such that the following works:
```ruby
class User < ActiveModel::Base
  ...
end

module Api
  module V1
    class UsersController < ApplicationController
      def index
        render json: User.all
      end
    end
    class UserSerializer < ActiveModel::Serializer
      ...
    end
  end
end
```