### PR TITLE
Pass fields down from constructor

### DIFF
--- a/lib/active_model/serializer/adapter/attributes.rb
+++ b/lib/active_model/serializer/adapter/attributes.rb
@@ -9,6 +9,7 @@ module ActiveModel
 
         def serializable_hash(options = nil)
           options ||= {}
+          options[:fields] = instance_options[:fields] if options[:fields].nil?
 
           if serializer.respond_to?(:each)
             serializable_hash_for_collection(options)

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -85,6 +85,20 @@ module ActiveModel
 
             assert_equal(expected, actual)
           end
+
+          def test_fields_with_no_associations_include_option
+            actual = ActiveModel::SerializableResource.new(
+              [@first_post, @second_post], adapter: :json, fields: [:id], include: []
+            ).as_json
+
+            expected = { posts: [{
+              id: 1
+            }, {
+              id: 2
+            }] }
+
+            assert_equal(expected, actual)
+          end
         end
       end
     end


### PR DESCRIPTION
Passes down the fields option to the serializer from the constructor unless it's overridden.