### PR TITLE
Enable use of an `object` key in serilaized forms

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -46,10 +46,8 @@ module ActiveModel
 
     with_options instance_writer: false, instance_reader: false do |serializer|
       class_attribute :_type, instance_reader: true
-      class_attribute :_attributes               # @api private : names of attribute methods, @see Serializer#attribute
-      self._attributes ||= []
-      class_attribute :_attributes_keys          # @api private : maps attribute value to explict key name, @see Serializer#attribute
-      self._attributes_keys ||= {}
+      class_attribute :_attributes_map           # @api private : maps attribute key names to names to names of implementing methods, @see Serializer#attribute
+      self._attributes_map ||= {}
       class_attribute :_links                    # @api private : links definitions, @see Serializer#link
       self._links ||= {}
 
@@ -69,12 +67,11 @@ module ActiveModel
       serializer.class_attribute :_cache_digest # @api private : Generated
     end
 
-    # Serializers inherit _attributes and _attributes_keys.
+    # Serializers inherit _attributes_map
     # Generates a unique digest for each serializer at load.
     def self.inherited(base)
       caller_line = caller.first
-      base._attributes = _attributes.dup
-      base._attributes_keys = _attributes_keys.dup
+      base._attributes_map = _attributes_map.dup
       base._links = _links.dup
       base._cache_digest = digest_caller_file(caller_line)
       super
@@ -112,14 +109,28 @@ module ActiveModel
     #     enr
     def self.attribute(attr, options = {})
       key = options.fetch(:key, attr)
-      _attributes_keys[attr] = { key: key } if key != attr
-      _attributes << key unless _attributes.include?(key)
+      _attributes_map[key] = attr
 
       ActiveModelSerializers.silence_warnings do
-        define_method key do
+        define_method attr do
           object.read_attribute_for_serialization(attr)
-        end unless method_defined?(key) || _fragmented.respond_to?(attr)
+        end unless method_defined?(attr) || _fragmented.respond_to?(attr)
       end
+    end
+
+    # @api private
+    # An accessor for the old _attributes internal API
+    def self._attributes
+      _attributes_map.keys
+    end
+
+    # @api private
+    # An accessor for the old _attributes_keys internal API
+    def self._attributes_keys
+      _attributes_map
+        .select { |key, impl| key != impl }
+        .map { |key, impl| [impl, { key: key }] }
+        .to_h
     end
 
     # @api private
@@ -247,12 +258,12 @@ module ActiveModel
     # Return the +attributes+ of +object+ as presented
     # by the serializer.
     def attributes(requested_attrs = nil)
-      self.class._attributes.each_with_object({}) do |name, hash|
-        next unless requested_attrs.nil? || requested_attrs.include?(name)
+      self.class._attributes_map.each_with_object({}) do |(key, attr), hash|
+        next unless requested_attrs.nil? || requested_attrs.include?(key)
         if self.class._fragmented
-          hash[name] = self.class._fragmented.public_send(name)
+          hash[key] = self.class._fragmented.public_send(attr)
         else
-          hash[name] = send(name)
+          hash[key] = send(attr)
         end
       end
     end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -129,8 +129,7 @@ module ActiveModel
     def self._attributes_keys
       _attributes_map
         .select { |key, impl| key != impl }
-        .map { |key, impl| [impl, { key: key }] }
-        .to_h
+        .each_with_object({}) { |(key, impl), acc| acc[impl] = { key: key } }
     end
 
     # @api private

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -43,6 +43,15 @@ module ActiveModel
         assert_equal({ blog: { id: 'AMS Hints' } }, adapter.serializable_hash)
       end
 
+      def test_object_attribute_override
+        serializer = Class.new(ActiveModel::Serializer) do
+          attribute :name, key: :object
+        end
+
+        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer.new(@blog))
+        assert_equal({ blog: { object: 'AMS Hints' } }, adapter.serializable_hash)
+      end
+
       def test_type_attribute
         attribute_serializer = Class.new(ActiveModel::Serializer) do
           attribute :id, key: :type


### PR DESCRIPTION
Because all serializers already implement an `object` method (part of the API expected when customizing a serializer), attempting to add a key to the serialized object with the name `object` would not output the expected value, and would instead dump a serialized version of the object under serialization.

This prevents a commonly used identifier from appearing in serialized output. As one real world example, the Stripe API includes an `object` key in each serialized object describing its type.

I introduced a change in the storage for the serializer configuration, and added methods to access it in the same way as before. Open question: I stored the key/attribute mapping in a Hash<Symbol => Symbol>; would the project be better served mapping to a nested hash to support additional configuration options in the future without changing the storage again?

This may have introduced a breaking change; before, methods were defined on the serializer based on the name of the key; now they will be defined based on the name of the underlying attribute. This behavior doesn't seem to be explicitly mentioned in docs or tested anywhere, though, so it may be a non-issue.