### PR TITLE
Remove unnecessary `dup` in `ActiveModel::Serializer::Associations#associate`

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -76,8 +76,6 @@ module ActiveModel
         # @api private
         #
         def associate(reflection)
-          self._reflections = _reflections.dup
-
           self._reflections << reflection
         end
       end


### PR DESCRIPTION
The `_reflections` are duped on `inherited` - no need to `dup` them
with each addition.