### PR TITLE
Add inline syntax for attributes and associations

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -69,7 +69,7 @@ module ActiveModel
       serializer.class_attribute :_cache_digest # @api private : Generated
     end
 
-    # Serializers inherit serialized_attributes and _attributes_keys.
+    # Serializers inherit serialized_attributes, _attributes_keys, and _reflections.
     # Generates a unique digest for each serializer at load.
     def self.inherited(base)
       caller_line = caller.first

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -184,6 +184,15 @@ module ActiveModel
       end
     end
 
+    def self._serializer_instance_method_defined?(name)
+      _serializer_instance_methods.include?(name)
+    end
+
+    def self._serializer_instance_methods
+      @_serializer_instance_methods ||= (public_instance_methods - Object.public_instance_methods).to_set
+    end
+    private_class_method :_serializer_instance_methods
+
     attr_accessor :object, :root, :scope
 
     # `scope_name` is set as :current_user by default in the controller.
@@ -209,7 +218,7 @@ module ActiveModel
     end
 
     def read_attribute_for_serialization(attr)
-      if _serializer_method_defined?(attr)
+      if self.class._serializer_instance_method_defined?(attr)
         send(attr)
       elsif self.class._fragmented
         self.class._fragmented.read_attribute_for_serialization(attr)
@@ -227,15 +236,5 @@ module ActiveModel
     protected
 
     attr_accessor :instance_options
-
-    private
-
-    def _serializer_instance_methods
-      @_serializer_instance_methods ||= (public_methods - Object.public_instance_methods).to_set
-    end
-
-    def _serializer_method_defined?(name)
-      _serializer_instance_methods.include?(name)
-    end
   end
 end

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -13,9 +13,8 @@ module ActiveModel
       DEFAULT_INCLUDE_TREE = ActiveModel::Serializer::IncludeTree.from_string('*')
 
       included do |base|
-        class << base
-          attr_accessor :_reflections
-        end
+        base.class_attribute :_reflections
+        base._reflections ||= []
 
         extend ActiveSupport::Autoload
         autoload :Association
@@ -28,8 +27,10 @@ module ActiveModel
       end
 
       module ClassMethods
+        # Serializers inherit _reflections.
         def inherited(base)
-          base._reflections = self._reflections.try(:dup) || []
+          super
+          base._reflections = _reflections.dup
         end
 
         # @param [Symbol] name of the association
@@ -39,8 +40,8 @@ module ActiveModel
         # @example
         #  has_many :comments, serializer: CommentSummarySerializer
         #
-        def has_many(name, options = {})
-          associate HasManyReflection.new(name, options)
+        def has_many(name, options = {}, &block)
+          associate(HasManyReflection.new(name, options), block)
         end
 
         # @param [Symbol] name of the association
@@ -50,8 +51,8 @@ module ActiveModel
         # @example
         #  belongs_to :author, serializer: AuthorSerializer
         #
-        def belongs_to(name, options = {})
-          associate BelongsToReflection.new(name, options)
+        def belongs_to(name, options = {}, &block)
+          associate(BelongsToReflection.new(name, options), block)
         end
 
         # @param [Symbol] name of the association
@@ -61,8 +62,8 @@ module ActiveModel
         # @example
         #  has_one :author, serializer: AuthorSerializer
         #
-        def has_one(name, options = {})
-          associate HasOneReflection.new(name, options)
+        def has_one(name, options = {}, &block)
+          associate(HasOneReflection.new(name, options), block)
         end
 
         private
@@ -73,11 +74,15 @@ module ActiveModel
         #
         # @api private
         #
-        def associate(reflection)
+        def associate(reflection, block)
           self._reflections = _reflections.dup
 
           define_method reflection.name do
-            object.send reflection.name
+            if block_given?
+              instance_eval(&block)
+            else
+              object.send reflection.name
+            end
           end unless method_defined?(reflection.name)
 
           self._reflections << reflection

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -40,8 +40,9 @@ module ActiveModel
 
         # Return the +attributes+ of +object+ as presented
         # by the serializer.
-        def attributes(requested_attrs = nil)
-          self.class._attribute_mappings.each_with_object({}) do |(key, attribute_mapping), hash|
+        def attributes(requested_attrs = nil, reload = false)
+          @attributes = nil if reload
+          @attributes ||= self.class._attribute_mappings.each_with_object({}) do |(key, attribute_mapping), hash|
             next unless requested_attrs.nil? || requested_attrs.include?(key)
             hash[key] = attribute_mapping.call(self)
           end
@@ -65,7 +66,6 @@ module ActiveModel
           end
         end
 
-        # TODO: remove the dynamic method definition
         # @example
         #   class AdminAuthorSerializer < ActiveModel::Serializer
         #     attributes :id, :recent_edits

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -3,10 +3,12 @@ module ActiveModel
     module Attributes
       class Attribute
         delegate :call, to: :reader
+
         attr_reader :name, :reader
+
         def initialize(name)
           @name = name
-          @reader = nil
+          @reader = :no_reader
         end
 
         def self.build(name, block)

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -1,6 +1,7 @@
 module ActiveModel
   class Serializer
     module Attributes
