### PR TITLE
Never mutate controller options

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -26,13 +26,13 @@ module ActionController
         respond_to?(_serialization_scope, true)
     end
 
-    def get_serializer(resource, serializer_options = {})
+    def get_serializer(resource, serialization_options = {})
       if !use_adapter?
         warn 'ActionController::Serialization#use_adapter? has been removed. '\
           "Please pass 'adapter: false' or see ActiveSupport::SerializableResource.new"
-        serializer_options[:adapter] = false
+        serialization_options[:adapter] = false
       end
-      serializable_resource = ActiveModel::SerializableResource.new(resource, serializer_options)
+      serializable_resource = ActiveModel::SerializableResource.new(resource, serialization_options)
       if serializable_resource.serializer?
         serializable_resource.serialization_scope ||= serialization_scope
         serializable_resource.serialization_scope_name = _serialization_scope
@@ -57,11 +57,14 @@ module ActionController
     [:_render_option_json, :_render_with_renderer_json].each do |renderer_method|
       define_method renderer_method do |resource, options|
         options.freeze
-        serializer_options = options.deep_dup
-        serializer_options.fetch(:serialization_context) do
-          serializer_options[:serialization_context] = ActiveModelSerializers::SerializationContext.new(request, serializer_options)
+        serialization_options = options.deep_dup
+        if options.key?(:serializer)
+          serialization_options[:serializer] = options[:serializer]
         end
-        serializable_resource = get_serializer(resource, serializer_options)
+        unless serialization_options.key?(:serialization_context)
+          serialization_options[:serialization_context] = ActiveModelSerializers::SerializationContext.new(request, serialization_options)
+        end
+        serializable_resource = get_serializer(resource, serialization_options)
         super(serializable_resource, options)
       end
     end

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -2,7 +2,7 @@ require 'set'
 require 'active_model_serializers/adapter'
 module ActiveModel
   class SerializableResource
-    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links])
+    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links, :serialization_context])
     include ActiveModelSerializers::Logging
 
     delegate :serializable_hash, :as_json, :to_json, to: :adapter

--- a/lib/active_model_serializers/adapter/json.rb
+++ b/lib/active_model_serializers/adapter/json.rb
@@ -4,7 +4,7 @@ module ActiveModelSerializers
       def serializable_hash(options = nil)
         options ||= {}
         serialized_hash = { root => Attributes.new(serializer, instance_options).serializable_hash(options) }
-        transform_key_casing!(serialized_hash, options[:serialization_context])
+        transform_key_casing!(serialized_hash, instance_options[:serialization_context])
       end
     end
   end

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -128,7 +128,7 @@ module ActiveModelSerializers
 
         if is_collection && serializer.paginated?
           hash[:links] ||= {}
-          hash[:links].update(pagination_links_for(serializer, options))
+          hash[:links].update(pagination_links_for(serializer))
         end
 
         hash
@@ -498,8 +498,8 @@ module ActiveModelSerializers
       #   end
       # prs:
       #   https://github.com/rails-api/active_model_serializers/pull/1041
-      def pagination_links_for(serializer, options)
-        PaginationLinks.new(serializer.object, options[:serialization_context]).serializable_hash(options)
+      def pagination_links_for(serializer)
+        PaginationLinks.new(serializer.object, instance_options[:serialization_context]).as_json(instance_options)
       end
 
       # {http://jsonapi.org/format/#document-meta Docment Meta}

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # {http://jsonapi.org/format/ JSON API specification}
 # rubocop:disable Style/AsciiComments
 # TODO: implement!
@@ -43,14 +44,13 @@ module ActiveModelSerializers
 
       # {http://jsonapi.org/format/#crud Requests are transactional, i.e. success or failure}
       # {http://jsonapi.org/format/#document-top-level data and errors MUST NOT coexist in the same document.}
-      def serializable_hash(options = nil)
-        options ||= {}
+      def serializable_hash(_options = nil)
         document = if serializer.success?
-                     success_document(options)
+                     success_document
                    else
                      failure_document
                    end
-        transform_key_casing!(document, options[:serialization_context])
+        transform_key_casing!(document, instance_options[:serialization_context])
       end
 
       # {http://jsonapi.org/format/#document-top-level Primary data}
@@ -68,7 +68,7 @@ module ActiveModelSerializers
       #    links: toplevel_links,
       #    jsonapi: toplevel_jsonapi
       #  }.reject! {|_,v| v.nil? }
-      def success_document(options)
+      def success_document
         is_collection = serializer.respond_to?(:each)
         serializers = is_collection ? serializer : [serializer]
         primary_data, included = resource_objects_for(serializers)

--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -11,7 +11,7 @@ module ActiveModelSerializers
           @context = context
         end
 
-        def serializable_hash(options = {})
+        def as_json(options = {})
           per_page = collection.try(:per_page) || collection.try(:limit_value) || collection.size
           pages_from.each_with_object({}) do |(key, value), hash|
             params = query_parameters.merge(page: { number: value, size: per_page }).to_query

--- a/test/adapter/json/key_case_test.rb
+++ b/test/adapter/json/key_case_test.rb
@@ -21,21 +21,19 @@ module ActiveModelSerializers
         def setup
           ActionController::Base.cache_store.clear
           @blog = Blog.new(id: 1, name: 'My Blog!!', special_attribute: 'neat')
