### PR TITLE
Add support for relationship-level links and meta attributes.

### DIFF
--- a/lib/active_model/serializer/adapter/json_api/association.rb
+++ b/lib/active_model/serializer/adapter/json_api/association.rb
@@ -1,0 +1,48 @@
+module ActiveModel
+  class Serializer
+    module Adapter
+      class JsonApi
+        class Association
+          def initialize(parent_serializer, serializer, options, links, meta)
+            @object = parent_serializer.object
+            @scope = parent_serializer.scope
+
+            @options = options
+            @data = data_for(serializer, options)
+            @links = links
+                     .map { |key, value| { key => Link.new(parent_serializer, value).as_json } }
+                     .reduce({}, :merge)
+            @meta = meta.respond_to?(:call) ? parent_serializer.instance_eval(&meta) : meta
+          end
+
+          def as_json
+            hash = {}
+            hash[:data] = @data if @options[:include_data]
+            hash[:links] = @links if @links.any?
+            hash[:meta] = @meta if @meta
+
+            hash
+          end
+
+          protected
+
+          attr_reader :object, :scope
+
+          private
+
+          def data_for(serializer, options)
+            if serializer.respond_to?(:each)
+              serializer.map { |s| ResourceIdentifier.new(s).as_json }
+            else
+              if options[:virtual_value]
+                options[:virtual_value]
+              elsif serializer && serializer.object
+                ResourceIdentifier.new(serializer).as_json
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_model/serializer/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model/serializer/adapter/json_api/resource_identifier.rb
@@ -1,0 +1,41 @@
+module ActiveModel
+  class Serializer
+    module Adapter
+      class JsonApi
+        class ResourceIdentifier
+          def initialize(serializer)
+            @id = id_for(serializer)
+            @type = type_for(serializer)
+          end
+
+          def as_json
+            { id: @id.to_s, type: @type }
+          end
+
+          protected
+
+          attr_reader :object, :scope
+
+          private
+
+          def type_for(serializer)
+            return serializer._type if serializer._type
+            if ActiveModelSerializers.config.jsonapi_resource_type == :singular
+              serializer.object.class.model_name.singular
+            else
+              serializer.object.class.model_name.plural
+            end
+          end
+
+          def id_for(serializer)
+            if serializer.respond_to?(:id)
+              serializer.id
+            else
+              serializer.object.id
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -9,7 +9,7 @@ module ActiveModel
     # @example
     #  Association.new(:comments, CommentSummarySerializer)
     #
-    Association = Struct.new(:name, :serializer, :options) do
+    Association = Struct.new(:name, :serializer, :options, :links, :meta) do
       # @return [Symbol]
       #
       def key

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -34,6 +34,38 @@ module ActiveModel
     # So you can inspect reflections in your Adapters.
     #
     class Reflection < Field
+      def initialize(*)
+        super
+        @_links = {}
+        @_include_data = true
+      end
+
+      def link(name, value = nil, &block)
+        @_links[name] = block || value
+        nil
+      end
+
+      def meta(value = nil, &block)
+        @_meta = block || value
+        nil
+      end
+
+      def include_data(value = true)
+        @_include_data = value
+        nil
+      end
+
+      def value(serializer)
+        @object = serializer.object
+        @scope = serializer.scope
+
+        if block
+          instance_eval(&block)
+        else
+          serializer.read_attribute_for_serialization(name)
+        end
+      end
+
       # Build association. This method is used internally to
       # build serializer's association by its reflection.
       #
@@ -59,6 +91,7 @@ module ActiveModel
         association_value = value(subject)
         reflection_options = options.dup
         serializer_class = subject.class.serializer_for(association_value, reflection_options)
+        reflection_options[:include_data] = @_include_data
 
         if serializer_class
           begin
@@ -73,8 +106,12 @@ module ActiveModel
           reflection_options[:virtual_value] = association_value
         end
 
-        Association.new(name, serializer, reflection_options)
+        Association.new(name, serializer, reflection_options, @_links, @_meta)
       end
+
+      protected
+
+      attr_accessor :object, :scope
 
       private
 

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -17,11 +17,23 @@ module ActiveModel
             link :yet_another do
               "//example.com/resource/#{object.id}"
             end
+
+            has_many :posts do
+              link :self do
+                href '//example.com/link_author/relationships/posts'
+                meta stuff: 'value'
+              end
+              link :related do
+                href '//example.com/link_author/posts'
+                meta count: object.posts.count
+              end
+              include_data false
+            end
           end
 
           def setup
             @post = Post.new(id: 1337, comments: [], author: nil)
-            @author = LinkAuthor.new(id: 1337)
+            @author = LinkAuthor.new(id: 1337, posts: [@post])
           end
 
           def test_toplevel_links
@@ -60,6 +72,23 @@ module ActiveModel
               yet_another: '//example.com/resource/1337'
             }
             assert_equal(expected, hash[:data][:links])
+          end
+
+          def test_relationship_links
+            hash = serializable(@author, adapter: :json_api).serializable_hash
+            expected = {
+              links: {
+                self: {
+                  href: '//example.com/link_author/relationships/posts',
+                  meta: { stuff: 'value' }
+                },
+                related: {
+                  href: '//example.com/link_author/posts',
+                  meta: { count: 1 }
+                }
+              }
+            }
+            assert_equal(expected, hash[:data][:relationships][:posts])
           end
         end
       end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -32,13 +32,13 @@ module ActiveModel
 
           case key
           when :posts
-            assert_equal({}, options)
+            assert_equal({ include_data: true }, options)
             assert_kind_of(ActiveModelSerializers.config.collection_serializer, serializer)
           when :bio
-            assert_equal({}, options)
+            assert_equal({ include_data: true }, options)
             assert_nil serializer
           when :roles
-            assert_equal({}, options)
+            assert_equal({ include_data: true }, options)
             assert_kind_of(ActiveModelSerializers.config.collection_serializer, serializer)
           else
             flunk "Unknown association: #{key}"
@@ -80,7 +80,7 @@ module ActiveModel
             flunk "Unknown association: #{key}"
           end
 
-          assert_equal({}, association.options)
+          assert_equal({ include_data: true }, association.options)
         end
       end
 


### PR DESCRIPTION
Based on top of #1447.
Allows the following:
```ruby
has_many :posts do
  link :self do
    href '//example.com/link_author/relationships/posts'
    meta stuff: 'value'
  end
  link :related do
    href '//example.com/link_author/posts'
    meta count: object.posts.count
  end
  include_data false
end
```