### PR TITLE
Fix regression where '?' is not removed from boolean syntactic sugar on attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Features:
 - [#1340](https://github.com/rails-api/active_model_serializers/pull/1340) Add support for resource-level meta. (@beauby)
 
 Fixes:
+- [#1563](https://github.com/rails-api/active_model_serializers/pull/1563) Remove '?' character from attribute keys' suffix. (@NullVoxPopuli)
 - [#1570](https://github.com/rails-api/active_model_serializers/pull/1570) Fixed pagination issue with last page size. (@bmorrall)
 - [#1516](https://github.com/rails-api/active_model_serializers/pull/1516) No longer return a nil href when only
   adding meta to a relationship link. (@groyoh)

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -55,7 +55,15 @@ module ActiveModel
         #     end
         def attribute(attr, options = {}, &block)
           key = options.fetch(:key, attr)
+          key = _remove_question_mark(key)
           _attributes_data[key] = Attribute.new(attr, options, block)
+        end
+
+        # @api private
+        # replace ? at the end of an attribute,
+        # as JSON API disallows the use of ? at the end of keys.
+        def _remove_question_mark(key)
+          key.to_s.sub(/\?\z/, '').to_sym
         end
 
         # @api private

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveModel
   class Serializer
     module Caching

--- a/lib/active_model/serializer/version.rb
+++ b/lib/active_model/serializer/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveModel
   class Serializer
     VERSION = '0.10.0.rc4'.freeze

--- a/lib/active_model_serializers/adapter.rb
+++ b/lib/active_model_serializers/adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveModelSerializers
   module Adapter
     UnknownAdapterError = Class.new(ArgumentError)

--- a/lib/active_model_serializers/adapter/base.rb
+++ b/lib/active_model_serializers/adapter/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveModelSerializers
   module Adapter
     class Base

--- a/lib/active_model_serializers/json_pointer.rb
+++ b/lib/active_model_serializers/json_pointer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveModelSerializers
   module JsonPointer
     module_function

--- a/lib/active_model_serializers/logging.rb
+++ b/lib/active_model_serializers/logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # ActiveModelSerializers::Logging
 #

--- a/test/action_controller/json_api/pagination_test.rb
+++ b/test/action_controller/json_api/pagination_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'will_paginate/array'
 require 'kaminari'

--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -27,7 +27,7 @@ class DefaultScopeNameTest < ActionController::TestCase
 
   def test_default_scope_name
     get :render_new_user
-    assert_equal '{"data":{"id":"1","type":"users","attributes":{"admin?":false}}}', @response.body
+    assert_equal '{"data":{"id":"1","type":"users","attributes":{"admin":false}}}', @response.body
   end
 end
 
@@ -58,6 +58,6 @@ class SerializationScopeNameTest < ActionController::TestCase
 
   def test_override_scope_name_with_controller
     get :render_new_user
-    assert_equal '{"data":{"id":"1","type":"users","attributes":{"admin?":true}}}', @response.body
+    assert_equal '{"data":{"id":"1","type":"users","attributes":{"admin":true}}}', @response.body
   end
 end

--- a/test/active_model_serializers/adapter_for_test.rb
+++ b/test/active_model_serializers/adapter_for_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveModelSerializers
   class AdapterForTest < ActiveSupport::TestCase
     UnknownAdapterError = ::ActiveModelSerializers::Adapter::UnknownAdapterError

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'will_paginate/array'
 require 'kaminari'

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -81,6 +81,17 @@ module ActiveModel
         assert_equal('custom', hash[:blog][:id])
       end
 
+      def test_id_with_question_mark_has_question_mark_removed
+        serializer = Class.new(ActiveModel::Serializer) do
+          attribute :boolean?
+        end
+
+        blog = Blog.new(boolean?: true)
+        hash = ActiveModel::SerializableResource.new(blog, adapter: :json, serializer: serializer).serializable_hash
+
+        assert_equal(true, hash[:blog][:boolean])
+      end
+
       PostWithVirtualAttribute = Class.new(::Model)
       class PostWithVirtualAttributeSerializer < ActiveModel::Serializer
         attribute :name do


### PR DESCRIPTION
#### Purpose

Pre 0.10, `?` was removed from attributes.

#### Changes

Added Test

#### Caveats

What about methods with `?` -- the ones that aren't just syntactic sugar?
This may result in checking if the object responds_to a method without the question mark -- which may lead to unexpected behavior.

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/issues/605



