### PR TITLE
Require ActiveSupport's string inflections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Breaking changes:
 Features:
 Fixes:
+- [#1488](https://github.com/rails-api/active_model_serializers/pull/1488) Require ActiveSupport's string inflections (@nate00)
 Misc:
 
 ### v0.10.0.rc4 (2016/01/27 11:00 +00:00)

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -1,6 +1,7 @@
 require 'active_model'
 require 'active_support'
 require 'active_support/core_ext/object/with_options'
+require 'active_support/core_ext/string/inflections'
 module ActiveModelSerializers
   extend ActiveSupport::Autoload
   autoload :Model


### PR DESCRIPTION
Active Model Serializers depends on Active Support's string inflections but doesn't require them. Thus, requiring this gem raises an exception. To reproduce:

```ruby
require 'bundler/setup'
require 'active_model_serializers'
```

This code raises an exception:

```
/active_model_serializers/lib/active_model/serializer/adapter.rb:49:in `register': undefined method `underscore' for "Null":String (NoMethodError)
        from /active_model_serializers/lib/active_model/serializer/adapter/base.rb:7:in `inherited'
        from /active_model_serializers/lib/active_model/serializer/adapter/null.rb:4:in `<module:Adapter>'
        from /active_model_serializers/lib/active_model/serializer/adapter/null.rb:3:in `<class:Serializer>'
        from /active_model_serializers/lib/active_model/serializer/adapter/null.rb:2:in `<module:ActiveModel>'
        from /active_model_serializers/lib/active_model/serializer/adapter/null.rb:1:in `<top (required)>'
        from /active_model_serializers/lib/active_model/serializer/adapter.rb:85:in `require'
        from /active_model_serializers/lib/active_model/serializer/adapter.rb:85:in `<module:Adapter>'
        from /active_model_serializers/lib/active_model/serializer/adapter.rb:3:in `<class:Serializer>'
        from /active_model_serializers/lib/active_model/serializer/adapter.rb:2:in `<module:ActiveModel>'
        from /active_model_serializers/lib/active_model/serializer/adapter.rb:1:in `<top (required)>'
        from /active_model_serializers/lib/active_model/serializer.rb:24:in `require'
        from /active_model_serializers/lib/active_model/serializer.rb:24:in `<class:Serializer>'
        from /active_model_serializers/lib/active_model/serializer.rb:17:in `<module:ActiveModel>'
        from /active_model_serializers/lib/active_model/serializer.rb:16:in `<top (required)>'
        from /active_model_serializers/lib/active_model_serializers.rb:20:in `require'
        from /active_model_serializers/lib/active_model_serializers.rb:20:in `<module:ActiveModelSerializers>'
        from /active_model_serializers/lib/active_model_serializers.rb:4:in `<top (required)>'
        from test.rb:2:in `require'
        from test.rb:2:in `<main>'
```