### PR TITLE
Add regression test for fields in JSON/Attributes adapter

### DIFF
--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -85,6 +85,20 @@ module ActiveModel
 
             assert_equal(expected, actual)
           end
+
+          def test_fields_with_no_associations_include_option
+            actual = ActiveModel::SerializableResource.new(
+              [@first_post, @second_post], adapter: :json, fields: [:id]
+            ).as_json
+
+            expected = { posts: [{
+              id: 1,
+            }, {
+              id: 2,
+            }] }
+
+            assert_equal(expected, actual)
+          end
         end
       end
     end


### PR DESCRIPTION
Regression test showing how fields fails when there are associations