### PR TITLE
Match file paths with spaces in caller regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Features:
 Fixes:
 - [#1239](https://github.com/rails-api/active_model_serializers/pull/1239) Fix duplicates in JSON API compound documents (@beauby)
 - [#1214](https://github.com/rails-api/active_model_serializers/pull/1214) retrieve the key from the reflection options when building associations (@NullVoxPopuli, @hut8)
+- [#1358](https://github.com/rails-api/active_model_serializers/pull/1358) Handle serializer file paths with spaces (@rwstauner, @bf4)
 
 Misc:
 - [#1233](https://github.com/rails-api/active_model_serializers/pull/1233) Top-level meta and meta_key options no longer handled at serializer level (@beauby)

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -23,7 +23,7 @@ module ActiveModel
     #  c/git/emberjs/ember-crm-backend/app/serializers/lead_serializer.rb
     CALLER_FILE = /
       \A       # start of string
-      \S+      # one or more non-spaces
+      .+       # file path (one or more characters)
       (?=      # stop previous match when
         :\d+     # a colon is followed by one or more digits
         :in      # followed by a colon followed by in


### PR DESCRIPTION
When matching only `\S+` I get warnings like this on my ci server:

```
Cannot digest non-existent file: '/tmp/space char20151201-28026-1sux619/some_ruby.rb20151201-28026-g481xg:1:in `<top (required)>''.
Please set `::_cache_digest` of the serializer
if you'd like to cache it.
```

Matching the trailing space after `:\d+:in` wasn't strictly necessary, but seemed like it would help it to be more accurate.