### PR TITLE
Add test and bugfix to include an array of string

### DIFF
--- a/lib/active_model/serializer/include_tree.rb
+++ b/lib/active_model/serializer/include_tree.rb
@@ -52,7 +52,7 @@ module ActiveModel
               hash[key] = include_args_to_hash(value)
             end
           when Array
-            included.reduce({}) { |a, e| a.merge!(include_args_to_hash(e)) }
+            included.reduce({}) { |a, e| a.deep_merge!(include_args_to_hash(e)) }
           when String
             include_string_to_hash(included)
           else

--- a/test/include_tree/include_args_to_hash_test.rb
+++ b/test/include_tree/include_args_to_hash_test.rb
@@ -44,6 +44,19 @@ module ActiveModel
 
             assert_equal(expected, actual)
           end
+
+          def test_array_of_string
+            expected = {
+              comments: { author: {}, attachment: {} }
+            }
+            input = [
+              'comments.author',
+              'comments.attachment'
+            ]
+            actual = Parsing.include_args_to_hash(input)
+
+            assert_equal(expected, actual)
+          end
         end
       end
     end


### PR DESCRIPTION
Hello,

I ran into an issue yesterday as I was trying to include multiple attributes of a nested object.

The following section of the README made me think that I would have the result writing `['comments.author', 'comments.attachment']` or `'comments.author,comments.attachment'` but I didn't.

```ruby
# IN README

render @posts, include: ['author', 'comments', 'comments.author']
# or
render @posts, include: 'author,comments,comments.author'
```

The problem came from 

```ruby
include_args_to_hash(['comments.author', `comments.attachment`])
# => { :comments => { :attachment => {} } }

include_args_to_hash('comments.author,comments.attachment')
# => { :comments => { :author => {}, :attachment => {} } }
```

So I think I found a bug, and here is the fix. 