### PR TITLE
Constructor does not pass down the options to serializer

### DIFF
--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -85,6 +85,20 @@ module ActiveModel
 
             assert_equal(expected, actual)
           end
+
+          def test_fields_with_no_associations_include_option
+            actual = ActiveModel::SerializableResource.new(
+              [@first_post, @second_post], adapter: :json, fields: [:id]
+            ).serializable_hash
+
+            expected = { posts: [{
+              id: 1
+            }, {
+              id: 2
+            }] }
+
+            assert_equal(expected, actual)
+          end
         end
       end
     end


### PR DESCRIPTION
This passes down the options for the serializer to the serializer:
```ruby
render json: @videos.limit(1), each_serializer: VideoSerializer,  fields: [:id]
```
due to here: https://github.com/rails-api/active_model_serializers/blob/master/lib/action_controller/serialization.rb#L50-L51

whereas this doesn't:
```ruby
render(
  json: ActiveModel::SerializableResource.new(@videos.limit(1), {
    each_serializer: VideoSerializer,  fields: [:id]
  }).serializable_hash
)
```