### PR TITLE
[FIX] The cache store needs to be the actually store, not e.g. :memory_store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Features:
 - [#1340](https://github.com/rails-api/active_model_serializers/pull/1340) Add support for resource-level meta. (@beauby)
 
 Fixes:
+- [#1480](https://github.com/rails-api/active_model_serializers/pull/1480) Fix setting of cache_store from Rails configuration. (@bf4)
+  Fix uninentional mutating of value in memory cache store. (@groyoh)
 - [#1622](https://github.com/rails-api/active_model_serializers/pull/1622) Fragment cache changed from per-record to per-serializer.
   Now, two serializers that use the same model may be separately cached. (@lserman)
 - [#1478](https://github.com/rails-api/active_model_serializers/pull/1478) Cache store will now be correctly set when serializers are

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -55,7 +55,7 @@ module ActiveModelSerializers
       def serializable_hash_for_single_resource(options)
         resource = resource_object_for(options)
         relationships = resource_relationships(options)
-        resource.merge!(relationships)
+        resource.merge(relationships)
       end
 
       def resource_relationships(options)

--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -25,8 +25,11 @@ module ActiveModelSerializers
     # and also before eager_loading (if enabled).
     initializer 'active_model_serializers.set_configs', :after => 'action_controller.set_configs' do
       ActiveModelSerializers.logger = Rails.configuration.action_controller.logger
-      ActiveModelSerializers.config.cache_store     = Rails.configuration.action_controller.cache_store
       ActiveModelSerializers.config.perform_caching = Rails.configuration.action_controller.perform_caching
+      # We want this hook to run after the config has been set, even if ActionController has already loaded.
+      ActiveSupport.on_load(:action_controller) do
+        ActiveModelSerializers.config.cache_store = cache_store
+      end
     end
 
     generators do |app|

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,8 +1,6 @@
 verbose = $VERBOSE
 $VERBOSE = nil
 class Model < ActiveModelSerializers::Model
-  FILE_DIGEST = Digest::MD5.hexdigest(File.open(__FILE__).read)
-
   ### Helper methods, not required to be serializable
 
   # Convenience when not adding @attributes readers and writers
@@ -20,10 +18,6 @@ class Model < ActiveModelSerializers::Model
   # in Rails 5
   def respond_to_missing?(method_name, _include_private = false)
     attributes.key?(method_name.to_s.tr('=', '').to_sym) || super
-  end
-
-  def cache_key_with_digest
-    "#{cache_key}/#{FILE_DIGEST}"
   end
 end
 
@@ -58,7 +52,13 @@ Post     = Class.new(Model)
 Like     = Class.new(Model)
 Author   = Class.new(Model)
 Bio      = Class.new(Model)
-Blog     = Class.new(Model)
+Blog     = Class.new(Model) do
+  FILE_DIGEST = Digest::MD5.hexdigest(File.open(__FILE__).read)
+
+  def cache_key_with_digest
+    "#{cache_key}/#{FILE_DIGEST}"
+  end
+end
 Role     = Class.new(Model)
 User     = Class.new(Model)
 Location = Class.new(Model)

--- a/test/serializers/caching_configuration_test_isolated.rb
+++ b/test/serializers/caching_configuration_test_isolated.rb
@@ -37,6 +37,7 @@ class CachingConfigurationTest < ActiveSupport::TestCase
         app.config.action_controller.perform_caching = true
         app.config.action_controller.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
       end
+      controller_cache_store # Force ActiveSupport.on_load(:action_controller) to run
     end
 
     test 'it sets perform_caching to true on AMS.config and serializers' do
@@ -103,6 +104,7 @@ class CachingConfigurationTest < ActiveSupport::TestCase
         app.config.action_controller.perform_caching = false
         app.config.action_controller.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
       end
+      controller_cache_store # Force ActiveSupport.on_load(:action_controller) to run
     end
 
     test 'it sets perform_caching to false on AMS.config and serializers' do

--- a/test/support/rails_app.rb
+++ b/test/support/rails_app.rb
@@ -5,6 +5,10 @@ module ActiveModelSerializers
       config.secret_key_base = 'abc123'
       config.active_support.test_order = :random
       config.action_controller.perform_caching = true
+      # TODO: figure out why turning on the memory cache changes
+      # the result of the CacheTest#test_associations_cache_when_updated
+      # and if it is more correct or less correct.
+      # config.action_controller.cache_store = :memory
     end
 
     app.routes.default_url_options = { host: 'example.com' }

--- a/test/support/rails_app.rb
+++ b/test/support/rails_app.rb
@@ -8,7 +8,7 @@ module ActiveModelSerializers
       # TODO: figure out why turning on the memory cache changes
       # the result of the CacheTest#test_associations_cache_when_updated
       # and if it is more correct or less correct.
-      # config.action_controller.cache_store = :memory
+      config.action_controller.cache_store = :memory_store
     end
 
     app.routes.default_url_options = { host: 'example.com' }

--- a/test/support/rails_app.rb
+++ b/test/support/rails_app.rb
@@ -5,7 +5,6 @@ module ActiveModelSerializers
       config.secret_key_base = 'abc123'
       config.active_support.test_order = :random
       config.action_controller.perform_caching = true
-      ActionController::Base.cache_store = :memory_store
     end
 
     app.routes.default_url_options = { host: 'example.com' }

--- a/test/support/rails_app.rb
+++ b/test/support/rails_app.rb
@@ -5,9 +5,6 @@ module ActiveModelSerializers
       config.secret_key_base = 'abc123'
       config.active_support.test_order = :random
       config.action_controller.perform_caching = true
-      # TODO: figure out why turning on the memory cache changes
-      # the result of the CacheTest#test_associations_cache_when_updated
-      # and if it is more correct or less correct.
       config.action_controller.cache_store = :memory_store
     end
 


### PR DESCRIPTION
Bug found: The cache store needs to be the actually store, not e.g. :memory_store

### Status quo in test app:

In Rails

```ruby
    ActionController::Base.cache_store = :memory_store
```

and then AMS Railtie will look like:

```ruby
  config = Rails.configuration
  ActiveModelSerializers.config.cache_store = config.action_controller.cache_store
```

then, in the AMS Railtie:

1. `ActiveSupport.on_load(:action_controller)` fires
  - `ActiveModelSerializers.config.cache_store #=> nil`
  - `ActionController::Base.cache_store        #=> #<ActiveSupport::Cache::FileStore:0x007fe319256760...]`

2. After `set_configs` fires
  - `ActiveModelSerializers.config.cache_store #+> #<ActiveSupport::Cache::FileStore:0x007fe319256760 ,`

3. Tests pass, but notice that we're using the FileStore, not memory store

### When we change the config to the test app:

```ruby
  ActionController::Base.cache_store = :memory_store
  config = Rails.configuration
  config.action_controller.cache_store = :memory_store
```

then, in the AMS Railtie:

1. `ActiveSupport.on_load(:action_controller)` fires
  - `ActiveModelSerializers.config.cache_store #=> nil`
  - `ActionController::Base.cache_store        #=> #ActiveSupport::Cache::MemoryStore entries=0, size=0, options={}>]`

2. After `set_configs` fires
  - `ActiveModelSerializers.config.cache_store #=> :memory_store`

3. And we get a lot of failures:
  - `NoMethodError: undefined method `fetch' for :memory_store:Symbol`

So, we see that when we set the `ActionController::Base.cache_store`
directly in our test app, we could set
`ActiveModelSerializers.config.cache_store` in the `:action_controller` load
hook, but that would never use the Rails config.

### To fix the Rails config, we change the config to the test app:

```ruby
  config = Rails.configuration
  config.action_controller.cache_store = :memory_store
```

and then AMS Railtie will look like:

```ruby
  ActiveModelSerializers.config.cache_store = ActiveSupport::Cache.lookup_store(config.action_controller.cache_store
  ActiveSupport.on_load(:action_controller) do
    ::ActiveModelSerializers.config.cache_store = cache_store
  end
```

then, in the AMS Railtie:

1. After `set_configs` fires
  - `ActiveModelSerializers.config.cache_store #=> <#ActiveSupport::Cache::MemoryStore, object_id 70207113611740`

2. `ActiveSupport.on_load(:action_controller)` fires
  - `ActionController::Base.cache_store        #=> <#ActiveSupport::Cache::MemoryStore, object_id 70207106279660`
  - `ActiveModelSerializers.config.cache_store #=> <#ActiveSupport::Cache::MemoryStore, object_id 70207106279660`
    (notice the object_id changed)

3. And we get a failure:

```
  1) Failure:
  ActiveModelSerializers::CacheTest#test_associations_cache_when_updated
  [active_model_serializers/test/cache_test.rb:141]:
  --- expected
  +++ actual
  @@ -1 +1 @@
  -{:id=>"post", :title=>"New Post", :body=>"Body"}
  +{:id=>"post", :title=>"New Post", :body=>"Body", :comments=>[{:id=>2, :body=>"ZOMG A NEW COMMENT"}], :blog=>{:id=>999, :name=>"Custom blog"}, :author=>{:id=>"author", :name=>"Joao M. D. Moura"}}
```

If we take out the `on_load(:action_controller)` hook, we get a ton of
failures.  So clearly, our code expects the controller cache to be the
same as the serializer cache.

So, we make sure we use an `on_load(:action_controller)` hook that runs
*after* `set_configs`

And look at the test and see it is filled with direct calls to `ActionController::Base.cache_store`

```ruby
    assert_equal(new_comment_serializer.attributes, ActionController::Base.cache_store.fetch(new_comment.cache_key))
    assert_equal(@post_serializer.attributes, ActionController::Base.cache_store.fetch(@post.cache_key))
```

But that's not a problem in this case, since they're the same object. That just explains all the failures before when they were different objects.

For now, let's remove the `:memory_store` setting and use the default FileStore and that one failure goes away.

The cache log is

<table><thead>
<th>FileStore</th>
<th>MemoryStore</th>
</thead>
<body>
<tr>
<td>
<pre>
Cache read: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache generate: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache write: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache read: comment/1 ({:expires_in=>1 day, :skip_digest=>true})
Cache generate: comment/1 ({:expires_in=>1 day, :skip_digest=>true})
Cache write: comment/1 ({:expires_in=>1 day, :skip_digest=>true})
Cache read: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache generate: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache write: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache read: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache generate: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache write: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache read: post/post-20160329215156000000000
Cache read: comment/1
Cache read: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache fetch_hit: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache read: comment/2 ({:expires_in=>1 day, :skip_digest=>true})
Cache generate: comment/2 ({:expires_in=>1 day, :skip_digest=>true})
Cache write: comment/2 ({:expires_in=>1 day, :skip_digest=>true})
Cache read: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache fetch_hit: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache read: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache fetch_hit: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache read: comment/2
Cache read: post/post-20160329215156000000000
</pre>
</td>
<td>
<pre>
Cache read: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache generate: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache write: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache read: comment/1 ({:expires_in=>1 day, :skip_digest=>true})
Cache generate: comment/1 ({:expires_in=>1 day, :skip_digest=>true})
Cache write: comment/1 ({:expires_in=>1 day, :skip_digest=>true})
Cache read: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache generate: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache write: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache read: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache generate: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache write: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache read: post/post-20160329215156000000000
Cache read: comment/1
Cache read: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache fetch_hit: post/post-20160329215156000000000 ({:expires_in=>0.1, :skip_digest=>true})
Cache read: comment/2 ({:expires_in=>1 day, :skip_digest=>true})
Cache generate: comment/2 ({:expires_in=>1 day, :skip_digest=>true})
Cache write: comment/2 ({:expires_in=>1 day, :skip_digest=>true})
Cache read: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache fetch_hit: blog/999-20160329215156000000000/272717207db26fd52c64393a49e6fc11
Cache read: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache fetch_hit: writer/author-20160329215156000000000 ({:skip_digest=>true})
Cache read: comment/2
Cache read: post/post-20160329215156000000000
</pre>
</td>
</tbody>
</table>