### PR TITLE
Favor ActiveSupport::TestCase over Minitest::Test

### DIFF
--- a/test/active_model_serializers/logging_test.rb
+++ b/test/active_model_serializers/logging_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class LoggingTest < Minitest::Test
+    class LoggingTest < ActiveSupport::TestCase
       class TestLogger < ActiveSupport::Logger
         def initialize
           @file = StringIO.new

--- a/test/active_model_serializers/model_test.rb
+++ b/test/active_model_serializers/model_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ActiveModelSerializers::ModelTest < Minitest::Test
+class ActiveModelSerializers::ModelTest < ActiveSupport::TestCase
   include ActiveModel::Serializer::Lint::Tests
 
   def setup

--- a/test/active_model_serializers/serialization_context_test.rb
+++ b/test/active_model_serializers/serialization_context_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ActiveModelSerializers::SerializationContextTest < Minitest::Test
+class ActiveModelSerializers::SerializationContextTest < ActiveSupport::TestCase
   def create_context
     request = Minitest::Mock.new
     request.expect(:original_url, 'original_url')

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ActiveRecordTest < Minitest::Test
+class ActiveRecordTest < ActiveSupport::TestCase
   include ActiveModel::Serializer::Lint::Tests
 
   def setup

--- a/test/adapter/fragment_cache_test.rb
+++ b/test/adapter/fragment_cache_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     module Adapter
-      class FragmentCacheTest < Minitest::Test
+      class FragmentCacheTest < ActiveSupport::TestCase
         def setup
           super
           @spam            = Spam::UnrelatedLink.new(id: 'spam-id-1')

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class Json
-        class BelongsToTest < Minitest::Test
+        class BelongsToTest < ActiveSupport::TestCase
           def setup
             @post = Post.new(id: 42, title: 'New Post', body: 'Body')
             @anonymous_post = Post.new(id: 43, title: 'Hello!!', body: 'Hello, world!!')

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class Json
-        class Collection < Minitest::Test
+        class Collection < ActiveSupport::TestCase
           def setup
             @author = Author.new(id: 1, name: 'Steve K.')
             @first_post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!')

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class Json
-        class HasManyTestTest < Minitest::Test
+        class HasManyTestTest < ActiveSupport::TestCase
           def setup
             ActionController::Base.cache_store.clear
             @author = Author.new(id: 1, name: 'Steve K.')

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class BelongsToTest < Minitest::Test
+        class BelongsToTest < ActiveSupport::TestCase
           def setup
             @author = Author.new(id: 1, name: 'Steve K.')
             @author.bio = nil

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class CollectionTest < Minitest::Test
+        class CollectionTest < ActiveSupport::TestCase
           def setup
             @author = Author.new(id: 1, name: 'Steve K.')
             @author.bio = nil

--- a/test/adapter/json_api/fields_test.rb
+++ b/test/adapter/json_api/fields_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class FieldsTest < Minitest::Test
+        class FieldsTest < ActiveSupport::TestCase
           Post = Class.new(::Model)
           class PostSerializer < ActiveModel::Serializer
             type 'posts'

--- a/test/adapter/json_api/has_many_embed_ids_test.rb
+++ b/test/adapter/json_api/has_many_embed_ids_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class HasManyEmbedIdsTest < Minitest::Test
+        class HasManyEmbedIdsTest < ActiveSupport::TestCase
           def setup
             @author = Author.new(name: 'Steve K.')
             @author.bio = nil

--- a/test/adapter/json_api/has_many_explicit_serializer_test.rb
+++ b/test/adapter/json_api/has_many_explicit_serializer_test.rb
@@ -5,7 +5,7 @@ module ActiveModel
     module Adapter
       class JsonApi
         # Test 'has_many :assocs, serializer: AssocXSerializer'
-        class HasManyExplicitSerializerTest < Minitest::Test
+        class HasManyExplicitSerializerTest < ActiveSupport::TestCase
           def setup
             @post = Post.new(title: 'New Post', body: 'Body')
             @author = Author.new(name: 'Jane Blogger')

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class HasManyTest < Minitest::Test
+        class HasManyTest < ActiveSupport::TestCase
           def setup
             ActionController::Base.cache_store.clear
             @author = Author.new(id: 1, name: 'Steve K.')

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class HasOneTest < Minitest::Test
+        class HasOneTest < ActiveSupport::TestCase
           def setup
             @author = Author.new(id: 1, name: 'Steve K.')
             @bio = Bio.new(id: 43, content: 'AMS Contributor')

--- a/test/adapter/json_api/json_api_test.rb
+++ b/test/adapter/json_api/json_api_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     module Adapter
-      class JsonApiTest < Minitest::Test
+      class JsonApiTest < ActiveSupport::TestCase
         def setup
           ActionController::Base.cache_store.clear
           @author = Author.new(id: 1, name: 'Steve K.')

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -9,7 +9,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class LinkedTest < Minitest::Test
+        class LinkedTest < ActiveSupport::TestCase
           def setup
             @author1 = Author.new(id: 1, name: 'Steve K.')
             @author2 = Author.new(id: 2, name: 'Tenderlove')
