### PR TITLE
Controller namespace lookup.

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -56,7 +56,7 @@ module ActionController
 
     [:_render_option_json, :_render_with_renderer_json].each do |renderer_method|
       define_method renderer_method do |resource, options|
-        options[:serialization_context] = ActiveModelSerializers::SerializationContext.new(self) unless options.key?(:serialization_context)
+        options[:serialization_context] = ActiveModelSerializers::SerializationContext.new(controller: self) unless options.key?(:serialization_context)
         serializable_resource = get_serializer(resource, options)
         super(serializable_resource, options)
       end

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -56,7 +56,7 @@ module ActionController
 
     [:_render_option_json, :_render_with_renderer_json].each do |renderer_method|
       define_method renderer_method do |resource, options|
-        options.fetch(:serialization_context) { options[:serialization_context] = ActiveModelSerializers::SerializationContext.new(request) }
+        options[:serialization_context] = ActiveModelSerializers::SerializationContext.new(self) unless options.key?(:serialization_context)
         serializable_resource = get_serializer(resource, options)
         super(serializable_resource, options)
       end

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -45,7 +45,7 @@ module ActiveModel
       @serializer ||=
         begin
           @serializer = serializer_opts.delete(:serializer)
-          @serializer ||= ActiveModel::Serializer.serializer_for(resource)
+          @serializer ||= ActiveModel::Serializer.serializer_for(resource, serializer_opts)
 
           if serializer_opts.key?(:each_serializer)
             serializer_opts[:serializer] = serializer_opts.delete(:each_serializer)

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -96,8 +96,8 @@ module ActiveModel
     def self.get_serializer_for(klass, serialization_context = nil)
       return nil unless config.serializer_lookup_enabled
       serializers_cache.fetch_or_store([klass, serialization_context]) do
-        # NOTE(beauby): When we drop 1.9.3 support we can lazify the map for perfs.
         serializer_class = serializer_lookup_chain_for(klass, serialization_context)
+                           .lazy
                            .map(&:safe_constantize)
                            .find { |x| x && x < ActiveModel::Serializer }
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -56,7 +56,7 @@ module ActiveModel
       elsif resource.respond_to?(:to_ary)
         config.collection_serializer
       else
-        options.fetch(:serializer) { get_serializer_for(resource.class) }
+        options.fetch(:serializer) { get_serializer_for(resource.class, options[:serialization_context]) }
       end
     end
 
@@ -66,14 +66,16 @@ module ActiveModel
     end
 
     # @api private
-    def self.serializer_lookup_chain_for(klass)
+    def self.serializer_lookup_chain_for(klass, serialization_context = nil)
       chain = []
 
       resource_class_name = klass.name.demodulize
       resource_namespace = klass.name.deconstantize
+      controller_namespace = serialization_context.controller_namespace if serialization_context
       serializer_class_name = "#{resource_class_name}Serializer"
 
       chain.push("#{name}::#{serializer_class_name}") if self != ActiveModel::Serializer
+      chain.push("#{controller_namespace}::#{serializer_class_name}") if controller_namespace
       chain.push("#{resource_namespace}::#{serializer_class_name}")
 
       chain
@@ -91,16 +93,18 @@ module ActiveModel
     #   1. class name appended with "Serializer"
     #   2. try again with superclass, if present
     #   3. nil
-    def self.get_serializer_for(klass)
+    def self.get_serializer_for(klass, serialization_context = nil)
       return nil unless config.serializer_lookup_enabled
-      serializers_cache.fetch_or_store(klass) do
+      serializers_cache.fetch_or_store([klass, serialization_context]) do
         # NOTE(beauby): When we drop 1.9.3 support we can lazify the map for perfs.
-        serializer_class = serializer_lookup_chain_for(klass).map(&:safe_constantize).find { |x| x && x < ActiveModel::Serializer }
+        serializer_class = serializer_lookup_chain_for(klass, serialization_context)
+                           .map(&:safe_constantize)
+                           .find { |x| x && x < ActiveModel::Serializer }
 
         if serializer_class
           serializer_class
         elsif klass.superclass
-          get_serializer_for(klass.superclass)
+          get_serializer_for(klass.superclass, serialization_context)
         end
       end
     end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -74,8 +74,11 @@ module ActiveModel
       controller_namespace = serialization_context.controller_namespace if serialization_context
       serializer_class_name = "#{resource_class_name}Serializer"
 
+      # Look for a nested serializer first.
       chain.push("#{name}::#{serializer_class_name}") if self != ActiveModel::Serializer
+      # Then look for a serializer within the namespace of the calling controller if any.
       chain.push("#{controller_namespace}::#{serializer_class_name}") if controller_namespace
+      # Finally look for a serializer within the resource's namespace.
       chain.push("#{resource_namespace}::#{serializer_class_name}")
 
       chain

--- a/lib/active_model_serializers/serialization_context.rb
+++ b/lib/active_model_serializers/serialization_context.rb
@@ -1,20 +1,15 @@
 module ActiveModelSerializers
   class SerializationContext
-    attr_reader :request_url, :query_parameters, :controller_namespace, :parent_serializer_namespace
+    attr_reader :request_url, :query_parameters, :controller_namespace
 
     def initialize(options = {})
       self.controller = options[:controller] if options.key?(:controller)
-      self.parent_serializer = options[:parent_serializer] if options.key?(:parent_serializer)
     end
 
     def controller=(controller)
       @request_url = controller.request.original_url[/\A[^?]+/]
       @query_parameters = controller.request.query_parameters
       @controller_namespace = controller.class.to_s.deconstantize
