### PR TITLE
Update SimpleCov; remove compatibility patch

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -19,7 +19,6 @@ ENV['FULL_BUILD'] ||= ENV['CI']
 # rubocop:enable Style/DoubleNegation
 
 ## CONFIGURE SIMPLECOV
-SimpleCov.pid = $$ # In case there's any forking
 
 SimpleCov.profiles.define 'app' do
   coverage_dir 'coverage'

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ group :test do
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
 
   gem 'codeclimate-test-reporter', require: false
-  gem 'simplecov', '~> 0.10', require: false, group: :development
 end
 
 group :development, :test do

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'will_paginate', '~> 3.0', '>= 3.0.7'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'simplecov', '~> 0.11'
   spec.add_development_dependency 'timecop', '~> 0.7'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'grape', ['>= 0.13', '< 1.0']

--- a/test/support/simplecov.rb
+++ b/test/support/simplecov.rb
@@ -1,6 +1,0 @@
-# https://github.com/colszowka/simplecov/pull/400
-# https://github.com/ruby/ruby/blob/trunk/lib/English.rb
-unless defined?(English)
-  # The exception object passed to +raise+.
-  alias $ERROR_INFO $! # rubocop:disable Style/SpecialGlobalVars
-end


### PR DESCRIPTION
Also, SimpleCov.start already called
   SimpleCov.pid = Process.pid
So, no need for that