### PR TITLE
ActiveModel::Serializer::type now accepts a block

### DIFF
--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -111,6 +111,10 @@ e.g.
 class UserProfileSerializer < ActiveModel::Serializer
   type 'profile'
 end
+
+class UserSerializer < ActiveModel::Serializer
+  type { object.type }
+end
 ```
 
 #### ::link

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -78,8 +78,9 @@ module ActiveModel
     # @example
     #   class AdminAuthorSerializer < ActiveModel::Serializer
     #     type 'authors'
-    def self.type(type)
-      self._type = type
+    #     type { object.type }
+    def self.type(type = nil, &block)
+      self._type = block || type
     end
 
     def self.link(name, value = nil, &block)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -113,11 +113,19 @@ module ActiveModel
         end
 
         def resource_identifier_type_for(serializer)
-          return serializer._type if serializer._type
-          if ActiveModelSerializers.config.jsonapi_resource_type == :singular
-            serializer.object.class.model_name.singular
+          value_or_block = serializer._type
+          if value_or_block
+            if value_or_block.respond_to?(:call)
+              serializer.instance_eval(&value_or_block)
+            else
+              value_or_block
+            end
           else
-            serializer.object.class.model_name.plural
+            if ActiveModelSerializers.config.jsonapi_resource_type == :singular
+              serializer.object.class.model_name.singular
+            else
+              serializer.object.class.model_name.plural
+            end
           end
         end
 

--- a/test/adapter/json_api/resource_type_config_test.rb
+++ b/test/adapter/json_api/resource_type_config_test.rb
@@ -10,12 +10,24 @@ module ActiveModel
             type 'profile'
           end
 
+          class SpecialProfileTypeSerializer < ProfileTypeSerializer
+            type 'special_profile'
+          end
+
+          class PostTypeSerializer < ActiveModel::Serializer
+            type { object.type }
+          end
+
+          class SpecialPostTypeSerializer < PostTypeSerializer
+            type { 'special_post' }
+          end
+
           def setup
             @author = Author.new(id: 1, name: 'Steve K.')
             @author.bio = nil
             @author.roles = []
             @blog = Blog.new(id: 23, name: 'AMS Blog')
-            @post = Post.new(id: 42, title: 'New Post', body: 'Body')
+            @post = Post.new(id: 42, title: 'New Post', body: 'Body', type: 'block_post')
             @anonymous_post = Post.new(id: 43, title: 'Hello!!', body: 'Hello, world!!')
             @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
             @post.comments = [@comment]
@@ -32,6 +44,36 @@ module ActiveModel
             @author.posts = []
           end
 
+          def test_config_plural
+            with_jsonapi_resource_type :plural do
+              assert_type('comments', @comment)
+            end
+          end
+
+          def test_config_singular
+            with_jsonapi_resource_type :singular do
+              assert_type('comment', @comment)
+            end
+          end
+
+          def test_explicit_type_value
+            assert_type('profile', @author, serializer: ProfileTypeSerializer)
+          end
+
+          def test_explicit_type_value_for_subclass
+            assert_type('special_profile', @author, serializer: SpecialProfileTypeSerializer)
+          end
+
+          def test_explicit_type_block
+            assert_type('block_post', @post, serializer: PostTypeSerializer)
+          end
+
+          def test_explicit_type_block_for_subclass
+            assert_type('special_post', @post, serializer: SpecialPostTypeSerializer)
+          end
+
+          private
+
           def with_jsonapi_resource_type type
             old_type = ActiveModelSerializers.config.jsonapi_resource_type
             ActiveModelSerializers.config.jsonapi_resource_type = type
@@ -40,26 +82,11 @@ module ActiveModel
             ActiveModelSerializers.config.jsonapi_resource_type = old_type
           end
 
-          def test_config_plural
-            with_jsonapi_resource_type :plural do
-              hash = serializable(@comment, adapter: :json_api).serializable_hash
-              assert_equal('comments', hash[:data][:type])
-            end
+          def assert_type(type, object, options = {})
+            options.merge!(adapter: :json_api)
+            hash = serializable(object, options).serializable_hash
+            assert_equal(type, hash.fetch(:data).fetch(:type))
           end
-
-          def test_config_singular
-            with_jsonapi_resource_type :singular do
-              hash = serializable(@comment, adapter: :json_api).serializable_hash
-              assert_equal('comment', hash[:data][:type])
-            end
-          end
-
-          def test_explicit_type_value
-            hash = serializable(@author, serializer: ProfileTypeSerializer, adapter: :json_api).serializable_hash
-            assert_equal('profile', hash.fetch(:data).fetch(:type))
-          end
-
-          private
 
           def serializable(resource, options = {})
             ActiveModel::SerializableResource.new(resource, options)


### PR DESCRIPTION
A block passed to the type method will be instance_eval'd to the serializer.
This allows us to avoid overriding the #_type method to have a dynamic type.