-    end
-
-    def parent_serializer=(parent_serializer)
-      @parent_serializer_namespace = parent_serializer.class.to_s.deconstantize
     end
   end
 end

--- a/lib/active_model_serializers/serialization_context.rb
+++ b/lib/active_model_serializers/serialization_context.rb
@@ -1,10 +1,11 @@
 module ActiveModelSerializers
   class SerializationContext
-    attr_reader :request_url, :query_parameters
+    attr_reader :request_url, :query_parameters, :controller_namespace
 
-    def initialize(request)
-      @request_url = request.original_url[/\A[^?]+/]
-      @query_parameters = request.query_parameters
+    def initialize(controller)
+      @request_url = controller.request.original_url[/\A[^?]+/]
+      @query_parameters = controller.request.query_parameters
+      @controller_namespace = controller.class.to_s.deconstantize
     end
   end
 end

--- a/lib/active_model_serializers/serialization_context.rb
+++ b/lib/active_model_serializers/serialization_context.rb
@@ -2,10 +2,15 @@ module ActiveModelSerializers
   class SerializationContext
     attr_reader :request_url, :query_parameters, :controller_namespace
 
-    def initialize(controller)
-      @request_url = controller.request.original_url[/\A[^?]+/]
-      @query_parameters = controller.request.query_parameters
-      @controller_namespace = controller.class.to_s.deconstantize
+    def initialize(options = {})
+      if (controller = options[:controller])
+        @request_url = controller.request.original_url[/\A[^?]+/]
+        @query_parameters = controller.request.query_parameters
+        @controller_namespace = controller.class.to_s.deconstantize
+      end
+      if (parent_serializer = options[:parent_serializer])
+        @parent_serializer_namespace = parent_serializer.class.to_s.deconstantize
+      end
     end
   end
 end

--- a/lib/active_model_serializers/serialization_context.rb
+++ b/lib/active_model_serializers/serialization_context.rb
@@ -1,16 +1,20 @@
 module ActiveModelSerializers
   class SerializationContext
-    attr_reader :request_url, :query_parameters, :controller_namespace
+    attr_reader :request_url, :query_parameters, :controller_namespace, :parent_serializer_namespace
 
     def initialize(options = {})
-      if (controller = options[:controller])
-        @request_url = controller.request.original_url[/\A[^?]+/]
-        @query_parameters = controller.request.query_parameters
-        @controller_namespace = controller.class.to_s.deconstantize
-      end
-      if (parent_serializer = options[:parent_serializer])
-        @parent_serializer_namespace = parent_serializer.class.to_s.deconstantize
-      end
+      self.controller = options[:controller] if options.key?(:controller)
+      self.parent_serializer = options[:parent_serializer] if options.key?(:parent_serializer)
+    end
+
+    def controller=(controller)
+      @request_url = controller.request.original_url[/\A[^?]+/]
+      @query_parameters = controller.request.query_parameters
+      @controller_namespace = controller.class.to_s.deconstantize
+    end
+
+    def parent_serializer=(parent_serializer)
+      @parent_serializer_namespace = parent_serializer.class.to_s.deconstantize
     end
   end
 end

--- a/test/active_model_serializers/serialization_context_test.rb
+++ b/test/active_model_serializers/serialization_context_test.rb
@@ -1,18 +1,13 @@
 require 'test_helper'
 
-class ActiveModelSerializers::SerializationContextTest < ActiveSupport::TestCase
-  def create_context
-    request = Minitest::Mock.new
-    request.expect(:original_url, 'original_url')
-    request.expect(:query_parameters, 'query_parameters')
+module ActiveModelSerializers
+  class SerializationContextTest < ActionController::TestCase
+    def test_create_context_with_request_url_and_query_parameters
+      context = ActiveModelSerializers::SerializationContext.new(controller: self)
 
-    ActiveModelSerializers::SerializationContext.new(request)
-  end
-
-  def test_create_context_with_request_url_and_query_parameters
-    context = create_context
-
-    assert_equal context.request_url, 'original_url'
-    assert_equal context.query_parameters, 'query_parameters'
+      assert_equal('http://test.host', context.request_url)
+      assert_equal({}, context.query_parameters)
+      assert_equal('ActiveModelSerializers', context.controller_namespace)
+    end
   end
 end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -202,9 +202,7 @@ module ActiveModel
 
       class NestedSerializersTest < ActiveSupport::TestCase
         Post    = Class.new(::Model)
-        Comment = Class.new(::Model)
-        Author  = Class.new(::Model)
-        Description = Class.new(::Model)
+        ::Description = Class.new(::Model)
         class PostSerializer < ActiveModel::Serializer
           has_many :comments
           CommentSerializer = Class.new(ActiveModel::Serializer)
@@ -215,9 +213,9 @@ module ActiveModel
         end
 
         def setup
-          @comment = Comment.new
-          @author = Author.new
-          @description = Description.new
+          @comment = ::Comment.new
+          @author = ::Author.new
+          @description = ::Description.new
           @post = Post.new(comments: [@comment],
                            author: @author,
                            description: @description)


### PR DESCRIPTION
Just took a stab at it. Basically, it allows for inferring the serializer in the following scenario:
```ruby
class Api::V1::PostController < ActionController::Base
  def create
    @post = Post.create(params)
    render json: @post
  end
end

class Api::V1::PostSerializer < ActiveModel::Serializer
  ...
end
```

Ref #1265, #886.