@@ -283,7 +283,7 @@ module ActiveModel
           end
         end
 
-        class NoDuplicatesTest < Minitest::Test
+        class NoDuplicatesTest < ActiveSupport::TestCase
           Post = Class.new(::Model)
           Author = Class.new(::Model)
 

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class LinksTest < Minitest::Test
+        class LinksTest < ActiveSupport::TestCase
           LinkAuthor = Class.new(::Model)
           class LinkAuthorSerializer < ActiveModel::Serializer
             link :self do

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -8,7 +8,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class PaginationLinksTest < Minitest::Test
+        class PaginationLinksTest < ActiveSupport::TestCase
           URI = 'http://example.com'
 
           def setup

--- a/test/adapter/json_api/resource_type_config_test.rb
+++ b/test/adapter/json_api/resource_type_config_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class ResourceTypeConfigTest < Minitest::Test
+        class ResourceTypeConfigTest < ActiveSupport::TestCase
           class ProfileTypeSerializer < ActiveModel::Serializer
             attributes :name
             type 'profile'

--- a/test/adapter/json_api/toplevel_jsonapi_test.rb
+++ b/test/adapter/json_api/toplevel_jsonapi_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class TopLevelJsonApiTest < Minitest::Test
+        class TopLevelJsonApiTest < ActiveSupport::TestCase
           def setup
             @author = Author.new(id: 1, name: 'Steve K.')
             @author.bio = nil

--- a/test/adapter/json_test.rb
+++ b/test/adapter/json_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     module Adapter
-      class JsonTest < Minitest::Test
+      class JsonTest < ActiveSupport::TestCase
         def setup
           ActionController::Base.cache_store.clear
           @author = Author.new(id: 1, name: 'Steve K.')

--- a/test/adapter/null_test.rb
+++ b/test/adapter/null_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     module Adapter
-      class NullTest < Minitest::Test
+      class NullTest < ActiveSupport::TestCase
         def setup
           profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
           serializer = ProfileSerializer.new(profile)

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class AdapterTest < Minitest::Test
+    class AdapterTest < ActiveSupport::TestCase
       def setup
         profile = Profile.new
         @serializer = ProfileSerializer.new(profile)

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -21,7 +21,7 @@ module ActiveModel
         end
       end
     else