+      # @api private
       class Attribute
         delegate :call, to: :reader
 
@@ -19,12 +20,14 @@ module ActiveModel
           end
         end
       end
+      # @api private
       class AttributeReader < Attribute
         def initialize(name)
           super(name)
           @reader = ->(instance) { instance.read_attribute_for_serialization(name) }
         end
       end
+      # @api private
       class AttributeBlock < Attribute
         def initialize(name, block)
           super(name)

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -1,0 +1,107 @@
+module ActiveModel
+  class Serializer
+    module Attributes
+      class Attribute
+        delegate :call, to: :reader
+        attr_reader :name, :reader
+        def initialize(name)
+          @name = name
+          @reader = nil
+        end
+
+        def self.build(name, block)
+          if block
+            AttributeBlock.new(name, block)
+          else
+            AttributeReader.new(name)
+          end
+        end
+      end
+      class AttributeReader < Attribute
+        def initialize(name)
+          super(name)
+          @reader = ->(instance) { instance.read_attribute_for_serialization(name) }
+        end
+      end
+      class AttributeBlock < Attribute
+        def initialize(name, block)
+          super(name)
+          @reader = ->(instance) { instance.instance_eval(&block) }
+        end
+      end
+
+      extend ActiveSupport::Concern
+
+      included do
+        with_options instance_writer: false, instance_reader: false do |serializer|
+          serializer.class_attribute :_attribute_mappings # @api private : maps attribute key names to names to names of implementing methods, @see #attribute
+          self._attribute_mappings ||= {}
+        end
+
+        # Return the +attributes+ of +object+ as presented
+        # by the serializer.
+        def attributes(requested_attrs = nil)
+          self.class._attribute_mappings.each_with_object({}) do |(key, attribute_mapping), hash|
+            next unless requested_attrs.nil? || requested_attrs.include?(key)
+            hash[key] = attribute_mapping.call(self)
+          end
+        end
+      end
+
+      module ClassMethods
+        def inherited(base)
+          super
+          base._attribute_mappings = _attribute_mappings.dup
+        end
+
+        # @example
+        #   class AdminAuthorSerializer < ActiveModel::Serializer
+        #     attributes :id, :name, :recent_edits
+        def attributes(*attrs)
+          attrs = attrs.first if attrs.first.class == Array
+
+          attrs.each do |attr|
+            attribute(attr)
+          end
+        end
+
+        # TODO: remove the dynamic method definition
+        # @example
+        #   class AdminAuthorSerializer < ActiveModel::Serializer
+        #     attributes :id, :recent_edits
+        #     attribute :name, key: :title
+        #
+        #     attribute :full_name do
+        #       "#{object.first_name} #{object.last_name}"
+        #     end
+        #
+        #     def recent_edits
+        #       object.edits.last(5)
+        #     end
+        def attribute(attr, options = {}, &block)
+          key = options.fetch(:key, attr)
+          _attribute_mappings[key] = Attribute.build(attr, block)
+        end
+
+        # @api private
+        # names of attribute methods
+        # @see Serializer::attribute
+        def _attributes
+          _attribute_mappings.keys
+        end
+
+        # @api private
+        # maps attribute value to explict key name
+        # @see Serializer::attribute
+        # @see Adapter::FragmentCache#fragment_serializer
+        def _attributes_keys
+          _attribute_mappings
+            .each_with_object({}) do |(key, attribute_mapping), hash|
+              next if key == attribute_mapping.name
+              hash[attribute_mapping.name] = { key: key }
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -35,10 +35,12 @@ module ActiveModel
         @reader = self.class.build_reader(name, block)
       end
 
+      # @api private
       def value(instance)
         call(instance)
       end
 
+      # @api private
       def self.build_reader(name, block)
         if block
           ->(instance) { instance.read_attribute_for_serialization(name).instance_eval(&block) }

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -7,7 +7,15 @@ module ActiveModel
     #  class PostSerializer < ActiveModel::Serializer
     #     has_one :author, serializer: AuthorSerializer
     #     has_many :comments
+    #     has_many :comments, key: :last_comments do
+    #       last(1)
+    #     end
     #  end
+    #
+    #  Notice that the association block is evaluated in the context of the association.
+    #  Specifically, the association 'comments' is evaluated two different ways:
+    #  1) as 'comments' and named 'comments'.
+    #  2) as 'comments.last(1)' and named 'last_comments'.
     #
     #  PostSerializer._reflections #=>
     #    # [
@@ -33,7 +41,7 @@ module ActiveModel
 
       def self.build_reader(name, block)
         if block
-          ->(instance) { instance.instance_eval(&block) }
+          ->(instance) { instance.read_attribute_for_serialization(name).instance_eval(&block) }
         else
           ->(instance) { instance.read_attribute_for_serialization(name) }
         end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -116,7 +116,7 @@ RoleSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :name, :description, :slug
 
   def slug
-    "#{name}-#{id}"
+    "#{object.name}-#{object.id}"
   end
 
   belongs_to :author

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -128,8 +128,8 @@ module ActiveModel
 
       class InlineAssociationTestPostSerializer < ActiveModel::Serializer
         has_many :comments
