### PR TITLE
Update attribute/association overriding docs

### DIFF
--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -188,8 +188,6 @@ If you want to override any association, you can use:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
-  attributes :id, :body
-
   has_many :comments
 
   def comments
@@ -204,9 +202,7 @@ If you want to override any attribute, you can use:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
-  attributes :id, :body
-
-  has_many :comments
+  attributes :body
 
   def body
     object.body.downcase

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -184,13 +184,11 @@ For more information, see [the Serializer class on GitHub](https://github.com/ra
 
 ## Overriding association methods
 
-If you want to override any association, you can use:
+To override an association, call `has_many`, `has_one` or `belongs_to` with a block:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
-  has_many :comments
-
-  def comments
+  has_many :comments do
     object.comments.active
   end
 end
@@ -198,13 +196,11 @@ end
 
 ## Overriding attribute methods
 
-If you want to override any attribute, you can use:
+To override an attribute, call `attribute` with a block:
 
 ```ruby
 class PostSerializer < ActiveModel::Serializer
-  attributes :body
-
-  def body
+  attribute :body do
     object.body.downcase
   end
 end


### PR DESCRIPTION
This PR updates the documentation for overriding attributes and associations. It replaces the old method-based style with the new block-based style.

Fixes #1433 