### PR TITLE
Remove defunct .root_name from test fixtures

### DIFF
--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -85,10 +85,6 @@ end
 SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
   has_many :related
-
-  def self.root_name
-    'posts'
-  end
 end
 
 CommentSerializer = Class.new(ActiveModel::Serializer) do
@@ -193,10 +189,6 @@ AuthorPreviewSerializer = Class.new(ActiveModel::Serializer) do
 end
 
 PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
-  def self.root_name
-    'posts'
-  end
-
   attributes :title, :body, :id
 
   has_many :comments, serializer: CommentPreviewSerializer


### PR DESCRIPTION
Was removed elsewhere in
7847d05ecbf2ab777bea8be588a6f9ef1891e3ad