### PR TITLE
updates Readme to reflect AMS is no longer default in Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ AMS](https://medium.com/@joaomdmoura/the-future-of-ams-e5f9047ca7e9)'.
 
 ## Installation
 
-Note: *ActiveModelSerializers is already included on Rails >= 5*
-
 Add this line to your application's Gemfile:
 
 ```


### PR DESCRIPTION
As of https://github.com/rails/rails/commit/f8edd2043e864aff0bde9289da550709532268a6 AMS is no longer included in Rails by default when the `--api` option is used.