### PR TITLE
Conditional attributes/associations (if/unless)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Breaking changes:
 
 Features:
 
+- [#1403](https://github.com/rails-api/active_model_serializers/pull/1403) Add support for if/unless on attributes/associations (@beauby)
 - [#1248](https://github.com/rails-api/active_model_serializers/pull/1248) Experimental: Add support for JSON API deserialization (@beauby)
 - [#1378](https://github.com/rails-api/active_model_serializers/pull/1378) Change association blocks
   to be evaluated in *serializer* scope, rather than *association* scope. (@bf4)

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -88,6 +88,7 @@ module ActiveModel
 
         Enumerator.new do |y|
           self.class._reflections.each do |reflection|
+            next unless reflection.included?(self)
             key = reflection.options.fetch(:key, reflection.name)
             next unless include_tree.key?(key)
             y.yield reflection.build_association(self, instance_options)

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -88,7 +88,7 @@ module ActiveModel
 
         Enumerator.new do |y|
           self.class._reflections.each do |reflection|
-            next unless reflection.included?(self)
+            next if reflection.excluded?(self)
             key = reflection.options.fetch(:key, reflection.name)
             next unless include_tree.key?(key)
             y.yield reflection.build_association(self, instance_options)

--- a/lib/active_model/serializer/attribute.rb
+++ b/lib/active_model/serializer/attribute.rb
@@ -1,12 +1,39 @@
 module ActiveModel
   class Serializer
-    Attribute = Struct.new(:name, :block) do
+    Attribute = Struct.new(:name, :options, :block) do
       def value(serializer)
         if block
           serializer.instance_eval(&block)
         else
           serializer.read_attribute_for_serialization(name)
         end
+      end
+
+      def included?(serializer)
+        case condition
+        when :if
+          serializer.public_send(condition)
+        when :unless
+          !serializer.public_send(condition)
+        else
+          true
+        end
+      end
+
+      private
+
+      def condition_type
+        if options.key?(:if)
+          :if
+        elsif options.key?(:unless)
+          :unless
+        else
+          :none
+        end
+      end
+
+      def condition
+        options[condition_type]
       end
     end
   end

--- a/lib/active_model/serializer/attribute.rb
+++ b/lib/active_model/serializer/attribute.rb
@@ -1,40 +1,25 @@
+require 'active_model/serializer/field'
+
 module ActiveModel
   class Serializer
-    Attribute = Struct.new(:name, :options, :block) do
-      def value(serializer)
-        if block
-          serializer.instance_eval(&block)
-        else
-          serializer.read_attribute_for_serialization(name)
-        end
-      end
-
-      def included?(serializer)
-        case condition
-        when :if
-          serializer.public_send(condition)
-        when :unless
-          !serializer.public_send(condition)
-        else
-          true
-        end
-      end
-
-      private
-
-      def condition_type
-        if options.key?(:if)
-          :if
-        elsif options.key?(:unless)
-          :unless
-        else
-          :none
-        end
-      end
-
-      def condition
-        options[condition_type]
-      end
+    # Holds all the meta-data about an attribute as it was specified in the
+    # ActiveModel::Serializer class.
+    #
+    # @example
+    #   class PostSerializer < ActiveModel::Serializer
+    #     attribute :content
+    #     attribute :name, key: :title
+    #     attribute :email, key: :author_email, if: :user_logged_in?
+    #     attribute :preview do
+    #       truncate(object.content)
+    #     end
+    #
+    #     def user_logged_in?
+    #       current_user.logged_in?
+    #     end
+    #   end
+    #
+    class Attribute < Field
     end
   end
 end

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -17,6 +17,7 @@ module ActiveModel
         def attributes(requested_attrs = nil, reload = false)
           @attributes = nil if reload
           @attributes ||= self.class._attributes_data.each_with_object({}) do |(key, attr), hash|
+            next unless attr.included?(self)
             next unless requested_attrs.nil? || requested_attrs.include?(key)
             hash[key] = attr.value(self)
           end
@@ -54,7 +55,7 @@ module ActiveModel
         #     end
         def attribute(attr, options = {}, &block)
           key = options.fetch(:key, attr)
-          _attributes_data[key] = Attribute.new(attr, block)
+          _attributes_data[key] = Attribute.new(attr, options, block)
         end
 
         # @api private

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -17,7 +17,7 @@ module ActiveModel
         def attributes(requested_attrs = nil, reload = false)
           @attributes = nil if reload
           @attributes ||= self.class._attributes_data.each_with_object({}) do |(key, attr), hash|
-            next unless attr.included?(self)
+            next if attr.excluded?(self)
             next unless requested_attrs.nil? || requested_attrs.include?(key)
             hash[key] = attr.value(self)
           end

--- a/lib/active_model/serializer/field.rb
+++ b/lib/active_model/serializer/field.rb
@@ -1,0 +1,55 @@
+module ActiveModel
+  class Serializer
+    # Holds all the meta-data about a field (i.e. attribute or association) as it was
+    # specified in the ActiveModel::Serializer class.
+    # Notice that the field block is evaluated in the context of the serializer.
+    Field = Struct.new(:name, :options, :block) do
+      # Compute the actual value of a field for a given serializer instance.
+      # @param [Serializer] The serializer instance for which the value is computed.
+      # @return [Object] value
+      #
+      # @api private
+      #
+      def value(serializer)
+        if block
+          serializer.instance_eval(&block)
+        else
+          serializer.read_attribute_for_serialization(name)
+        end
+      end
+
+      # Decide whether the field should be serialized by the given serializer instance.
+      # @param [Serializer] The serializer instance
+      # @return [Bool]
+      #
+      # @api private
+      #
+      def included?(serializer)
+        case condition
+        when :if
+          serializer.public_send(condition)
+        when :unless
+          !serializer.public_send(condition)
+        else
+          true
+        end
+      end
+
+      private
+
+      def condition_type
+        if options.key?(:if)
+          :if
+        elsif options.key?(:unless)
+          :unless
+        else
+          :none
+        end
+      end
+
+      def condition
+        options[condition_type]
+      end
+    end
+  end
+end

--- a/lib/active_model/serializer/field.rb
+++ b/lib/active_model/serializer/field.rb
@@ -25,7 +25,7 @@ module ActiveModel
       # @api private
       #
       def included?(serializer)
-        case condition
+        case condition_type
         when :if
           serializer.public_send(condition)
         when :unless
@@ -38,13 +38,14 @@ module ActiveModel
       private
 
       def condition_type
-        if options.key?(:if)
-          :if
-        elsif options.key?(:unless)
-          :unless
-        else
-          :none
-        end
+        @condition_type ||=
+          if options.key?(:if)
+            :if
+          elsif options.key?(:unless)
+            :unless
+          else
+            :none
+          end
       end
 
       def condition

--- a/lib/active_model/serializer/field.rb
+++ b/lib/active_model/serializer/field.rb
@@ -24,14 +24,14 @@ module ActiveModel
       #
       # @api private
       #
-      def included?(serializer)
+      def excluded?(serializer)
         case condition_type
         when :if
-          serializer.public_send(condition)
-        when :unless
           !serializer.public_send(condition)
+        when :unless
+          serializer.public_send(condition)
         else
-          true
+          false
         end
       end
 

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -35,6 +35,18 @@ module ActiveModel
         end
       end
 
+      # @api private
+      def included?(serializer)
+        case condition_type
+        when :if
+          serializer.public_send(condition)
+        when :unless
+          !serializer.public_send(condition)
+        else
+          true
+        end
+      end
+
       # Build association. This method is used internally to
       # build serializer's association by its reflection.
       #
@@ -78,6 +90,20 @@ module ActiveModel
       end
 
       private
+
+      def condition_type
+        if options.key?(:if)
+          :if
+        elsif options.key?(:unless)
+          :unless
+        else
+          :none
+        end
+      end
+
+      def condition
+        options[condition_type]
+      end
 
       def serializer_options(subject, parent_serializer_options, reflection_options)
         serializer = reflection_options.fetch(:serializer, nil)

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -238,6 +238,29 @@ module ActiveModel
             end
           end
         end
+
+        def test_conditional_associations
+          serializer = Class.new(ActiveModel::Serializer) do
+            belongs_to :if_assoc_included, if: :true
+            belongs_to :if_assoc_excluded, if: :false
+            belongs_to :unless_assoc_included, unless: :false
+            belongs_to :unless_assoc_excluded, unless: :true
+
+            def true
+              true
+            end
+
+            def false
+              false
+            end
+          end
+
+          model = ::Model.new
+          hash = serializable(model, serializer: serializer).serializable_hash
+          expected = { if_assoc_included: nil, unless_assoc_included: nil }
+
+          assert_equal(expected, hash)
+        end
       end
     end
   end

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     class AttributeTest < ActiveSupport::TestCase
       def setup
-        @blog = Blog.new({ id: 1, name: 'AMS Hints', type: 'stuff' })
+        @blog = Blog.new(id: 1, name: 'AMS Hints', type: 'stuff')
         @blog_serializer = AlternateBlogSerializer.new(@blog)
       end
 
@@ -92,6 +92,29 @@ module ActiveModel
         post = PostWithVirtualAttribute.new(first_name: 'Lucas', last_name: 'Hosseini')
         hash = serializable(post).serializable_hash
         expected = { name: 'Lucas Hosseini' }
+
+        assert_equal(expected, hash)
+      end
+
+      def test_conditional_attributes
+        serializer = Class.new(ActiveModel::Serializer) do
+          attribute :if_attribute_included, if: :true
+          attribute :if_attribute_excluded, if: :false
+          attribute :unless_attribute_included, unless: :false
+          attribute :unless_attribute_excluded, unless: :true
+
+          def true
+            true
+          end
+
+          def false
+            false
+          end
+        end
+
+        model = ::Model.new
+        hash = serializable(model, serializer: serializer).serializable_hash
+        expected = { if_attribute_included: nil, unless_attribute_included: nil }
 
         assert_equal(expected, hash)
       end


### PR DESCRIPTION
My take at conditional attributes/associations. Previous work has been done in this direction (#1266), but I figured it was easily expressed on top of #1370. 
This PR adds support for `if/unless` options to attribute/association definitions in serializers. Those options take a symbol of a method name on the serializer.

Example:
```ruby
class UserSerializer < ActiveModel::Serializer
  attributes :name, :description, :date_of_birth
  attribute :private_data, if: :is_current_user?

  def is_current_user?
    object.id == current_user.id
  end
end
```

Note: if this gets traction, I'll add tests.

Ref #1245, #1266, #1058, #922, #1141