### PR TITLE
Drop JRuby 1.9 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
   include:
   - rvm: 2.2
     env: CAPTURE_STDERR=true
-  - rvm: jruby-19mode
-    env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false -Xcli.debug=true --debug'
   allow_failures:
     - rvm: ruby-head
   fast_finish: true


### PR DESCRIPTION
Hi guys,

I think we can remove this from .travis since we are dropping 1.9.3 support https://github.com/rails-api/active_model_serializers/pull/1360.

This [is causing the build](https://travis-ci.org/rails-api/active_model_serializers/jobs/98412347) from my other PR https://github.com/rails-api/active_model_serializers/pull/1270 be broken :cry: 