### PR TITLE
Fixed pagination issue with last page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Features:
 - [#1340](https://github.com/rails-api/active_model_serializers/pull/1340) Add support for resource-level meta. (@beauby)
 
 Fixes:
+- [#1570](https://github.com/rails-api/active_model_serializers/pull/1570) Fixed pagination issue with last page size. (@bmorrall)
 - [#1516](https://github.com/rails-api/active_model_serializers/pull/1516) No longer return a nil href when only
   adding meta to a relationship link. (@groyoh)
 - [#1458](https://github.com/rails-api/active_model_serializers/pull/1458) Preserve the serializer

--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -12,8 +12,9 @@ module ActiveModelSerializers
         end
 
         def serializable_hash(options = {})
+          per_page = collection.try(:per_page) || collection.try(:limit_value) || collection.size
           pages_from.each_with_object({}) do |(key, value), hash|
-            params = query_parameters.merge(page: { number: value, size: collection.size }).to_query
+            params = query_parameters.merge(page: { number: value, size: per_page }).to_query
 
             hash[key] = "#{url(options)}?#{params}"
           end


### PR DESCRIPTION
#### Purpose
When using pagination with the `json_api` adaptor, the `page[size]` parameter is incorrectly set to the number of items on the current page, instead of the number of items per page.

This is compounded by 'WillPaginate' using `#per_page` and 'Kaminari' using `#limit_value`; neither of which return the expected value from the previously used `#size` method.

#### Changes
Changed `ActiveModelSerializers::Adapter::JsonApi::PaginationLinks` to attempt to use, `#per_page`, then `#limit_value`, falling back to `#size` to determine the number of items per page.

#### Caveats
Might work differently with other third party pagination gems, but should work fine for 'WillPaginate' and 'Kaminari'/

#### Related GitHub issues
This might be referenced in https://github.com/rails-api/active_model_serializers/pull/1443

#### Additional helpful information
Currently using this in an App in development, seems to be working fine.


