### PR TITLE
Fix bug displaying nil for relationship link href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Features:
 - [#1340](https://github.com/rails-api/active_model_serializers/pull/1340) Add support for resource-level meta. (@beauby)
 
 Fixes:
+- [#1516](https://github.com/rails-api/active_model_serializers/pull/1501) No longer return a nil href when only
+  adding meta to a relationship link. (@groyoh)
 - [#1458](https://github.com/rails-api/active_model_serializers/pull/1458) Preserve the serializer
   type when fragment caching. (@bdmac)
 - [#1477](https://github.com/rails-api/active_model_serializers/pull/1477) Fix `fragment_cached?`

--- a/lib/active_model/serializer/adapter/json_api/link.rb
+++ b/lib/active_model/serializer/adapter/json_api/link.rb
@@ -28,8 +28,9 @@ module ActiveModel
           def as_json
             return @value if @value
 
-            hash = { href: @href }
-            hash.merge!(meta: @meta) if @meta
+            hash = {}
+            hash[:href] = @href if @href
+            hash[:meta] = @meta if @meta
 
             hash
           end


### PR DESCRIPTION
Follow up to https://github.com/rails-api/active_model_serializers/pull/1504#discussion_r52518656. When using the relationship link with a block, calling "meta" without "href", e.g.

```ruby
has_one :bio do
  link :related do
    meta id: 1
  end
end
# => { links: { posts: { related: { href: nil, meta: { id: 1 } }  } } }.
```
results in in a nil "href".
According to JSONAPI, we should be able to use meta without href (http://jsonapi.org/format/#document-links).

Depending on the ouput from #1514, this PR might need some follow up.