### PR TITLE
Add optional fields support for associations

### DIFF
--- a/lib/active_model/serializer/adapter/attributes.rb
+++ b/lib/active_model/serializer/adapter/attributes.rb
@@ -35,8 +35,19 @@ module ActiveModel
 
         def resource_relationships(options)
           relationships = {}
+
+          association_fields_hash = {}
+          if options[:fields]
+            association_fields_hash = Hash[
+              *options[:fields].select { |s| s.is_a? Hash }
+            ]
+          end
+
           serializer.associations(@include_tree).each do |association|
-            relationships[association.key] = relationship_value_for(association, options)
+            relationships[association.key] = relationship_value_for(
+              association,
+              options.merge(fields: association_fields_hash[association.name])
+            )
           end
 
           relationships

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -85,6 +85,72 @@ module ActiveModel
 
             assert_equal(expected, actual)
           end
+
+          def test_fields_option
+            serializer = ArraySerializer.new([@first_post, @second_post])
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer)
+            actual = adapter.serializable_hash(fields: [:id])
+
+            expected = { posts: [{
+              id: 1,
+              comments: [],
+              author: {
+                id: 1,
+                name: 'Steve K.'
+              },
+              blog: {
+                id: 999,
+                name: 'Custom blog'
+              }
+            }, {
+              id: 2,
+              comments: [],
+              author: {
+                id: 1,
+                name: 'Steve K.'
+              },
+              blog: {
+                id: 999,
+                name: 'Custom blog'
+              }
+            }] }
+
+            assert_equal(expected, actual)
+          end
+
+          def test_fields_with_no_associations_include_option
+            serializer = ArraySerializer.new([@first_post, @second_post])
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, include: [])
+            actual = adapter.serializable_hash(fields: [:id])
+
+            expected = { posts: [{
+              id: 1
+            }, {
+              id: 2
+            }] }
+
+            assert_equal(expected, actual)
+          end
+
+          def test_fields_with_associations_fields_option
+            serializer = ArraySerializer.new([@first_post, @second_post])
+            adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, include: [:author])
+            actual = adapter.serializable_hash(fields: [:id, author: [:name]])
+
+            expected = { posts: [{
+              id: 1,
+              author: {
+                name: 'Steve K.'
+              }
+            }, {
+              id: 2,
+              author: {
+                name: 'Steve K.'
+              }
+            }] }
+
+            assert_equal(expected, actual)
+          end
         end
       end
     end


### PR DESCRIPTION
I am really fond of JSONAPI but there are people that they still need JSON (mostly) and Attributes adapters :) Plus, we should opt for best migration from 0.8.x and 0.9x adapters.

There is a minor bug in the fields option in master branch. If you have:

```ruby
render json: @videos.limit(1), each_serializer: VideoSerializer,  fields: [:id],
```

This will apply the fields to all associations too. We don't want that. What we want is:

If there is a fields param, apply it to the main resource. If there are associations, serialize the associations without removing any attributes. For instance:
```ruby
render json: @videos.limit(1), each_serializer: VideoSerializer,  fields: [:id]
```
Then this should apply the `fields: [:id]` only in the VideoSerializer and not in any association.

If there are associations in the fields array (just like in StrongParams) and these also exist in the main resource, apply the associations fields there. For instance:
```ruby
render json: @videos.limit(1), each_serializer: VideoSerializer,  fields: [:id, user: [:name]]
```
Then this should apply the `fields: [:id]` only in the VideoSerializer and if there is a user association, apply `fields: [:name]` in the UserSerializer.

I am really looking forward to merge this PR so if you need anything from me just ping me. I will also create a regression test highlighting the bug.