### PR TITLE
Only use subclasses of ActiveModel::Serializer during lookup.

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -202,7 +202,7 @@ module ActiveModel
     def self.get_serializer_for(klass)
       serializers_cache.fetch_or_store(klass) do
         # NOTE(beauby): When we drop 1.9.3 support we can lazify the map for perfs.
-        serializer_class = serializer_lookup_chain_for(klass).map(&:safe_constantize).find { |x| x }
+        serializer_class = serializer_lookup_chain_for(klass).map(&:safe_constantize).find { |x| x && x < ActiveModel::Serializer }
 
         if serializer_class
           serializer_class

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -44,11 +44,20 @@ module ActiveModel
           def serializer_class; ProfileSerializer; end
         end
 
+        Tweet = Class.new(::Model)
+        TweetSerializer = Class.new
+
         def setup
           @profile = Profile.new
           @my_profile = MyProfile.new
           @custom_profile = CustomProfile.new
           @model = ::Model.new
+          @tweet = Tweet.new
+        end
+
+        def test_serializer_for_non_ams_serializer
+          serializer = ActiveModel::Serializer.serializer_for(@tweet)
+          assert_nil(serializer)
         end
 
         def test_serializer_for_existing_serializer


### PR DESCRIPTION
Fixes #1293.