### PR TITLE
Tidy up the tests

### DIFF
--- a/lib/active_model/serializer/lint.rb
+++ b/lib/active_model/serializer/lint.rb
@@ -102,7 +102,7 @@ module ActiveModel::Serializer::Lint
     def test_updated_at
       assert_respond_to resource, :updated_at
       actual_arity = resource.method(:updated_at).arity
-      assert_equal actual_arity, 0, "expected #{actual_arity.inspect} to be 0"
+      assert_equal 0, actual_arity
     end
 
     # Passes if the object responds to <tt>id</tt> and if it takes no
@@ -113,7 +113,7 @@ module ActiveModel::Serializer::Lint
     # It is not required unless caching is enabled.
     def test_id
       assert_respond_to resource, :id
-      assert_equal resource.method(:id).arity, 0
+      assert_equal 0, resource.method(:id).arity
     end
 
     # Passes if the object's class responds to <tt>model_name</tt> and if it

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -28,7 +28,7 @@ module ActiveModel
             comment = Comment.new
             post = Post.new
             serializer = ArraySerializer.new([comment, post])
-            assert_equal serializer.json_key, 'comments'
+            assert_equal 'comments', serializer.json_key
           end)
           assert_match(/Calling deprecated ArraySerializer/, stderr)
         end

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -36,7 +36,7 @@ module ActiveModel
         assert_kind_of PostSerializer, serializers.last
         assert_kind_of Post, serializers.last.object
 
-        assert_equal serializers.last.custom_options[:some], :options
+        assert_equal :options, serializers.last.custom_options[:some]
       end
 
       def test_serializer_option_not_passed_to_each_serializer
@@ -47,50 +47,50 @@ module ActiveModel
 
       def test_root_default
         @serializer = collection_serializer.new([@comment, @post])
-        assert_equal @serializer.root, nil
+        assert_nil @serializer.root
       end
 
       def test_root
         expected =  'custom_root'
         @serializer = collection_serializer.new([@comment, @post], root: expected)
-        assert_equal @serializer.root, expected
+        assert_equal expected, @serializer.root
       end
 
       def test_root_with_no_serializers
         expected =  'custom_root'
         @serializer = collection_serializer.new([], root: expected)
-        assert_equal @serializer.root, expected
+        assert_equal expected, @serializer.root
       end
 
       def test_json_key
-        assert_equal @serializer.json_key, 'comments'
+        assert_equal 'comments', @serializer.json_key
       end
 
       def test_json_key_with_resource_with_name_and_no_serializers
         serializer = collection_serializer.new(build_named_collection)
-        assert_equal serializer.json_key, 'me_resources'
+        assert_equal 'me_resources', serializer.json_key
       end
 
       def test_json_key_with_resource_with_nil_name_and_no_serializers
         resource = []
         resource.define_singleton_method(:name) { nil }
         serializer = collection_serializer.new(resource)
-        assert_equal serializer.json_key, nil
+        assert_nil serializer.json_key
       end
 
       def test_json_key_with_resource_without_name_and_no_serializers
         serializer = collection_serializer.new([])
-        assert_equal serializer.json_key, nil
+        assert_nil serializer.json_key
       end
 
       def test_json_key_with_root
         serializer = collection_serializer.new(@resource, root: 'custom_root')
-        assert_equal serializer.json_key, 'custom_roots'
+        assert_equal 'custom_roots', serializer.json_key
       end
 
       def test_json_key_with_root_and_no_serializers
         serializer = collection_serializer.new(build_named_collection, root: 'custom_root')
-        assert_equal serializer.json_key, 'custom_roots'
+        assert_equal 'custom_roots', serializer.json_key
       end
     end
   end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -52,8 +52,8 @@ module ActiveModel
           serializer = association.serializer
           options = association.options
 
-          assert_equal key, :tags
-          assert_equal serializer, nil
+          assert_equal :tags, key
+          assert_nil serializer
           assert_equal [{ name: '#hashtagged' }].to_json, options[:virtual_value].to_json
         end
       end


### PR DESCRIPTION
* Use assert_nil where appropriate - assert_nil is equivalent to assert_equal with nil as the expectation, so the failure message should be the same. http://apidock.com/ruby/Test/Unit/Assertions/assert_nil
* Lead with the expected value in collection_serializer_test.rb, etc
 so that expected/actual in test failure messages are not reversed