### PR TITLE
change attibutes adapter to show associations at "second" level by as…

### DIFF
--- a/lib/active_model/serializer/adapter/attributes.rb
+++ b/lib/active_model/serializer/adapter/attributes.rb
@@ -46,7 +46,11 @@ module ActiveModel
           return association.options[:virtual_value] if association.options[:virtual_value]
           return unless association.serializer && association.serializer.object
 
-          opts = instance_options.merge(include: @include_tree[association.key])
+          include_tree_hash        = @include_tree[association.key].instance_variable_get(:@hash)
+          include_association_hash = IncludeTree.from_include_args(association.options[:include]).instance_variable_get(:@hash)
+          include_tree = IncludeTree.from_include_args(include_association_hash.merge include_tree_hash)
+
+          opts = instance_options.merge(include: include_tree)
           Attributes.new(association.serializer, opts).serializable_hash(options)
         end
 

--- a/test/adapter/attributes_test.rb
+++ b/test/adapter/attributes_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    module Adapter
+      class AttributesTest < Minitest::Test
+        class PostTestSerializer < Serializer
+          attributes :id, :title
+
+          has_many :comments, include: :author
+          belongs_to :author
+        end
+
+        def setup
+          Rails.cache.clear
+          @first_author = Author.new(id: 1, name: 'Marge S.')
+          @second_author = Author.new(id: 2, name: 'Homer S.')
+          @post = Post.new(id: 1, title: 'New Post')
+          @comment = Comment.new(id: 1, body: 'A COMMENT')
+
+          @post.comments = [@comment]
+          @comment.post = @post
+          @comment.author = @second_author
+          @post.author = @first_author
+
+          @serializer = PostTestSerializer.new(@post)
+        end
+
+        def test_association_include
+          @adapter = ActiveModel::Serializer::Adapter::Attributes.new(@serializer)
+
+          assert_equal({
+            id: 1,
+            title: 'New Post',
+            comments: [{
+              id: 1,
+              body: 'A COMMENT',
+              author: { id: 2, name: 'Homer S.' }
+            }],
+            author: { id: 1, name: 'Marge S.' }
+            }, @adapter.serializable_hash)
+        end
+
+        def test_overwriting_association_include
+          @adapter = ActiveModel::Serializer::Adapter::Attributes.
+            new(@serializer, include: :author)
+
+          assert_equal({
+            id: 1,
+            title: 'New Post',
+            author: { id: 1, name: 'Marge S.' }
+            }, @adapter.serializable_hash)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
…sociation's option.

issue: #1205