-          serializer = CustomBlogSerializer.new(@blog)
-          @adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
         end
 
         def test_key_transform_default
           mock_request
           assert_equal({
             blog: { id: 1, special_attribute: 'neat', articles: nil }
-          }, @adapter.serializable_hash(@options))
+          }, adapter.serializable_hash)
         end
 
         def test_key_transform_global_config
           mock_request
           result = with_config(key_transform: :camel_lower) do
-            @adapter.serializable_hash(@options)
+            adapter.serializable_hash
           end
           assert_equal({
             blog: { id: 1, specialAttribute: 'neat', articles: nil }
@@ -45,7 +43,7 @@ module ActiveModelSerializers
         def test_key_transform_serialization_ctx_overrides_global_config
           mock_request(:camel)
           result = with_config(key_transform: :camel_lower) do
-            @adapter.serializable_hash(@options)
+            adapter.serializable_hash
           end
           assert_equal({
             Blog: { Id: 1, SpecialAttribute: 'neat', Articles: nil }
@@ -56,7 +54,7 @@ module ActiveModelSerializers
           mock_request(:blam)
           result = nil
           assert_raises NoMethodError do
-            result = @adapter.serializable_hash(@options)
+            result = adapter.serializable_hash
           end
         end
 
@@ -64,28 +62,33 @@ module ActiveModelSerializers
           mock_request(:dashed)
           assert_equal({
             blog: { id: 1, :"special-attribute" => 'neat', articles: nil }
-          }, @adapter.serializable_hash(@options))
+          }, adapter.serializable_hash)
         end
 
         def test_key_transform_unaltered
           mock_request(:unaltered)
           assert_equal({
             blog: { id: 1, special_attribute: 'neat', articles: nil }
-          }, @adapter.serializable_hash(@options))
+          }, adapter.serializable_hash)
         end
 
         def test_key_transform_camel
           mock_request(:camel)
           assert_equal({
             Blog: { Id: 1, SpecialAttribute: 'neat', Articles: nil }
-          }, @adapter.serializable_hash(@options))
+          }, adapter.serializable_hash)
         end
 
         def test_key_transform_camel_lower
           mock_request(:camel_lower)
           assert_equal({
             blog: { id: 1, specialAttribute: 'neat', articles: nil }
-          }, @adapter.serializable_hash(@options))
+          }, adapter.serializable_hash)
+        end
+
+        def adapter
+          serializer = CustomBlogSerializer.new(@blog)
+          ActiveModelSerializers::Adapter::Json.new(serializer, @options || {})
         end
       end
     end

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -26,12 +26,18 @@ module ActiveModelSerializers
           context.expect(:request_url, original_url)
           context.expect(:query_parameters, query_parameters)
           context.expect(:key_transform, nil)
-          @options = {}
-          @options[:serialization_context] = context
+          @serializer_options = {
+            serialization_context: context,
+            adapter: :json_api
+          }
         end
 
         def load_adapter(paginated_collection, options = {})
-          options = options.merge(adapter: :json_api)
+          if options
+            options.merge!(@serializer_options)
+          else
+            options = @serializer_options
+          end
           ActiveModel::SerializableResource.new(paginated_collection, options)
         end
 
@@ -106,14 +112,14 @@ module ActiveModelSerializers
           adapter = load_adapter(using_kaminari)
 
           mock_request
-          assert_equal expected_response_with_pagination_links, adapter.serializable_hash(@options)
+          assert_equal expected_response_with_pagination_links, adapter.serializable_hash
         end
 
         def test_pagination_links_using_will_paginate
           adapter = load_adapter(using_will_paginate)
 
           mock_request
-          assert_equal expected_response_with_pagination_links, adapter.serializable_hash(@options)
+          assert_equal expected_response_with_pagination_links, adapter.serializable_hash
         end
 
         def test_pagination_links_with_additional_params
@@ -121,7 +127,7 @@ module ActiveModelSerializers
 
           mock_request({ test: 'test' })
           assert_equal expected_response_with_pagination_links_and_additional_params,
-            adapter.serializable_hash(@options)
+            adapter.serializable_hash
         end
 
         def test_last_page_pagination_links_using_kaminari


### PR DESCRIPTION
#### Purpose

Pagination links incorrectly passing options to `serializable_hash`.

Only the renderer should be passing options to `serializable_hash`.

It's only working now because we are mutating the controller options which it
later passes to `to_json` which calls `serializable_hash` on the adapter.

This PR ensures that we do not mutate controller options, which
exposes failures *only* in the pagination links.

 #### Changes

1. Make a (deep) dup of rendering options to pass to SerializableResource
1. Freezes rendering options (might be undesirable)

 #### Caveats

- freezing rendering options might be undesirable in general, and probably is
not necessary for this fix.

 #### Related GitHub issues

AMS 0.10.0.rc4 / master

https://github.com/rails-api/active_model_serializers/blob/6b4c8df6fb6bc142ee6a74da51bb26c42a025b3c/lib/active_model_serializers/adapter/json_api.rb

```ruby
def pagination_links_for(serializer, options)
  PaginationLinks.new(serializer.object, options[:serialization_context]).serializable_hash(options)
end
```

Those options come from the call to `adapter.serializable_hash(options)`
which is wrong.  They should be passed into the Adapter initializer.