### PR TITLE
Add 0.9 rewrite to changelog, document unreleased changes in 0.8 at the beginning of the rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,8 @@ Features:
 
 * Serializers default namespace can be set in `default_serializer_options` and inherited by associations.
 
+* [Beginning of rewrite: c65d387705ec534db171712671ba7fcda4f49f68](https://github.com/rails-api/active_model_serializers/commit/c65d387705ec534db171712671ba7fcda4f49f68)
+
 ## 0.08.x
 
 ### v0.8.3 (2014/12/10 14:45 +00:00)


### PR DESCRIPTION
Demonstrates that there was unreleased code in 0-8 that does not
exist on 0-8-stable https://github.com/rails-api/active_model_serializers/blob/919bb3840107e8176a65d90c0af8ec1e02cef683/CHANGELOG.md

specifically: https://github.com/rails-api/active_model_serializers/compare/731528e1f6ac91081f94e25f71ab5ef07cd8c698...919bb3840107e8176a65d90c0af8ec1e02cef683

```
git branch --contains 919bb3840107e8176a65d90c0af8ec1e02cef683
  0-9-stable
  fractaloop-merge-multiple-nested-associations
```