### PR TITLE
0.8 ActiveModel::Serializer _fast_attributes - raise NameError without backtrace

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -107,9 +107,8 @@ module ActiveModel
         #  attributes are added later in a classes lifecycle
         # poison the cache
         define_method :_fast_attributes do
-          raise NameError
+          raise NameError, nil, []
         end
-
       end
 
       def associate(klass, attrs) #:nodoc:


### PR DESCRIPTION
For this test I'm getting ~x2 improvement on JRuby.
NameError is used internally for flow controll. Backtrace is not needed, so I'm not raising it.
Links: https://github.com/jruby/jruby/wiki/BacktraceGeneration https://www.coffeepowered.net/2011/06/17/jruby-performance-exceptions-are-not-flow-control/

u is istance of User class from bench/perf.rb

```ruby
serializers = []

10_000.times do
  serializers << Class.new(ActiveModel::Serializer) do
    attributes :id, :name
  end
end

Benchmark.bm do |x|
  x.report("serializable_hash") do
    serializers.each do |serializer|
      serializer.new(u).serializable_hash
    end
  end
end
```

without patch:
```
$ jruby -S rake bench
Resolving dependencies.....
       user     system      total        real
serializable_hash 10.300000   0.610000  10.910000 (  7.324000)
```

with:
```
$ jruby -S rake bench
Resolving dependencies.....
       user     system      total        real
serializable_hash  6.470000   0.480000   6.950000 (  3.249000)
```