### PR TITLE
support custom options for relections

### DIFF
--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -94,11 +94,13 @@ module ActiveModel
       private
 
       def serializer_options(subject, parent_serializer_options, reflection_options)
-        serializer = reflection_options.fetch(:serializer, nil)
+        serializer = reflection_options.delete(:serializer)
 
         serializer_options = parent_serializer_options.except(:serializer)
         serializer_options[:serializer] = serializer if serializer
         serializer_options[:serializer_context_class] = subject.class
+        serializer_options[:reflection_options] = reflection_options
+
         serializer_options
       end
     end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -116,6 +116,26 @@ module ActiveModel
         )
       end
 
+      def test_custom_options_for_reflections
+        inherited_klass = Class.new(ActiveModel::Serializer) do
+          belongs_to :author, serializer: AuthorSerializer, name: :author
+
+          has_many :comments, serializer: CommentSerializer, name: :comments
+        end
+
+        inherited_klass.new(@post).associations.each do |association|
+          serializer = association.serializer
+
+          if serializer.respond_to?(:each)
+            serializer.each do |sub_serializer|
+              assert_equal sub_serializer.send(:instance_options)[:reflection_options][:name], :comments
+            end
+          else
+            assert_equal serializer.send(:instance_options)[:reflection_options][:name], :author
+          end
+        end
+      end
+
       def test_associations_custom_keys
         serializer = PostWithCustomKeysSerializer.new(@post)
 


### PR DESCRIPTION
Support the DSL like below.
```ruby
class PostSerializer < ActiveModel::Serializer
  belongs_to :author, serializer: AuthorSerializer, custom_options: :author
  has_many :comments, serializer: CommentSerializer, custom_options: :comments
end
```

```ruby
class AuthorSerializer < ActiveModel::Serializer
  def custom_options
    instance_options[:reflection_options]  # => { custom_options: :author }
  end
end

class CommentSerializer < ActiveModel::Serializer
  def custom_options
    instance_options[:reflection_options]  # => { custom_options: :comments }
  end
end
```