### PR TITLE
fix broken link

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ and, if there is no serializer, primitives.
 The **`ActiveModel::Adapter`** describes the structure of the JSON document generated from a
 serializer. For example, the `Attributes` example represents each serializer as its
 unmodified attributes.  The `JsonApi` adapter represents the serializer as a [JSON
-API](jsonapi.org/) document.
+API](http://jsonapi.org/) document.
 
 The **`ActiveModel::SerializableResource`** acts to coordinate the serializer(s) and adapter
 to an object that responds to `to_json`, and `as_json`.  It is used in the controller to


### PR DESCRIPTION
previously if you clicked it while reading the MD doc on github it would send you to https://github.com/rails-api/active_model_serializers/blob/master/docs/jsonapi.org, which obviously doesn't exist. Adding 'http://' fixes it