### PR TITLE
Changed the yardoc link in README.md for documentation to v.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 ## Documentation
 
-- [0.10 (master) Documentation](http://www.rubydoc.info/github/rails-api/active_model_serializers/v0.10.0.rc4)
-  - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/github/rails-api/active_model_serializers)
+- [0.10 (master) Documentation](https://github.com/rails-api/active_model_serializers/tree/master)
+  - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/github/rails-api/active_model_serializers/v0.10.0.rc4)
   - [Guides](docs)
-- [0.9 (0-9-stable) Documentation](http://www.rubydoc.info/github/rails-api/active_model_serializers/0-9-stable)
-- [0.8 (0-8-stable) Documentation](http://www.rubydoc.info/github/rails-api/active_model_serializers/0-8-stable)
+- [0.9 (0-9-stable) Documentation](https://github.com/rails-api/active_model_serializers/tree/0-9-stable)
+- [0.8 (0-8-stable) Documentation](https://github.com/rails-api/active_model_serializers/tree/0-8-stable)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 ## Documentation
 
-- [0.10 (master) Documentation](https://github.com/rails-api/active_model_serializers/tree/master)
+- [0.10 (master) Documentation](http://www.rubydoc.info/github/rails-api/active_model_serializers/v0.10.0.rc4)
   - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/github/rails-api/active_model_serializers)
   - [Guides](docs)
-- [0.9 (0-9-stable) Documentation](https://github.com/rails-api/active_model_serializers/tree/0-9-stable)
-- [0.8 (0-8-stable) Documentation](https://github.com/rails-api/active_model_serializers/tree/0-8-stable)
+- [0.9 (0-9-stable) Documentation](http://www.rubydoc.info/github/rails-api/active_model_serializers/0-9-stable)
+- [0.8 (0-8-stable) Documentation](http://www.rubydoc.info/github/rails-api/active_model_serializers/0-8-stable)
 
 ## About
 


### PR DESCRIPTION
Yard doc links in readme are changed as discussed here in this [PR](https://github.com/rails-api/active_model_serializers/pull/1490#issuecomment-178670201).
Now they redirect to rubydoc site as they were supposed to.
@bf4