### PR TITLE
Fix db state leaking across tests

### DIFF
--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -153,6 +153,9 @@ module ActiveModel
         }
 
         assert_equal expected, actual
+      ensure
+        ::ARModels::Post.delete_all
+        ::ARModels::Comment.delete_all
       end
 
       class NamespacedResourcesTest < Minitest::Test


### PR DESCRIPTION
See e.g. https://travis-ci.org/rails-api/active_model_serializers/builds/97975719

db records created specs weren't being cleared, so that
other specs calling `all` had unexpected records in them.

TODO: include a mixin to automatically clear records.  Maybe

```ruby
module TransactionalTests
   # Minitest.run_one_method isn't present in minitest 4
   if $minitest_version > 4 # rubocop:disable Style/GlobalVars
     def run_one_method(*)
       super
     ensure
       ActiveRecord::Base.descendants.each do |record_class|
         record_class.delete_all
       end
     end
  end
end
module SomeTest < Minitest::Test
  extend TransactionalTests
end
```

Perhaps consider replacing all usages of `Minitest::Test` with `ActiveSupport::Test`
for better compatibility.