### PR TITLE
rename context to serialization_context

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/class/attribute'
+require 'active_model_serializers/serialization_context'
 
 module ActionController
   module Serialization
@@ -46,7 +47,7 @@ module ActionController
 
     [:_render_option_json, :_render_with_renderer_json].each do |renderer_method|
       define_method renderer_method do |resource, options|
-        options.fetch(:context) { options[:context] = request }
+        options.fetch(:serialization_context) { options[:serialization_context] = ActiveModelSerializers::SerializationContext.new(request) }
         serializable_resource = get_serializer(resource, options)
         super(serializable_resource, options)
       end

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -222,7 +222,7 @@ module ActiveModel
         end
 
         def pagination_links_for(serializer, options)
-          JsonApi::PaginationLinks.new(serializer.object, options[:context]).serializable_hash(options)
+          JsonApi::PaginationLinks.new(serializer.object, options[:serialization_context]).serializable_hash(options)
         end
       end
     end

--- a/lib/active_model/serializer/adapter/json_api/pagination_links.rb
+++ b/lib/active_model/serializer/adapter/json_api/pagination_links.rb
@@ -41,11 +41,11 @@ module ActiveModel
           end
 
           def url(options)
-            @url ||= options.fetch(:links, {}).fetch(:self, nil) || original_url
+            @url ||= options.fetch(:links, {}).fetch(:self, nil) || request_url
           end
 
-          def original_url
-            @original_url ||= context.original_url[/\A[^?]+/]
+          def request_url
+            @request_url ||= context.request_url
           end
 
           def query_parameters

--- a/lib/active_model_serializers/serialization_context.rb
+++ b/lib/active_model_serializers/serialization_context.rb
@@ -1,0 +1,10 @@
+module ActiveModelSerializers
+  class SerializationContext
+    attr_reader :request_url, :query_parameters
+
+    def initialize(request)
+      @request_url = request.original_url[/\A[^?]+/]
+      @query_parameters = request.query_parameters
+    end
+  end
+end

--- a/test/active_model_serializers/serialization_context_test.rb
+++ b/test/active_model_serializers/serialization_context_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ActiveModelSerializers::SerializationContextTest < Minitest::Test
+  def create_context
+    request = Minitest::Mock.new
+    request.expect(:original_url, 'original_url')
+    request.expect(:query_parameters, 'query_parameters')
+
+    ActiveModelSerializers::SerializationContext.new(request)
+  end
+
+  def test_create_context_with_request_url_and_query_parameters
+    context = create_context
+
+    assert_equal context.request_url, 'original_url'
+    assert_equal context.query_parameters, 'query_parameters'
+  end
+end

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -22,10 +22,10 @@ module ActiveModel
 
           def mock_request(query_parameters = {}, original_url = URI)
             context = Minitest::Mock.new
-            context.expect(:original_url, original_url)
+            context.expect(:request_url, original_url)
             context.expect(:query_parameters, query_parameters)
             @options = {}
-            @options[:context] = context
+            @options[:serialization_context] = context
           end
 
           def load_adapter(paginated_collection, options = {})


### PR DESCRIPTION
A resubmit of my earlier PR. Removed all references to `url_helpers` for now. See https://github.com/rails-api/active_model_serializers/pull/1289#discussion_r42808317 for reference

cc @bf4 