### PR TITLE
Fixed fragment_cached? method to check if caching

### DIFF
--- a/lib/active_model/serializer/adapter/cached_serializer.rb
+++ b/lib/active_model/serializer/adapter/cached_serializer.rb
@@ -24,7 +24,7 @@ module ActiveModel
         end
 
         def fragment_cached?
-          @klass._cache_only && !@klass._cache_except || !@klass._cache_only && @klass._cache_except
+          @klass._cache && (@klass._cache_only && !@klass._cache_except || !@klass._cache_only && @klass._cache_except)
         end
 
         def cache_key


### PR DESCRIPTION
I noticed that fragment caching does not actually check if caching is
enabled as it seemingly should.

The way CachedSerializer#fragment_cached? worked previously would return
true even in an environment where caching was disabled as defined by
`ActiveModelSerializers.config.perform_caching`.

Added check for `_cache` like in the `cached?` method before checking
whether `_cache_only` or `_cache_except` is set.

There were no existing tests for any of these methods but it's a pretty
trivial change.