### PR TITLE
Update Document/Readme for ‘attribute’ method in version 0.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Master
 - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/github/rails-api/active_model_serializers)
 - [Guides](https://github.com/rails-api/active_model_serializers/tree/master/docs)
 
+Older Versions
+
+- [0.9.x](#/tree/0-9-stable)
+- [0.8.x](#/tree/0-8-stable)
+
 # RELEASE CANDIDATE, PLEASE READ
 
 This is the master branch of AMS. It will become the `0.10.0` release when it's

--- a/README.md
+++ b/README.md
@@ -91,18 +91,8 @@ class PostSerializer < ActiveModel::Serializer
 end
 ```
 
-However, ```attribute``` method is deprecated in version ```0.9.x```. To alias your attribute in ```0.9.x```, use this instead
-
-```Ruby
-class PostSerializer < ActiveModel::Serializer
-  attributes :id, :body, :subject
-  has_many :comments
-
-  def subject
-    object.title
-  end
-end
-```
+If you are encountering `undefined method ‘attribute’ for ActiveModel::Serializer class` error, you might be using version `0.9.x`.
+Please see [How to Alias Attribute in 0.9.x](#/tree/0-9-stable#alias-attribute)
 
 In your controllers, when you use `render :json`, Rails will now first search
 for a serializer for the object and use it if available.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Master
 
 Older Versions
 
-- [0.9.x](#/tree/0-9-stable)
-- [0.8.x](#/tree/0-8-stable)
+- [0.9.x](#/blob/0-9-stable/README.md)
+- [0.8.x](#/blob/0-8-stable/README.md)
 
 # RELEASE CANDIDATE, PLEASE READ
 
@@ -95,9 +95,6 @@ class PostSerializer < ActiveModel::Serializer
   has_many :comments
 end
 ```
-
-If you are encountering `undefined method ‘attribute’ for ActiveModel::Serializer class` error, you might be using version `0.9.x`.
-Please see [How to Alias Attribute in 0.9.x](#/tree/0-9-stable#alias-attribute)
 
 In your controllers, when you use `render :json`, Rails will now first search
 for a serializer for the object and use it if available.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ class PostSerializer < ActiveModel::Serializer
 end
 ```
 
+However, ```attribute``` method is deprecated in version ```0.9.x```. To alias your attribute in ```0.9.x```, use this instead
+
+```Ruby
+class PostSerializer < ActiveModel::Serializer
+  attributes :id, :body, :subject
+  has_many :comments
+
+  def subject
+    object.title
+  end
+end
+```
+
 In your controllers, when you use `render :json`, Rails will now first search
 for a serializer for the object and use it if available.
 


### PR DESCRIPTION
- Because method `attribute` is deprecated in version 0.9.x and the current Readme is abandoning whoever using version 0.9.x.
- This will help people save time to seek for solutions when they encounter `undefined method ‘attribute’ for ActiveModel::Serializer class` error.