### PR TITLE
[0.8-stable] additional documentation for POROs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+* Add documentation with example to `README` for POROs and alternative ORMs
+
 # VERSION 0.8.1
 
 * Fix bug whereby a serializer using 'options' would blow up.

--- a/README.md
+++ b/README.md
@@ -45,17 +45,34 @@ the serializer generator:
 $ rails g serializer post
 ```
 
-### Support for PORO's and other ORM's.
+### Support for POROs and other ORMs.
 
 Currently `ActiveModel::Serializers` adds serialization support to all models
-that descend from `ActiveRecord` or include `Mongoid::Document`. If you are
-using another ORM, or if you are using objects that are `ActiveModel`
-compliant but do not descend from `ActiveRecord` or include
-`Mongoid::Document`, you must add an include statement for
-`ActiveModel::SerializerSupport` to make models serializable. If you
-also want to make collections serializable, you should include
+that descend from `ActiveRecord` or include `Mongoid::Document`. If you are:
+
+- using another ORM, or
+- using objects that are `ActiveModel` compliant but do not descend from
+`ActiveRecord` *or* include `Mongoid::Document`
+
+You must add an include statement for `ActiveModel::SerializerSupport` to
+make models serializable. 
+
+If you also want to make collections serializable, you should include
 `ActiveModel::ArraySerializerSupport` into your ORM's
 relation/criteria class.
+
+Example model (`app/models/avatar.rb`):
+
+```ruby
+class Avatar
+  include ActiveModel::SerializerSupport
+  # etc, etc
+end
+```
+
+If your classes follow the naming conventions prescribed by `ActiveModel`,
+you don't need to do anything different in your controller to render the
+serialized json.
 
 # ActiveModel::Serializer
 


### PR DESCRIPTION
hey pals! :wave: 

i know, i know, it's not documentation for master :disappointed:, but still, it's documentation! :smile:

it's mostly clarification on when you need to take additional steps to use AM:S with POROs/alternative ORMs, along with a small example to show *how* to implement the required steps to use it. (ok, i also removed the apostrophes, you caught me)

well, you can just read it on the next tab :relaxed: 

let me know if you'd like any changes or adjustments here and i'm happy to do so!