### PR TITLE
begin integration docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ This is the documentation of AMS, it's focused on the **0.10.x version.**
 |----|-----|----
 | Ember.js | 0.9.x | [active-model-adapter](https://github.com/ember-data/active-model-adapter)
 | Ember.js | 0.10.x + |  [docs/integrations/ember-and-json-api.md](integrations/ember-and-json-api.md)
-| Grape | 0.10.x + | #1258  |
+| Grape | 0.10.x + | [#1258](https://github.com/rails-api/active_model_serializers/issues/1258)  |
 | Grape | 0.9.x | https://github.com/jrhe/grape-active_model_serializers/ |
 | Sinatra | 0.9.x | https://github.com/SauloSilva/sinatra-active-model-serializers/
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,10 @@ This is the documentation of AMS, it's focused on the **0.10.x version.**
 - [How to add root key](howto/add_root_key.md)
 - [How to add pagination links](howto/add_pagination_links.md)
 - [Using AMS Outside Of Controllers](howto/outside_controller_use.md)
-- [How to use JSON API with Ember](howto/ember-and-json-api.md)
+
+## Integrations
+- [Ember with JSON API](integrations/ember-and-json-api.md)
+- [Grape](integrations/grape.md)
 
 ## Getting Help
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,13 @@ This is the documentation of AMS, it's focused on the **0.10.x version.**
 - [Using AMS Outside Of Controllers](howto/outside_controller_use.md)
 
 ## Integrations
-- [Ember with JSON API](integrations/ember-and-json-api.md)
-- [Grape](integrations/grape.md)
+| Integration | Supported AMS versions |  Gem name and/or link
+|----|-----|----
+| Ember.js | 0.9.x | [active-model-adapter](https://github.com/ember-data/active-model-adapter)
+| Ember.js | 0.10.x + |  [docs/integrations/ember-and-json-api.md](integrations/ember-and-json-api.md)
+| Grape | 0.10.x + | #1258  |
+| Grape | 0.9.x | https://github.com/jrhe/grape-active_model_serializers/ |
+| Sinatra | 0.9.x | https://github.com/SauloSilva/sinatra-active-model-serializers/
 
 ## Getting Help
 

--- a/docs/integrations/ember-and-json-api.md
+++ b/docs/integrations/ember-and-json-api.md
@@ -34,6 +34,8 @@ export default  DS.JSONAPIAdapter.extend({
 
   // allows queries to be sent along with a findRecord
   // hopefully Ember / EmberData will soon have this built in
+  // ember-data issue tracked here:
+  // https://github.com/emberjs/data/issues/3596
   urlForFindRecord(id, modelName, snapshot) {
     let url = this._super(...arguments);
     let query = Ember.get(snapshot, 'adapterOptions.query');

--- a/docs/integrations/ember-and-json-api.md
+++ b/docs/integrations/ember-and-json-api.md
@@ -1,7 +1,8 @@
 # Integrating with Ember and JSON API
 
  - [Preparation](./ember-and-json-api.md#preparation)
-   - [Adapter Changes](./ember-and-json-api.md#adapter-changes)
+ - [Server-Side Changes](./ember-and-json-api.md#server-side-changes)
+ - [Adapter Changes](./ember-and-json-api.md#adapter-changes)
    - [Serializer Changes](./ember-and-json-api.md#serializer-changes)
  - [Including Nested Resources](./ember-and-json-api.md#including-nested-resources)
 
@@ -11,6 +12,21 @@ Note: This guide assumes that `ember-cli` is used for your ember app.
 
 The JSON API specification calls for hyphens for multi-word separators. AMS uses underscores.
 To solve this, in Ember, both the adapter and the serializer will need some modifications:
+
+### Server-Side Changes
+
+there are multiple mimetypes for json that should all be parsed similarly, so
+in `config/initializers/mime_types.rb`:
+```ruby
+api_mime_types = %W(
+  application/vnd.api+json
+  text/x-json
+  application/json
+)
+
+Mime::Type.unregister :json
+Mime::Type.register 'application/json', :json, api_mime_types
+```
 
 ### Adapter Changes
 

--- a/docs/integrations/ember-and-json-api.md
+++ b/docs/integrations/ember-and-json-api.md
@@ -1,4 +1,4 @@
-# How to use JSON API Query Parameters with Ember
+# Integrating with Ember and JSON API
 
  - [Preparation](./ember-and-json-api.md#preparation)
    - [Adapter Changes](./ember-and-json-api.md#adapter-changes)

--- a/docs/integrations/grape.md
+++ b/docs/integrations/grape.md
@@ -1,0 +1,3 @@
+# Integration with Grape
+
+TODO: details on how to integrate with grape

--- a/docs/integrations/grape.md
+++ b/docs/integrations/grape.md
@@ -1,3 +1,0 @@
-# Integration with Grape
-
-TODO: details on how to integrate with grape


### PR DESCRIPTION
There are always going to be little quirks here and there when integrating with different technologies, especially newer ones.

Here is a pattern suggested by @bf4 for organizing information on how to prepare other technologies to work along with AMS.

note: this doesn't mean that these docs are only for if the integratee needs to change to work with AMS.
When AMS gets the ability to change the key format (specifically for JSON-api) that will clean up the ember-integration documentation a bit.