### PR TITLE
Allow users to globally opt out of automatic lookup

### DIFF
--- a/docs/general/configuration_options.md
+++ b/docs/general/configuration_options.md
@@ -5,6 +5,7 @@ The following configuration options can be set on `ActiveModel::Serializer.confi
 ## General
 
 - `adapter`: The [adapter](adapters.md) to use. Possible values: `:attributes, :json, :json_api`. Default: `:attributes`.
+- `automatic_lookup`: Whether serializer should be automatically looked up or manually provided. Default: `true`
 
 ## JSON API
 

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -20,6 +20,10 @@ module ActionController
     end
 
     def get_serializer(resource, options = {})
+      unless options[:serializer] || options[:each_serializer] || ActiveModel::Serializer.config.automatic_lookup
+        return resource
+      end
+
       if !use_adapter?
         warn 'ActionController::Serialization#use_adapter? has been removed. '\
           "Please pass 'adapter: false' or see ActiveSupport::SerializableResource.new"

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -20,6 +20,7 @@ module ActiveModel
 
         config.adapter = :attributes
         config.jsonapi_resource_type = :plural
+        config.automatic_lookup = true
       end
     end
   end


### PR DESCRIPTION
Adds an option allowing existing applications to opt out of automatic Serialization lookup.

Two use cases where I've already needed this:

  * Existing applications where another serialization system is stomping on the `.*Serializer` suffix and you need to migrate over to AMS piecemeal 
  * Existing applications that have existing public API where they can't change JSON responses and can't change the existing response structure. E.g. if you a `Tweet` model and want to add a `TweetSerializer` for controllers under the `v2` namespace but not change existing responses for `v1` that are created with a bare `render json: a_tweet`

If this looks good, I'll get a test in.

Closes #1293