### PR TITLE
Ensure that generators get configured correctly

### DIFF
--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -24,7 +24,9 @@ module ActiveModelSerializers
       ActiveModelSerializers.config.perform_caching = Rails.configuration.action_controller.perform_caching
     end
 
-    generators do
+    generators do |app|
+      Rails::Generators.configure!(app.config.generators)
+      Rails::Generators.hidden_namespaces.uniq!
       require 'generators/rails/resource_override'
     end
 


### PR DESCRIPTION
This fixes #1465 by ensuring the generators are configured when using a `generator` block. This follows the same pattern used by JBuilder and includes the configuration steps which seemed redundant but are not. See https://github.com/rails/rails/pull/9647
