### PR TITLE
Drop Ruby 1.9.3 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ skip_tags: true
 
 environment:
   matrix:
-    - ruby_version: "193"
-    - ruby_version: "193-x64"
     - ruby_version: "200"
     - ruby_version: "200-x64"
     - ruby_version: "21"


### PR DESCRIPTION
Hi guys,

I think we can remove this from AppVeyor since we are dropping 1.9.3 support #1360.

This is causing the build from my other PR #1270 be broken :disappointed: 