### PR TITLE
Add JRuby 9000 to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
   include:
   - rvm: 2.2
     env: CAPTURE_STDERR=true
+  - rvm: jruby-9000
+    env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false -Xcli.debug=true --debug'
   allow_failures:
     - rvm: ruby-head
   fast_finish: true


### PR DESCRIPTION
Follows removing JRuby-19mode from the matrix
(as part of dropping Ruby < 2.0

ref: https://github.com/rails-api/active_model_serializers/pull/1391