### PR TITLE
Add :except as an option to Adapter::Attributes

### DIFF
--- a/docs/general/adapters.md
+++ b/docs/general/adapters.md
@@ -180,6 +180,19 @@ It could be combined, like above, with other paths in any combination desired.
   render json: @posts, include: 'author.comments.**'
 ```
 
+#### Excluded
+
+Sometimes you want to omit a specific field or association during serialization.
+You can use the `except` option for this:
+
+```ruby
+  render json: @posts, include: '*', except: :author
+```
+
+This is particularly helpful if you are using the recursive include wildstar
+(`**`), as it can lead to infinite recursion when you have associations that
+can be traversed in a cycle.
+
 ##### Security Considerations
 
 Since the included options may come from the query params (i.e. user-controller):

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -64,6 +64,7 @@ Where:
   - `unless:`
   - `virtual_value:`
   - `polymorphic:` defines if polymorphic relation type should be nested in serialized association.
+  - `except`: Specify attributes or associations to be ommitted from serialization
 - optional: `&block` is a context that returns the association's attributes.
   - prevents `association_name` method from being called.
   - return value of block is used as the association value.

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -14,10 +14,12 @@ module ActiveModel
 
         # Return the +attributes+ of +object+ as presented
         # by the serializer.
-        def attributes(requested_attrs = nil, reload = false)
+        def attributes(options = {}, reload = false)
+          requested_attrs = options[:only]
+          excepts = Array(options[:except])
           @attributes = nil if reload
           @attributes ||= self.class._attributes_data.each_with_object({}) do |(key, attr), hash|
-            next if attr.excluded?(self)
+            next if attr.excluded?(self) || excepts.include?(key)
             next unless requested_attrs.nil? || requested_attrs.include?(key)
             hash[key] = attr.value(self)
           end

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -33,7 +33,9 @@ module ActiveModelSerializers
 
       def resource_relationships(options)
         relationships = {}
+        excepts = Array(options[:except])
         serializer.associations(@include_tree).each do |association|
+          next if excepts.include?(association.key)
           relationships[association.key] ||= relationship_value_for(association, options)
         end
 
@@ -45,7 +47,8 @@ module ActiveModelSerializers
         return unless association.serializer && association.serializer.object
 
         opts = instance_options.merge(include: @include_tree[association.key])
-        relationship_value = Attributes.new(association.serializer, opts).serializable_hash(options)
+        hash_opts = options.merge(except: association.options[:except])
+        relationship_value = Attributes.new(association.serializer, opts).serializable_hash(hash_opts)
 
         if association.options[:polymorphic] && relationship_value
           polymorphic_type = association.serializer.object.class.name.underscore
@@ -63,12 +66,14 @@ module ActiveModelSerializers
       end
 
       def resource_object_for(options)
+        fields = options.fetch(:fields, {})
+        fields = fields.merge(except: options[:except]) if options[:except]
         if serializer.class.cache_enabled?
           @cached_attributes.fetch(serializer.cache_key(self)) do
-            serializer.cached_fields(options[:fields], self)
+            serializer.cached_fields(fields, self)
           end
         else
-          serializer.cached_fields(options[:fields], self)
+          serializer.cached_fields(fields, self)
         end
       end
     end

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -285,7 +285,7 @@ module ActiveModelSerializers
       #     foo: 'bar'
       #   }
       def attributes_for(serializer, fields)
-        serializer.attributes(fields).except(:id)
+        serializer.attributes(only: fields, except: :id)
       end
 
       # {http://jsonapi.org/format/#document-resource-objects Document Resource Objects}

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -140,6 +140,17 @@ module ActionController
 
           render json: like
         end
+
+        def render_object_except
+          blog = Blog.new(id: 1, name: 'Blogariffic')
+          blog.articles = [
+            Post.new(id: 1, title: 'Hello', body: 'world'),
+            Post.new(id: 2, title: 'Moby Dick', body: 'Call me Ishmael.')
+          ]
+          blog.writer = Author.new(id: 1, name: 'Joao Moura.')
+
+          render json: blog, except: [:articles, :name]
+        end
       end
 
       tests ImplicitSerializationTestController
@@ -463,6 +474,14 @@ module ActionController
         assert_equal 'render.active_model_serializers', @name
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+
+      def test_render_object_except
+        get :render_object_except
+        assert_equal(
+          { id: 1, writer: { id: 1, name: 'Joao Moura.' } }.to_json,
+          @response.body
+        )
       end
     end
   end


### PR DESCRIPTION
This supports passing `except:`  as an option to `render` or as an option to `has_many`, etc. declrations. This is useful when avoiding circular includes.

The `except` name was chosen to mirror behavior found in the 0.8x branch (which will help our upgrade path), and partly addresses #1333.