### PR TITLE
Fix bug happening when using fields and include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Features:
 - [#1340](https://github.com/rails-api/active_model_serializers/pull/1340) Add support for resource-level meta. (@beauby)
 
 Fixes:
+- [#1528](https://github.com/rails-api/active_model_serializers/pull/1528) Relationships are no longer included
+  in the "included" array if they are excluded by the :fields option. (@groyoh)
 - [#1516](https://github.com/rails-api/active_model_serializers/pull/1501) No longer return a nil href when only
   adding meta to a relationship link. (@groyoh)
 - [#1458](https://github.com/rails-api/active_model_serializers/pull/1458) Preserve the serializer

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -113,7 +113,10 @@ module ActiveModel
         end
 
         def process_relationships(serializer, include_tree)
+          resource_identifier    = ApiObjects::ResourceIdentifier.new(serializer).as_json
+          requested_associations = fieldset.fields_for(resource_identifier[:type])
           serializer.associations(include_tree).each do |association|
+            next unless requested_associations.nil? || requested_associations.include?(association.name)
             process_relationship(association.serializer, include_tree[association.key])
           end
         end

--- a/test/adapter/json_api/fields_test.rb
+++ b/test/adapter/json_api/fields_test.rb
@@ -62,7 +62,7 @@ module ActiveModel
           end
 
           def test_fields_included
-            fields = { posts: [:author], comments: [:body] }
+            fields = { posts: [:author, :comments], comments: [:body] }
             hash = serializable(@post, adapter: :json_api, fields: fields, include: 'comments').serializable_hash
             expected = [
               {

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -208,21 +208,21 @@ module ActiveModel
             assert_equal expected, alt_adapter.serializable_hash[:included]
           end
 
-          def test_underscore_model_namespace_for_linked_resource_type
-            spammy_post = Post.new(id: 123)
-            spammy_post.related = [Spam::UnrelatedLink.new(id: 456)]
-            serializer = SpammyPostSerializer.new(spammy_post)
-            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
-            relationships = adapter.serializable_hash[:data][:relationships]
+          def test_include_with_fieldset
+            serializer = AuthorSerializer.new(@author1)
+            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(
+              serializer,
+              include: [:posts],
+              fields: { authors: [:name] }
+            )
             expected = {
-              related: {
-                data: [{
-                  type: 'spam_unrelated_links',
-                  id: '456'
-                }]
+              data: {
+                id: '1',
+                type: 'authors',
+                attributes: { name: 'Steve K.' }
               }
             }
-            assert_equal expected, relationships
+            assert_equal(expected, adapter.as_json)
           end
 
           def test_multiple_references_to_same_resource


### PR DESCRIPTION
See #1520. When the :fields and :include options were used to filter out
and include the same attribute, the attribute would not appear in the
relationship but would still be included in the "included" array.