### PR TITLE
Don't pluralize the CollectionSerializer#root for #json_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Breaking changes:
         Adapter functions.
     * named `Base` because it's a Rails-ism.
     * It helps to isolate and highlight what the Adapter interface actually is.
+- [#1418](https://github.com/rails-api/active_model_serializers/pull/1418)
+  serialized collections now use the root option as is; now, only the
+  root derived from the serializer or object is always pluralized.
 
 Features:
 

--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -23,8 +23,7 @@ module ActiveModel
       end
 
       def json_key
-        key = root || serializers.first.try(:json_key) || object.try(:name).try(:underscore)
-        key.try(:pluralize)
+        root || derived_root
       end
 
       def paginated?
@@ -36,6 +35,13 @@ module ActiveModel
       protected
 
       attr_reader :serializers
+
+      private
+
+      def derived_root
+        key = serializers.first.try(:json_key) || object.try(:name).try(:underscore)
+        key.try(:pluralize)
+      end
     end
   end
 end

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -171,7 +171,7 @@ module ActionController
         with_adapter :json do
           get :render_array_using_custom_root
         end
-        expected = { custom_roots: [{ name: 'Name 1', description: 'Description 1' }] }
+        expected = { custom_root: [{ name: 'Name 1', description: 'Description 1' }] }
         assert_equal 'application/json', @response.content_type
         assert_equal expected.to_json, @response.body
       end
@@ -181,7 +181,7 @@ module ActionController
           get :render_array_that_is_empty_using_custom_root
         end
 
-        expected = { custom_roots: [] }
+        expected = { custom_root: [] }
         assert_equal 'application/json', @response.content_type
         assert_equal expected.to_json, @response.body
       end

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -62,8 +62,9 @@ module ActiveModel
         assert_equal expected, @serializer.root
       end
 
-      def test_json_key
-        assert_equal 'comments', @serializer.json_key
+      def test_json_key_with_resource_with_serializer
+        singular_key = @serializer.send(:serializers).first.json_key
+        assert_equal singular_key.pluralize, @serializer.json_key
       end
 
       def test_json_key_with_resource_with_name_and_no_serializers
@@ -84,13 +85,15 @@ module ActiveModel
       end
 
       def test_json_key_with_root
-        serializer = collection_serializer.new(@resource, root: 'custom_root')
-        assert_equal 'custom_roots', serializer.json_key
+        expected = 'custom_root'
+        serializer = collection_serializer.new(@resource, root: expected)
+        assert_equal expected, serializer.json_key
       end
 
       def test_json_key_with_root_and_no_serializers
-        serializer = collection_serializer.new(build_named_collection, root: 'custom_root')
-        assert_equal 'custom_roots', serializer.json_key
+        expected = 'custom_root'
+        serializer = collection_serializer.new(build_named_collection, root: expected)
+        assert_equal expected, serializer.json_key
       end
     end
   end


### PR DESCRIPTION
One of three constituents is used to provide the CollectionSerializer's #json_key:
1) the :root option - controlled by the caller
2) the #name of the first resource serializer - the root or
   underscored model name
3) the underscored #name of the resources object - generally
   equivalent to the underscored model name of #2

Of the three, only the latter 2 are out of the callers control, and
only the latter two are expected to be singular by default. Not
pluralizing the root gives the caller additional flexibility in
defining the desired root, whether conventionally plural,
unconventionally plural (e.g. objects_received:) or singular.