### PR TITLE
Pin rake to < 11.0

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -56,4 +56,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'grape', ['>= 0.13', '< 1.0']
   spec.add_development_dependency 'json_schema'
+  # https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11/35893625#35893625
+  spec.add_development_dependency 'rake', '< 11.0'
 end


### PR DESCRIPTION
#### Purpose

Pin rake to < 11.0. The `last_comment` method was removed from rake and breaks the test suite.

#### Changes

Pin rake to < 11.0

#### Additional helpful information

https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11/35893625#35893625