### PR TITLE
Deserialize empty hasmany

### DIFF
--- a/lib/active_model/serializer/adapter/json_api/deserialization.rb
+++ b/lib/active_model/serializer/adapter/json_api/deserialization.rb
@@ -180,12 +180,13 @@ module ActiveModel
           #
           # @api private
           def parse_relationship(assoc_name, assoc_data, options)
-            prefix_key = field_key(assoc_name, options).to_s.singularize
+            prefix_key = field_key(assoc_name, options).to_s
             hash =
-              if assoc_data.is_a?(Array)
-                { "#{prefix_key}_ids".to_sym => assoc_data.map { |ri| ri['id'] } }
+              if prefix_key == prefix_key.pluralize
+                assoc_data = [] unless assoc_data
+                { "#{prefix_key.singularize}_ids".to_sym => assoc_data.map { |ri| ri['id'] } }
               else
-                { "#{prefix_key}_id".to_sym => assoc_data ? assoc_data['id'] : nil }
+                { "#{prefix_key.singularize}_id".to_sym => assoc_data ? assoc_data['id'] : nil }
               end
 
             polymorphic = (options[:polymorphic] || []).include?(assoc_name.to_sym)

--- a/test/action_controller/json_api/deserialization_test.rb
+++ b/test/action_controller/json_api/deserialization_test.rb
@@ -34,6 +34,9 @@ module ActionController
                     { 'type' => 'comments', 'id' => '1' },
                     { 'type' => 'comments', 'id' => '2' }
                   ]
+                },
+                'subscribers' => {
+                  'data' => nil
                 }
               }
             }
@@ -48,7 +51,8 @@ module ActionController
             'src' => 'http://example.com/images/productivity.png',
             'author_id' => nil,
             'photographer_id' => '9',
-            'comment_ids' => %w(1 2)
+            'comment_ids' => %w(1 2),
+            'subscriber_ids' => []
           }
 
           assert_equal(expected, response)


### PR DESCRIPTION
In < Rails 5, all incoming params with [empty arrays are converted to `nil`](https://github.com/rails/rails/pull/16924). When a JSONAPI `has_many` relationships payload is empty (which is very common for Ember Data `POST`), the deserializer is given `nil` as the associated data, therefore assuming that the relationship is `has_one` or `belongs_to` and pluralizes the key incorrectly.

https://github.com/rails-api/active_model_serializers/issues/1532