### PR TITLE
Fix deprecation warning

### DIFF
--- a/test/adapter/json_api/api_objects/relationship_test.rb
+++ b/test/adapter/json_api/api_objects/relationship_test.rb
@@ -37,7 +37,7 @@ module ActiveModel
 
             def test_relationship_with_data_array
               posts = [Post.new(id: 1), Post.new(id: 2)]
-              @serializer = ActiveModel::Serializer::ArraySerializer.new(posts)
+              @serializer = ActiveModel::Serializer::CollectionSerializer.new(posts)
               @author.posts = posts
               @author.blog = nil
               expected = {


### PR DESCRIPTION
In https://github.com/rails-api/active_model_serializers/commit/2c4193851b3a2e3120cbb3c61fa45577bd5c8ed7 I used `ArraySerializer` instead of `CollectionSerializer` causing a deprecation message when running the specs. This PR change the `ArraySerializer` back to `CollectionSerializer`.