### PR TITLE
Fix Rails 5 warnings (uses Rails5Shim)

### DIFF
--- a/test/action_controller/json_api/deserialization_test.rb
+++ b/test/action_controller/json_api/deserialization_test.rb
@@ -39,7 +39,7 @@ module ActionController
             }
           }
 
-          post :render_parsed_payload, hash
+          post :render_parsed_payload, params: hash
 
           response = JSON.parse(@response.body)
           expected = {

--- a/test/support/rails5_shims.rb
+++ b/test/support/rails5_shims.rb
@@ -3,17 +3,35 @@ module Rails5Shims
     # https://github.com/rails/rails/blob/b217354/actionpack/lib/action_controller/test_case.rb
     REQUEST_KWARGS = [:params, :session, :flash, :method, :body, :xhr]
 
+    def get(path, *args)
+      fold_kwargs!(args)
+      super
+    end
+
+    def post(path, *args)
+      fold_kwargs!(args)
+      super
+    end
+
+    def patch(path, *args)
+      fold_kwargs!(args)
+      super
+    end
+
+    def put(path, *args)
+      fold_kwargs!(args)
+      super
+    end
+
     # Fold kwargs from test request into args
     # Band-aid for DEPRECATION WARNING
-    def get(path, *args)
+    def fold_kwargs!(args)
       hash = args && args[0]
-      if hash.respond_to?(:key)
-        Rails5Shims::ControllerTests::REQUEST_KWARGS.each do |kwarg|
-          next unless hash.key?(kwarg)
-          hash.merge! hash.delete(kwarg)
-        end
+      return unless hash.respond_to?(:key)
+      Rails5Shims::ControllerTests::REQUEST_KWARGS.each do |kwarg|
+        next unless hash.key?(kwarg)
+        hash.merge! hash.delete(kwarg)
       end
-      super
     end
 
     # Uncomment for debugging where the kwargs warnings come from


### PR DESCRIPTION
```plain
DEPRECATION WARNING: ActionController::TestCase HTTP request methods will accept only
keyword arguments in future Rails versions.

Examples:

get :show, params: { id: 1 }, session: { user_id: 1 }
process :update, method: :post, params: { id: 1 }
 (called from test_deserialization at ~/repos/active_model_serializers/test/action_controller/json_api/deserialization_test.rb:42)
 ```