### PR TITLE
Fix `#as_json` glitch caused by JSON and Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - ree
-  - jruby-18mode
   - jruby-19mode
   - rbx-2
 gemfile:
@@ -14,15 +10,3 @@ gemfile:
 matrix:
   allow_failures:
     - gemfile: Gemfile.edge
-  exclude:
-    # Edge Rails is only compatible with 1.9.3
-    - gemfile: Gemfile.edge
-      rvm: 1.8.7
-    - gemfile: Gemfile.edge
-      rvm: 1.9.2
-    - gemfile: Gemfile.edge
-      rvm: ree
-    - gemfile: Gemfile.edge
-      rvm: jruby-18mode
-    - gemfile: Gemfile.edge
-      rvm: rbx-18mode

--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,6 @@ task :bench do
 end
 
 task :default => :test
+
+desc 'CI test task'
+task :ci => :default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+version: '{build}'
+
+skip_tags: true
+
+environment:
+  matrix:
+    - ruby_version: "193"
+    - ruby_version: "193-x64"
+    - ruby_version: "200"
+    - ruby_version: "200-x64"
+    - ruby_version: "21"
+    - ruby_version: "21-x64"
+
+cache:
+  - vendor/bundle
+
+install:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - ruby --version
+  - gem --version
+  - gem install bundler
+  - bundler --version
+  - bundle platform
+  - bundle install --path=vendor/bundle --retry=3 --jobs=3
+
+test_script:
+  - bundle exec rake ci
+
+build: off

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -338,7 +338,7 @@ module ActiveModel
     # object including the root.
     def as_json(options={})
       options ||= {}
-      if root = options.fetch(:root, @options.fetch(:root, root_name))
+      if root = options.to_hash.fetch(:root, @options.fetch(:root, root_name))
         @options[:hash] = hash = {}
         @options[:unique_values] = {}
 

--- a/test/serialization_test.rb
+++ b/test/serialization_test.rb
@@ -242,7 +242,7 @@ class RenderJsonTest < ActionController::TestCase
 
   def test_render_json_with_callback
     get :render_json_hello_world_with_callback
-    assert_equal 'alert({"hello":"world"})', @response.body
+    assert_equal '/**/alert({"hello":"world"})', @response.body
     # For JSONP, Rails 3 uses application/json, but Rails 4 uses text/javascript
     assert_match %r(application/json|text/javascript), @response.content_type.to_s
   end

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -1363,6 +1363,7 @@ class SerializerTest < ActiveModel::TestCase
   def test_inheritance_does_not_used_cached_attributes
     parent = Class.new(ActiveModel::Serializer) do
       attributes :title
+      alias :read_attribute_for_serialization :send
     end
 
     child = Class.new(parent) do
@@ -1371,6 +1372,7 @@ class SerializerTest < ActiveModel::TestCase
 
     data_class = Class.new do
       attr_accessor :title, :body
+      alias :read_attribute_for_serialization :send
     end
 
     item = data_class.new

--- a/test/test_fakes.rb
+++ b/test/test_fakes.rb
@@ -199,6 +199,7 @@ class SomeSerializer < ActiveModel::Serializer
 end
 
 class SomeObject < Struct.new(:some)
+  alias :read_attribute_for_serialization :send
 end
 
 # Set up some classes for polymorphic testing


### PR DESCRIPTION
This addresses issue #340 for the 0.8.x series.  It looks like the existing fix for that issue was not included in that series of active_model_serializers.