### PR TITLE
Block syntax for associations.

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -14,7 +14,7 @@ module ActiveModel
 
       included do |base|
         base.class_attribute :_reflections
-        self._reflections ||= []
+        base._reflections ||= []
 
         extend ActiveSupport::Autoload
         autoload :Association

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -13,9 +13,8 @@ module ActiveModel
       DEFAULT_INCLUDE_TREE = ActiveModel::Serializer::IncludeTree.from_string('*')
 
       included do |base|
-        class << base
-          attr_accessor :_reflections
-        end
+        base.class_attribute :_reflections
+        self._reflections ||= []
 
         extend ActiveSupport::Autoload
         autoload :Association
@@ -29,58 +28,44 @@ module ActiveModel
 
       module ClassMethods
         def inherited(base)
-          base._reflections = self._reflections.try(:dup) || []
+          super
+          base._reflections = _reflections.dup
         end
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional block to customize value of the reflection
         # @return [void]
         #
         # @example
         #  has_many :comments, serializer: CommentSummarySerializer
         #
-        def has_many(name, options = {})
-          associate HasManyReflection.new(name, options)
+        def has_many(name, options = {}, &block)
+          _reflections << HasManyReflection.new(name, options, block)
         end
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional block to customize value of the reflection
         # @return [void]
         #
         # @example
         #  belongs_to :author, serializer: AuthorSerializer
         #
-        def belongs_to(name, options = {})
-          associate BelongsToReflection.new(name, options)
+        def belongs_to(name, options = {}, &block)
+          _reflections << BelongsToReflection.new(name, options, block)
         end
 
         # @param [Symbol] name of the association
         # @param [Hash<Symbol => any>] options for the reflection
+        # @param [Block] optional block to customize value of the reflection
         # @return [void]
         #
         # @example
         #  has_one :author, serializer: AuthorSerializer
         #
-        def has_one(name, options = {})
-          associate HasOneReflection.new(name, options)
-        end
-
-        private
-
-        # Add reflection and define {name} accessor.
-        # @param [ActiveModel::Serializer::Reflection] reflection
-        # @return [void]
-        #
-        # @api private
-        #
-        def associate(reflection)
-          self._reflections = _reflections.dup
-
-          define_method reflection.name do
-            object.send reflection.name
-          end unless method_defined?(reflection.name)
-
-          self._reflections << reflection
+        def has_one(name, options = {}, &block)
+          _reflections << HasOneReflection.new(name, options, block)
         end
       end
 

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -132,8 +132,8 @@ module ActiveModel
                 id: '1',
                 type: 'virtual_values',
                 relationships: {
-                  maker: { data: { id: 1 } },
-                  reviews: { data: [{ id: 1 }, { id: 2 }] }
+                  maker: { data: { 'id' => 1 } },
+                  reviews: { data: [{ 'id' => 1 }, { 'id' => 2 }] }
                 }
               }
             }, adapter.serializable_hash)

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -66,8 +66,8 @@ module ActiveModel
                 id: '1',
                 type: 'virtual_values',
                 relationships: {
-                  maker: { data: { id: 1 } },
-                  reviews: { data: [{ id: 1 }, { id: 2 }] }
+                  maker: { data: { 'id' => 1 } },
+                  reviews: { data: [{ 'id' => 1 }, { 'id' => 2 }] }
                 }
               }
             }

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -122,9 +122,9 @@ end
 
 LocationSerializer = Class.new(ActiveModel::Serializer) do
   cache only: [:place], skip_digest: true
-  attributes :id, :lat, :lng
+  attributes :id, :lat, :lng, :place
 
-  belongs_to :place do
+  def place
     'Nowhere'
   end
 end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -62,12 +62,10 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :title, :body
 
   has_many :comments
-  belongs_to :blog
-  belongs_to :author
-
-  def blog
+  belongs_to :blog do
     Blog.new(id: 999, name: 'Custom blog')
   end
+  belongs_to :author
 
   def custom_options
     instance_options
@@ -126,9 +124,7 @@ LocationSerializer = Class.new(ActiveModel::Serializer) do
   cache only: [:place], skip_digest: true
   attributes :id, :lat, :lng
 
-  belongs_to :place
-
-  def place
+  belongs_to :place do
     'Nowhere'
   end
 end
@@ -212,13 +208,11 @@ end
 VirtualValueSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
 
-  has_many :reviews, virtual_value: [{ id: 1 }, { id: 2 }]
-  has_one :maker, virtual_value: { id: 1 }
-
-  def reviews
+  has_many :reviews do
+    [{ id: 1 }, { id: 2 }]
   end
-
-  def maker
+  has_one :maker do
+    { id: 1 }
   end
 end
 


### PR DESCRIPTION
This PR is half of #1262, introducing the block syntax for overriding associations (and removing the legacy method defining syntax).

Currently 2 tests fail, I believe those tests are ill (they seem to expect an association to be treated as an attribute).