### PR TITLE
[FIX] Serializers can now be defined *before* Rails initializes and cache store will be correctly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Features:
 - [#1340](https://github.com/rails-api/active_model_serializers/pull/1340) Add support for resource-level meta. (@beauby)
 
 Fixes:
+- [#1478](https://github.com/rails-api/active_model_serializers/pull/1478) Cache store will now be correctly set when serializers are
+  loaded *before* Rails initializes. (@bf4)
 - [#1570](https://github.com/rails-api/active_model_serializers/pull/1570) Fixed pagination issue with last page size. (@bmorrall)
 - [#1516](https://github.com/rails-api/active_model_serializers/pull/1516) No longer return a nil href when only
   adding meta to a relationship link. (@groyoh)

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,8 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-  t.ruby_opts = ['-w -r./test/test_helper.rb']
+  t.ruby_opts = ['-r./test/test_helper.rb']
+  t.ruby_opts << ' -w' unless ENV['NO_WARN'] == 'true'
   t.verbose = true
 end
 

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -99,34 +99,18 @@ module ActiveModel
           self._cache_options = options.empty? ? nil : options
         end
 
+        # Value is from ActiveModelSerializers.config.perform_caching. Is used to
+        # globally enable or disable all serializer caching, just like
+        # Rails.configuration.action_controller.perform_caching, which is its
+        # default value in a Rails application.
         # @return [true, false]
-        # We're using class variables here because it is a class attribute
-        # that is globally true for the `ActiveModel::Serializer` class; i.e. neither per subclass nor inherited.
-        #
-        # We're not using a class_attribute because of the special behavior in
-        # `perform_caching` setting itself to `ActiveModelSerializers.config.perform_caching`
-        # when first called if it wasn't first set.
-        #
-        # This is to allow us to have a global config that can be set any time before
-        # `perform_caching` is called.
-        #
-        # One downside of this, is that subsequent setting of the global config will not change
-        # `ActiveModel::Serializer.perform_caching`, but that should be an edge case that
-        # is easily handled.
-        #
-        # If you, reading this, can figure out how to have ActiveModel::Serializer always delegate
-        # `perform_caching` and `perform_caching=` to the global config, that would make a nice PR.
+        # Memoizes value of config first time it is called with a non-nil value.
         # rubocop:disable Style/ClassVars
         def perform_caching
-          return @@perform_caching if defined?(@@perform_caching)
-          self.perform_caching = ActiveModelSerializers.config.perform_caching
+          return @@perform_caching if defined?(@@perform_caching) && !@@perform_caching.nil?
+          @@perform_caching = ActiveModelSerializers.config.perform_caching
         end
         alias perform_caching? perform_caching
-
-        # @param [true, false]
-        def perform_caching=(perform_caching)
-          @@perform_caching = perform_caching
-        end
         # rubocop:enable Style/ClassVars
 
         # The canonical method for getting the cache store for the serializer.

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -89,6 +89,10 @@ module ActiveModel
         # https://github.com/rails-api/active_model_serializers/pull/1249#issuecomment-146567837
         def cache(options = {})
           self._cache = ActiveModelSerializers.config.cache_store if ActiveModelSerializers.config.perform_caching
+          serializer = self
+          ActiveSupport.on_load(:action_controller) do
+            serializer._cache = ActiveModelSerializers.config.cache_store if ActiveModelSerializers.config.perform_caching
+          end
           self._cache_key = options.delete(:key)
           self._cache_only = options.delete(:only)
           self._cache_except = options.delete(:except)

--- a/lib/active_model_serializers/cached_serializer.rb
+++ b/lib/active_model_serializers/cached_serializer.rb
@@ -18,11 +18,11 @@ module ActiveModelSerializers
     end
 
     def cached?
-      @klass._cache && !@klass._cache_only && !@klass._cache_except
+      @klass.cache_enabled?
     end
 
     def fragment_cached?
-      @klass._cache && (@klass._cache_only && !@klass._cache_except || !@klass._cache_only && @klass._cache_except)
+      @klass.fragment_cache_enabled?
     end
 
     def cache_key

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -454,7 +454,7 @@ module ActionController
       end
 
       def test_render_event_is_emmited
-        ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |name|
+        ::ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |name|
           @name = name
         end
 

--- a/test/active_model_serializers/adapter_for_test.rb
+++ b/test/active_model_serializers/adapter_for_test.rb
@@ -1,5 +1,7 @@
+require 'test_helper'
+
 module ActiveModelSerializers
-  class AdapterForTest < ActiveSupport::TestCase
+  class AdapterForTest < ::ActiveSupport::TestCase
     UnknownAdapterError = ::ActiveModelSerializers::Adapter::UnknownAdapterError
 
     def test_serializer_adapter_returns_configured_adapter

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -34,6 +34,19 @@ module ActiveModelSerializers
       @blog_serializer     = BlogSerializer.new(@blog)
     end
 
+    def test_explicit_cache_store
+      default_store = Class.new(ActiveModel::Serializer) do
+        cache
+      end
+      explicit_store = Class.new(ActiveModel::Serializer) do
+        cache cache_store: ActiveSupport::Cache::FileStore
+      end
+
+      assert ActiveSupport::Cache::MemoryStore, ActiveModelSerializers.config.cache_store
+      assert ActiveSupport::Cache::MemoryStore, default_store.cache_store
+      assert ActiveSupport::Cache::FileStore, explicit_store.cache_store
+    end
+
     def test_inherited_cache_configuration
       inherited_serializer = Class.new(PostSerializer)
 

--- a/test/serializers/caching_configuration_test_isolated.rb
+++ b/test/serializers/caching_configuration_test_isolated.rb
@@ -1,0 +1,168 @@
+# Execute this test in isolation
+require 'support/isolated_unit'
+
+class CachingConfigurationTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup do
+    require 'rails'
+    # AMS needs to be required before Rails.application is initialized for
+    # Railtie's to fire in Rails.application.initialize!
+    # (and make_basic_app initializes the app)
+    require 'active_model_serializers'
+    # Create serializers before Rails.application.initialize!
+    # To ensure we're testing that the cache settings depend on
+    # the Railtie firing, not on the ActionController being loaded.
+    create_serializers
+  end
+
+  def create_serializers
+    @cached_serializer = Class.new(ActiveModel::Serializer) do
+      cache skip_digest: true
+      attributes :id, :name, :title
+    end
+    @fragment_cached_serializer = Class.new(ActiveModel::Serializer) do
+      cache only: :id
+      attributes :id, :name, :title
+    end
+    @non_cached_serializer = Class.new(ActiveModel::Serializer) do
+      attributes :id, :name, :title
+    end
+  end
+
+  class PerformCachingTrue < CachingConfigurationTest
+    setup do
+      # Let's make that Rails app and initialize it!
+      make_basic_app do |app|
+        app.config.action_controller.perform_caching = true
+        app.config.action_controller.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
+      end
+    end
+
+    test 'it sets perform_caching to true on AMS.config and serializers' do
+      assert Rails.configuration.action_controller.perform_caching
+      assert ActiveModelSerializers.config.perform_caching
+      assert ActiveModel::Serializer.perform_caching?
+      assert @cached_serializer.perform_caching?
+      assert @non_cached_serializer.perform_caching?
+      assert @fragment_cached_serializer.perform_caching?
+    end
+
+    test 'it sets the AMS.config.cache_store to the controller cache_store' do
+      assert_equal controller_cache_store, ActiveSupport::Cache::MemoryStore
+      assert_equal controller_cache_store, ActiveModelSerializers.config.cache_store.class
+    end
+
+    test 'it sets the cached serializer cache_store to the ActionController::Base.cache_store' do
+      assert_equal ActiveSupport::Cache::NullStore, @cached_serializer._cache.class
+      assert_equal controller_cache_store, @cached_serializer.cache_store.class
+      assert_equal ActiveSupport::Cache::MemoryStore, @cached_serializer._cache.class
+    end
+
+    test 'the cached serializer has cache_enabled?' do
+      assert @cached_serializer.cache_enabled?
+    end
+
+    test 'the cached serializer does not have fragment_cache_enabled?' do
+      refute @cached_serializer.fragment_cache_enabled?
+    end
+
+    test 'the non-cached serializer cache_store is nil' do
+      assert_equal nil, @non_cached_serializer._cache
+      assert_equal nil, @non_cached_serializer.cache_store
+      assert_equal nil, @non_cached_serializer._cache
+    end
+
+    test 'the non-cached serializer does not have cache_enabled?' do
+      refute @non_cached_serializer.cache_enabled?
+    end
+
+    test 'the non-cached serializer does not have fragment_cache_enabled?' do
+      refute @non_cached_serializer.fragment_cache_enabled?
+    end
+
+    test 'it sets the fragment cached serializer cache_store to the ActionController::Base.cache_store' do
+      assert_equal ActiveSupport::Cache::NullStore, @fragment_cached_serializer._cache.class
+      assert_equal controller_cache_store, @fragment_cached_serializer.cache_store.class
+      assert_equal ActiveSupport::Cache::MemoryStore, @fragment_cached_serializer._cache.class
+    end
+
+    test 'the fragment cached serializer does not have cache_enabled?' do
+      refute @fragment_cached_serializer.cache_enabled?
+    end
+
+    test 'the fragment cached serializer has fragment_cache_enabled?' do
+      assert @fragment_cached_serializer.fragment_cache_enabled?
+    end
+  end
+
+  class PerformCachingFalse < CachingConfigurationTest
+    setup do
+      # Let's make that Rails app and initialize it!
+      make_basic_app do |app|
+        app.config.action_controller.perform_caching = false
+        app.config.action_controller.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
+      end
+    end
+
+    test 'it sets perform_caching to false on AMS.config and serializers' do
+      refute Rails.configuration.action_controller.perform_caching
+      refute ActiveModelSerializers.config.perform_caching
+      refute ActiveModel::Serializer.perform_caching?
+      refute @cached_serializer.perform_caching?
+      refute @non_cached_serializer.perform_caching?
+      refute @fragment_cached_serializer.perform_caching?
+    end
+
+    test 'it sets the AMS.config.cache_store to the controller cache_store' do
+      assert_equal controller_cache_store, ActiveSupport::Cache::MemoryStore
+      assert_equal controller_cache_store, ActiveModelSerializers.config.cache_store.class
+    end
+
+    test 'it sets the cached serializer cache_store to the ActionController::Base.cache_store' do
+      assert_equal ActiveSupport::Cache::NullStore, @cached_serializer._cache.class
+      assert_equal controller_cache_store, @cached_serializer.cache_store.class
+      assert_equal ActiveSupport::Cache::MemoryStore, @cached_serializer._cache.class
+    end
+
+    test 'the cached serializer does not have cache_enabled?' do
+      refute @cached_serializer.cache_enabled?
+    end
+
+    test 'the cached serializer does not have fragment_cache_enabled?' do
+      refute @cached_serializer.fragment_cache_enabled?
+    end
+
+    test 'the non-cached serializer cache_store is nil' do
+      assert_equal nil, @non_cached_serializer._cache
+      assert_equal nil, @non_cached_serializer.cache_store
+      assert_equal nil, @non_cached_serializer._cache
+    end
+
+    test 'the non-cached serializer does not have cache_enabled?' do
+      refute @non_cached_serializer.cache_enabled?
+    end
+
+    test 'the non-cached serializer does not have fragment_cache_enabled?' do
+      refute @non_cached_serializer.fragment_cache_enabled?
+    end
+
+    test 'it sets the fragment cached serializer cache_store to the ActionController::Base.cache_store' do
+      assert_equal ActiveSupport::Cache::NullStore, @fragment_cached_serializer._cache.class
+      assert_equal controller_cache_store, @fragment_cached_serializer.cache_store.class
+      assert_equal ActiveSupport::Cache::MemoryStore, @fragment_cached_serializer._cache.class
+    end
+
+    test 'the fragment cached serializer does not have cache_enabled?' do
+      refute @fragment_cached_serializer.cache_enabled?
+    end
+
+    test 'the fragment cached serializer does not have fragment_cache_enabled?' do
+      refute @fragment_cached_serializer.fragment_cache_enabled?
+    end
+  end
+
+  def controller_cache_store
+    ActionController::Base.cache_store.class
+  end
+end


### PR DESCRIPTION
Update: https://github.com/rails-api/active_model_serializers/pull/1478#issuecomment-197703871 and https://github.com/rails-api/active_model_serializers/pull/1478#issuecomment-197706572 https://github.com/rails-api/active_model_serializers/pull/1478#issuecomment-201111318


This is kind of a dumb fix for caching that demonstrates the
need in Rails for Serializer::_cache to be set after the controller is loaded
when Serializer::cache has already been called.


## Notes on the issue

```ruby
# Initialize app before any serializers are defined, for sanity's sake.
# Otherwise, you have to manually set perform caching.
#
# Details:
#
# 1. Upon load, when AMS.config.perform_caching is true,
#    serializers inherit the cache store from ActiveModelSerializers.config.cache_store
# 1. If the serializers are loaded before Rails is initialized (`Rails.application.initialize!`),
#    these values are nil, and are not applied to the already loaded serializers
# 1. If Rails is initialized before any serializers are loaded, then the configs are set,
#    and are used when serializers are loaded
# 1. In either case, `ActiveModelSerializers.config.cache_store`, and
#    `ActiveModelSerializers.config.perform_caching` can be set at any time before the serializers
#    are loaded,
#    e.g.  `ActiveModel::Serializer.config.cache_store ||=
#      ActiveSupport::Cache.lookup_store(ActionController::Base.cache_store ||
#      Rails.cache || :memory_store)`
#    and `ActiveModelSerializers.config.perform_caching = true`
# 1. If the serializers are loaded before Rails is initialized, then,
#    you can set the `_cache` store directly on the serializers.
#    `ActiveModel::Serializer._cache ||=
#      ActiveSupport::Cache.lookup_store(ActionController::Base.cache_store ||
#      Rails.cache || :memory_store`
#    is sufficient.
#    Setting `_cache` to a truthy value will cause the CachedSerializer
#    to consider it cached, which will apply to all serializers (bug? :bug: )
#
# This happens, in part, because the cache store is set for a serializer
# when `cache` is called, and cache is usually called when the serializer is defined.
#
# So, there's now a 'workaround', something to debug, and a starting point.
Rails.application.initialize!

# HACK: Serializer::cache depends on the ActionController-dependent configs being set.
ActiveSupport.on_load(:action_controller) do
  require_relative 'fixtures'
end
```