### PR TITLE
Namespaced serializers

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -53,7 +53,10 @@ module ActiveModel
       resource_namespace = klass.name.deconstantize
       serializer_class_name = "#{resource_class_name}Serializer"
 
-      chain.push("#{name}::#{serializer_class_name}") if self != ActiveModel::Serializer
+      if self != ActiveModel::Serializer
+        chain.push("#{name}::#{serializer_class_name}")
+        chain.push(*name.deconstantize.split('::').each_with_object([]) { |element, array| array.push((array.last ? array.last + '::' : '') + element) }.reverse.map { |k| k + "::#{serializer_class_name}" })
+      end
       chain.push("#{resource_namespace}::#{serializer_class_name}")
 
       chain

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -30,10 +30,14 @@ module ActiveModel
         module ResourceNamespace
           Post    = Class.new(::Model)
           Comment = Class.new(::Model)
+          Author  = Class.new(::Model)
 
           class PostSerializer < ActiveModel::Serializer
             class CommentSerializer < ActiveModel::Serializer
             end
+          end
+
+          class AuthorSerializer < ActiveModel::Serializer
           end
         end
 
@@ -127,6 +131,12 @@ module ActiveModel
             ResourceNamespace::PostSerializer.serializer_for(comment)
           end
           assert_equal nil, serializer
+        end
+
+        def test_serializer_for_namespace_nested_resource
+          author = ResourceNamespace::Author.new
+          serializer = ResourceNamespace::PostSerializer.serializer_for(author)
+          assert_equal(ResourceNamespace::AuthorSerializer, serializer)
         end
       end
     end


### PR DESCRIPTION
Adds support for finding serializers based on the "current" serializers
namespace to support things like serializer versioning. Without this you
have to be explicit in naming which serializer to use in all of your
serializer associations. That's OK usually (albeit annoying) but it
breaks polymorphism since you can't really specify the right serializer
ahead of time.

I came across a bunch of PRs such as #1225 that talk about different
versions of namespacing based on modules or controllers or whatever and
some of them even talk about supporting serializer namespaces but I have
been unable to find one that actually does this part of it. If there is
already work being done for this, feel free to ignore this PR but we
needed this for our current work.

This PR builds on top of the work done by @beauby in #1225 to add
support for namespaced serializer lookups. @beauby's work only allowed
for actual nesting of serializers withing a namespaced serializer (e.g.
for overrides) but did not actually walk up the tree to siblings or
serializers farther up the inheritance/namespace tree.

It simply modifies `Serializer#serializer_lookup_chain_for` to add all
of the possible levels of namespaces based on the current serializer.
With this patch for example if we have:
```ruby
class Public::V1::PostSerializer
  belongs_to :author
end

class Public::V1::AuthorSerializer
end
```
we will wind up with the following items in the lookup chain for an
author when serializing a Post with Public::V1::PostSerializer:
```ruby
['Public::V1::PostSerializer::AuthorSerializer',
'Public::V1::AuthorSerializer', 'Public::AuthorSerializer',
'::AuthorSerializer']
```