### PR TITLE
Remove ActiveModelSerializers.silence_warnings dead code

### DIFF
--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -13,39 +13,6 @@ module ActiveModelSerializers
   autoload :Model
   autoload :Callbacks
   autoload :Logging
-
-  module_function
-
-  # @note
-  #   ```ruby
-  #   private
-  #
-  #   attr_reader :resource, :adapter_opts, :serializer_opts
-  #   ```
-  #
-  #   Will generate a warning, though it shouldn't.
-  #   There's a bug in Ruby for this: https://bugs.ruby-lang.org/issues/10967
-  #
-  #   We can use +ActiveModelSerializers.silence_warnings+ as a
-  #   'safety valve' for unfixable or not-worth-fixing warnings,
-  #   and keep our app warning-free.
-  #
-  #   ```ruby
-  #   private
-  #
-  #   ActiveModelSerializers.silence_warnings do
-  #     attr_reader :resource, :adapter_opts, :serializer_opts
-  #   end
-  #   ```
-  #
-  #   or, as specific stopgap, define the attrs in the protected scope.
-  def silence_warnings
-    verbose = $VERBOSE
-    $VERBOSE = nil
-    yield
-  ensure
-    $VERBOSE = verbose
-  end
 end
 
 require 'active_model/serializer'


### PR DESCRIPTION
The ActiveModelSerializers.silence_warnings was used to avoid warnings on the
Ruby interpreter when define a private attr_acessor. This method is not used in
any part of the code and the recommend way to handle this case is to use
protected instead the silence_warnings [1].

This patch remove the method from the project, this way we avoid people using
this by mistake.

I hope you guys enjoy :smile: 

[1]: https://bugs.ruby-lang.org/issues/10967