-      class ArraySerializerTest < Minitest::Test
+      class ArraySerializerTest < ActiveSupport::TestCase
         extend ActiveSupport::Testing::Stream
         def test_json_key_with_root_warns_when_using_array_serializer
           stderr = (capture(:stderr) do

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class CollectionSerializerTest < Minitest::Test
+    class CollectionSerializerTest < ActiveSupport::TestCase
       def setup
         @comment = Comment.new
         @post = Post.new

--- a/test/grape_test.rb
+++ b/test/grape_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'grape'
 require 'grape/active_model_serializers'
 
-class ActiveModelSerializers::GrapeTest < Minitest::Test
+class ActiveModelSerializers::GrapeTest < ActiveSupport::TestCase
   include Rack::Test::Methods
   module Models
     def self.model1

--- a/test/include_tree/from_include_args_test.rb
+++ b/test/include_tree/from_include_args_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class IncludeTree
-      class FromStringTest < Minitest::Test
+      class FromStringTest < ActiveSupport::TestCase
         def test_simple_array
           input = [:comments, :author]
           actual = ActiveModel::Serializer::IncludeTree.from_include_args(input)

--- a/test/include_tree/from_string_test.rb
+++ b/test/include_tree/from_string_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class IncludeTree
-      class FromStringTest < Minitest::Test
+      class FromStringTest < ActiveSupport::TestCase
         def test_single_string
           input = 'author'
           actual = ActiveModel::Serializer::IncludeTree.from_string(input)

--- a/test/lint_test.rb
+++ b/test/lint_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class LintTest < Minitest::Test
+    class LintTest < ActiveSupport::TestCase
       include ActiveModel::Serializer::Lint::Tests
 
       class CompliantResource

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ActiveModelSerializers::LoggerTest < Minitest::Test
+class ActiveModelSerializers::LoggerTest < ActiveSupport::TestCase
   def test_logger_is_set_to_action_controller_logger_when_initializer_runs
     assert_equal $action_controller_logger, ActionController::Base.logger # rubocop:disable Style/GlobalVars
   end

--- a/test/poro_test.rb
+++ b/test/poro_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PoroTest < Minitest::Test
+class PoroTest < ActiveSupport::TestCase
   include ActiveModel::Serializer::Lint::Tests
 
   def setup

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module ActiveModel
-  class SerializableResourceTest < Minitest::Test
+  class SerializableResourceTest < ActiveSupport::TestCase
     def setup
       @resource = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
       @serializer = ProfileSerializer.new(@resource)

--- a/test/serializers/adapter_for_test.rb
+++ b/test/serializers/adapter_for_test.rb
@@ -1,6 +1,6 @@
 module ActiveModel
   class Serializer
-    class AdapterForTest < Minitest::Test
+    class AdapterForTest < ActiveSupport::TestCase
       UnknownAdapterError = ::ActiveModel::Serializer::Adapter::UnknownAdapterError
 
       def setup

--- a/test/serializers/association_macros_test.rb
+++ b/test/serializers/association_macros_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class AssociationMacrosTest < Minitest::Test
+    class AssociationMacrosTest < ActiveSupport::TestCase
       AuthorSummarySerializer = Class.new
       class AssociationsTestSerializer < Serializer
         belongs_to :author, serializer: AuthorSummarySerializer

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class AssociationsTest < Minitest::Test
+    class AssociationsTest < ActiveSupport::TestCase
       def setup
         @author = Author.new(name: 'Steve K.')
         @author.bio = nil
@@ -158,7 +158,7 @@ module ActiveModel
         ::ARModels::Comment.delete_all
       end
 
-      class NamespacedResourcesTest < Minitest::Test
+      class NamespacedResourcesTest < ActiveSupport::TestCase
         class ResourceNamespace
           Post    = Class.new(::Model)
           Comment = Class.new(::Model)
@@ -200,7 +200,7 @@ module ActiveModel
         end
       end
 
-      class NestedSerializersTest < Minitest::Test
+      class NestedSerializersTest < ActiveSupport::TestCase
         Post    = Class.new(::Model)
         Comment = Class.new(::Model)
         Author  = Class.new(::Model)

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class AttributeTest < Minitest::Test
+    class AttributeTest < ActiveSupport::TestCase
       def setup
         @blog = Blog.new({ id: 1, name: 'AMS Hints', type: 'stuff' })
         @blog_serializer = AlternateBlogSerializer.new(@blog)

--- a/test/serializers/attributes_test.rb
+++ b/test/serializers/attributes_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class AttributesTest < Minitest::Test
+    class AttributesTest < ActiveSupport::TestCase
       def setup
         @profile = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
         @profile_serializer = ProfileSerializer.new(@profile)

--- a/test/serializers/cache_test.rb
+++ b/test/serializers/cache_test.rb
@@ -3,7 +3,7 @@ require 'tmpdir'
 require 'tempfile'
 module ActiveModel
   class Serializer
-    class CacheTest < Minitest::Test
+    class CacheTest < ActiveSupport::TestCase
       include ActiveSupport::Testing::Stream
 
       def setup

--- a/test/serializers/configuration_test.rb
+++ b/test/serializers/configuration_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class ConfigurationTest < Minitest::Test
+    class ConfigurationTest < ActiveSupport::TestCase
       def test_collection_serializer
         assert_equal ActiveModel::Serializer::CollectionSerializer, ActiveModelSerializers.config.collection_serializer
       end

--- a/test/serializers/fieldset_test.rb
+++ b/test/serializers/fieldset_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class FieldsetTest < Minitest::Test
+    class FieldsetTest < ActiveSupport::TestCase
       def test_fieldset_with_hash
         fieldset = ActiveModel::Serializer::Fieldset.new('post' => %w(id title), 'comment' => ['body'])
         expected = { :post => [:id, :title], :comment => [:body] }

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class MetaTest < Minitest::Test
+    class MetaTest < ActiveSupport::TestCase
       def setup
         @blog = Blog.new(id: 1,
                          name: 'AMS Hints',

--- a/test/serializers/options_test.rb
+++ b/test/serializers/options_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class OptionsTest < Minitest::Test
+    class OptionsTest < ActiveSupport::TestCase
       def setup
         @profile = Profile.new(name: 'Name 1', description: 'Description 1')
       end

--- a/test/serializers/root_test.rb
+++ b/test/serializers/root_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class RootTest < Minitest::Test
+    class RootTest < ActiveSupport::TestCase
       def setup
         @virtual_value = VirtualValue.new(id: 1)
       end

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class SerializerForTest < Minitest::Test
-      class CollectionSerializerTest < Minitest::Test
+    class SerializerForTest < ActiveSupport::TestCase
+      class CollectionSerializerTest < ActiveSupport::TestCase
         def setup
           @array = [1, 2, 3]
           @previous_collection_serializer = ActiveModelSerializers.config.collection_serializer
@@ -26,7 +26,7 @@ module ActiveModel
         end
       end
 
-      class SerializerTest < Minitest::Test
+      class SerializerTest < ActiveSupport::TestCase
         module ResourceNamespace
           Post    = Class.new(::Model)
           Comment = Class.new(::Model)


### PR DESCRIPTION
- Better minitest 4/5 support
- Better DSL
- Already available with no changes
- Consistent interface

