### PR TITLE
Fix bundler caching in travis & Appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tmp
 *.swp
 .ruby-version
 .ruby-gemset
+vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: ruby
 
 sudo: false
 
-cache:
-  bundler: true
-
 rvm:
   - 1.9.3
   - 2.0.0
@@ -12,8 +9,10 @@ rvm:
   - ruby-head
   - rbx-2
 
-install:
-  - bundle install --retry=3
+install: bundle install --path=vendor/bundle --retry=3 --jobs=3
+cache:
+  directories:
+    - vendor/bundle
 
 script:
   - env CAPTURE_STDERR=${CAPTURE_STDERR:-false} bundle exec rake ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ environment:
     - ruby_version: "21"
     - ruby_version: "21-x64"
 
+cache:
+  - vendor/bundle
+
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
@@ -18,7 +21,7 @@ install:
   - gem install bundler
   - bundler --version
   - bundle platform
-  - bundle install --retry=3
+  - bundle install --path=vendor/bundle --retry=3 --jobs=3
 
 test_script:
   - bundle exec rake ci


### PR DESCRIPTION
I noticed while working on #1336 that Grape is not caching Gems correctly: 

<img width="600" alt="screen shot 2015-11-24 at 00 39 31" src="https://cloud.githubusercontent.com/assets/101739/11354510/da757e38-9243-11e5-9f5c-0613132454be.png">

This PR is an attempt to fix this.