-        has_many :last_comments do
-          object.comments.last(1)
+        has_many :comments, key: :last_comments do
+          last(1)
         end
       end
 

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -126,6 +126,35 @@ module ActiveModel
         assert expected_association_keys.include? :site
       end
 
+      class InlineAssociationTestPostSerializer < ActiveModel::Serializer
+        has_many :comments
+        has_many :last_comments do
+          object.comments.last(1)
+        end
+      end
+
+      def test_virtual_attribute_block
+        comment1 = ::ARModels::Comment.create!(contents: 'first comment')
+        comment2 = ::ARModels::Comment.create!(contents: 'last comment')
+        post = ::ARModels::Post.create!(
+          title: 'inline association test',
+          body: 'etc',
+          comments: [comment1, comment2]
+        )
+        actual = serializable(post, adapter: :attributes, serializer: InlineAssociationTestPostSerializer).as_json
+        expected = {
+          :comments =>           [
+            { :id => 1, :contents => 'first comment' },
+            { :id => 2, :contents => 'last comment' }
+          ],
+          :last_comments =>           [
+            { :id => 2, :contents => 'last comment' }
+          ]
+        }
+
+        assert_equal expected, actual
+      end
+
       class NamespacedResourcesTest < Minitest::Test
         class ResourceNamespace
           Post    = Class.new(::Model)

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -71,6 +71,21 @@ module ActiveModel
 
         assert_equal('custom', hash[:blog][:id])
       end
+
+      PostWithVirtualAttribute = Class.new(::Model)
+      class PostWithVirtualAttributeSerializer < ActiveModel::Serializer
+        attribute :name do
+          "#{object.first_name} #{object.last_name}"
+        end
+      end
+
+      def test_virtual_attribute_block
+        post = PostWithVirtualAttribute.new(first_name: 'Lucas', last_name: 'Hosseini')
+        hash = serializable(post).serializable_hash
+        expected = { name: 'Lucas Hosseini' }
+
+        assert_equal(expected, hash)
+      end
     end
   end
 end

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -43,6 +43,15 @@ module ActiveModel
         assert_equal({ blog: { id: 'AMS Hints' } }, adapter.serializable_hash)
       end
 
+      def test_object_attribute_override
+        serializer = Class.new(ActiveModel::Serializer) do
+          attribute :name, key: :object
+        end
+
+        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer.new(@blog))
+        assert_equal({ blog: { object: 'AMS Hints' } }, adapter.serializable_hash)
+      end
+
       def test_type_attribute
         attribute_serializer = Class.new(ActiveModel::Serializer) do
           attribute :id, key: :type


### PR DESCRIPTION
### Goals:

1. [x] Allow defining attributes so that they don't conflict with existing methods
1. [x] Allow customizing associations e.g. `has_many :comments do last(5) end`
  - [ ] compare to using [`virtual_value`](https://github.com/rails-api/active_model_serializers/pull/1356#discussion_r47146466) such as  `has_many :reviews, virtual_value: [{ id: 1 }, { id: 2 }]`
  and how association virtual values differ from attribute values.
1. [x] Remove dynamically defined methods on the serializer

Based on work in #1262, #1354

Ref: #1263, #1261, #1311

This PR is intended as a **starting point** for further work improving how
serializers map their resources attributes and associations

### Introduced, in support of this:

- [x] `Serializer#_attribute_mappings`
- [x] Extracted Serializer attribute methods to an Attributes module. I'd consider a class but this is a simpler first step and doesn't block changing it to an Attributes class than has many Attribute objects in the future

### [Possible regression](https://github.com/rails-api/active_model_serializers/pull/1356#discussion_r46381686): 

removed referring to object attributes in the serializer without calling them directly on object. (I didn't even know this was possible. We could add a respond_to_missing / method_missing for this)

```diff
   def slug
-    "#{name}-#{id}"
+    "#{object.name}-#{object.id}"
```
- [ ] Discuss

### Associations as 'includes'

It seems like we might benefit from thinking of associations, at least in the JSON API adapter, as includes, and only including them when requested (which is also similar to earlier naming and usage in the library, which I like).  This PR made me think of it, in part, because the difference between a reflection, an association, and associations, I think should be more clear (i.e. just an include).

- [ ] Discuss

### Blocks in serializer attribute definitions

I like this.  They remove the need for defining methods on the serializer, and make these attributes seem more like transformations.  I don't mind that they require a call to object, but would be okay eval'ing them in the context of the object, instead of the serializer.

- [x] `attribute :name do 'AMS' end`

### Blocks in serializer association definitions

Since there may be more options to pass in here, and to distinguish the context of an association block, which is on the association, from the attribute block, which is on the serializer, I'm tossing around the idea of having a `scope` option the receives a proc or lambda.  e.g. 

- [x]  `has_many :comments, ->{ last(5) }` (NOT `->{ comments.last(5) }`
  - [ ] consider `has_many :comments, scope: ->{ last(5) }`
