### PR TITLE
Don't require serializable objects to extend ActiveModel::Naming

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -135,7 +135,7 @@ module ActiveModel
 
     # Used by adapter as resource root.
     def json_key
-      root || object.class.model_name.to_s.underscore
+      root || model_name.to_s.underscore
     end
 
     def read_attribute_for_serialization(attr)
@@ -152,6 +152,16 @@ module ActiveModel
     # Used by JsonApi adapter to build resource links.
     def links
       self.class._links
+    end
+
+    # @api private
+    # Returns an ActiveModel::Name for the serializer's object
+    def model_name
+      if object.class.respond_to?(:model_name)
+        object.class.model_name
+      else
+        ActiveModel::Name.new(object.class)
+      end
     end
 
     protected

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -115,9 +115,9 @@ module ActiveModel
         def resource_identifier_type_for(serializer)
           return serializer._type if serializer._type
           if ActiveModelSerializers.config.jsonapi_resource_type == :singular
-            serializer.object.class.model_name.singular
+            serializer.model_name.singular
           else
-            serializer.object.class.model_name.plural
+            serializer.model_name.plural
           end
         end
 

--- a/lib/active_model/serializer/lint.rb
+++ b/lib/active_model/serializer/lint.rb
@@ -116,19 +116,6 @@ module ActiveModel::Serializer::Lint
       assert_equal 0, resource.method(:id).arity
     end
 
-    # Passes if the object's class responds to <tt>model_name</tt> and if it
-    # is in an instance of +ActiveModel::Name+.
-    # Fails otherwise.
-    #
-    # <tt>model_name</tt> returns an ActiveModel::Name instance.
-    # It is used by the serializer to identify the object's type.
-    # It is not required unless caching is enabled.
-    def test_model_name
-      resource_class = resource.class
-      assert_respond_to resource_class, :model_name
-      assert_instance_of resource_class.model_name, ActiveModel::Name
-    end
-
     private
 
     def resource

--- a/test/lint_test.rb
+++ b/test/lint_test.rb
@@ -26,10 +26,6 @@ module ActiveModel
 
         def updated_at
         end
-
-        def self.model_name
-          @_model_name ||= ActiveModel::Name.new(self)
-        end
       end
 
       def setup


### PR DESCRIPTION
The aspects of `#model_name` used here are all dependent on the class
alone, we don't need the full namespaced model name to produce
proper results.

This change takes advantage of `#model_name` if defined on the object,
but otherwise provides a name based on the class alone. This saves
us a bunch of:

```ruby
  class Foo
    extend ActiveModel::Naming
    include ActiveModel::Serialization
  end
```