### PR TITLE
Fix how we set JRuby env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ rvm:
 jdk:
   - oraclejdk8
 
-before_install:
-  - '[ "$JRUBY_OPTS" != "" ] && export JRUBY_OPTS="--dev -Xcli.debug=true --debug"'
-
 install: bundle install --path=vendor/bundle --retry=3 --jobs=3
 cache:
   directories:
@@ -26,10 +23,13 @@ script:
   - bundle exec rake ci
 
 env:
-  - "RAILS_VERSION=4.0"
-  - "RAILS_VERSION=4.1"
-  - "RAILS_VERSION=4.2"
-  - "RAILS_VERSION=master"
+  global:
+    - "JRUBY_OPTS='--dev -J-Xmx1024M'"
+  matrix:
+    - "RAILS_VERSION=4.0"
+    - "RAILS_VERSION=4.1"
+    - "RAILS_VERSION=4.2"
+    - "RAILS_VERSION=master"
 
 matrix:
   exclude:


### PR DESCRIPTION
Fixes e.g. https://travis-ci.org/rails-api/active_model_serializers/jobs/114970573


```plain
Setting environment variables from .travis.yml
$ export RAILS_VERSION=4.1
$ jdk_switcher use oraclejdk8
Switching to Oracle JDK8 (java-8-oracle), JAVA_HOME will be set to /usr/lib/jvm/java-8-oracle
rvm
100.97s$ rvm use jruby-9.0.4.0 --install --binary --fuzzy
Unknown ruby string (do not know how to handle): jruby-9.0.4.0.
Unknown ruby string (do not know how to handle): jruby-9.0.4.0.
jruby-9.0.4.0 is not installed - installing.
Unknown ruby string (do not know how to handle): jruby-9.0.4.0.
Unknown ruby string (do not know how to handle): jruby-9.0.4.0.
Searching for binary rubies, this might take some time.
Unknown ruby string (do not know how to handle): jruby-9.0.4.0.
Unknown ruby string (do not know how to handle): jruby-9.0.4.0.
Found remote file https://s3.amazonaws.com/jruby.org/downloads/9.0.4.0/jruby-bin-9.0.4.0.tar.gz
Checking requirements for ubuntu.
Requirements installation successful.
jruby-9.0.4.0 - #configure
Unknown ruby string (do not know how to handle): jruby-9.0.4.0.
jruby-9.0.4.0 - #download
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 36.4M  100 36.4M    0     0  41.3M      0 --:--:-- --:--:-- --:--:-- 41.3M
No checksum for downloaded archive, recording checksum in user configuration.
jruby-9.0.4.0 - #validate archive
jruby-9.0.4.0 - #extract
jruby-9.0.4.0 - #validate binary
jruby-9.0.4.0 - #setup
jruby-9.0.4.0 - #gemset created /home/travis/.rvm/gems/jruby-9.0.4.0@global
jruby-9.0.4.0 - #importing gemset /home/travis/.rvm/gemsets/jruby/global.gems................................................................................
jruby-9.0.4.0 - #generating global wrappers........
jruby: warning: unknown property jruby.cext.enabled
jruby-9.0.4.0 - #uninstalling gem rubygems-bundler-1.4.4.
jruby-9.0.4.0 - #gemset created /home/travis/.rvm/gems/jruby-9.0.4.0
jruby-9.0.4.0 - #importing gemset /home/travis/.rvm/gemsets/default.gems.....................
jruby-9.0.4.0 - #generating default wrappers........
chown: changing ownership of `/home/travis/.rvm/user/installs': Operation not permitted
Using /home/travis/.rvm/gems/jruby-9.0.4.0
$ export BUNDLE_GEMFILE=$PWD/Gemfile
cache.1
Setting up build cache
$ export CASHER_DIR=$HOME/.casher
0.05s$ Installing caching utilities
0.00s
1.01sattempting to download cache archive
fetching PR.1573/cache--jdk-oraclejdk8--rvm-jruby-9.0.4.0--gemfile-Gemfile.tgz
fetching PR.1573/cache--jdk-oraclejdk8--rvm-jruby-9.0.4.0--gemfile-Gemfile.tbz
fetching master/cache--jdk-oraclejdk8--rvm-jruby-9.0.4.0--gemfile-Gemfile.tgz
found cache
0.00s
1.67sadding /home/travis/build/rails-api/active_model_serializers/vendor/bundle to cache
$ java -Xmx32m -version
java version "1.8.0_31"
Java(TM) SE Runtime Environment (build 1.8.0_31-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.31-b07, mixed mode)
$ javac -J-Xmx32m -version
javac 1.8.0_31
$ ruby --version
jruby: warning: unknown property jruby.cext.enabled
jruby 9.0.4.0 (2.2.2) 2015-11-12 b9fb7aa Java HotSpot(TM) 64-Bit Server VM 25.31-b07 on 1.8.0_31-b13 +jit [linux-amd64]
$ rvm --version
rvm 1.26.10 (latest-minor) by Wayne E. Seguin <wayneeseguin@gmail.com>, Michal Papis <mpapis@gmail.com> [https://rvm.io/]
$ bundle --version
jruby: warning: unknown property jruby.cext.enabled
Bundler version 1.11.2
$ gem --version
jruby: warning: unknown property jruby.cext.enabled
2.4.8
before_install
0.00s$ [ "$JRUBY_OPTS" != "" ] && export JRUBY_OPTS="--dev -Xcli.debug=true --debug"
install
16.92s$ bundle install --path=vendor/bundle --retry=3 --jobs=3
Exception `LoadError' at org/jruby/RubyKernel.java:939 - no such file to load -- net/http/pipeline
Fetching gem metadata from https://rubygems.org/............
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies....................................................................................
Using i18n 0.7.0
Using rake 11.0.1
Using json 1.8.3
Using minitest 5.8.4
Using thread_safe 0.3.5
Using builder 3.2.2
Using erubis 2.7.0
Using rack 1.5.5
Using thor 0.19.1
Using arel 5.0.1.20140414130214
Using jdbc-sqlite3 3.8.11.2
Using ansi 1.5.0
Using ast 2.2.0
Using ice_nine 0.11.2
Using benchmark-ips 2.5.0
Using bundler 1.11.2
Using docile 1.1.5
Using simplecov-html 0.10.0
Using equalizer 0.0.11
Using hashie 3.4.3
Using multi_json 1.11.2
Using multi_xml 0.5.5
Using json_schema 0.12.1
Using ruby-progressbar 1.7.5
Using powerpack 0.1.1
Using rainbow 2.1.0
Using unicode-display_width 1.0.1
Using timecop 0.8.0
Using will_paginate 3.1.0
Using tzinfo 1.2.2
Using descendants_tracker 0.0.4
Using rack-test 0.6.3
Using rack-accept 0.4.5
Using rack-mount 0.8.3
Using parser 2.3.0.6
Using simplecov 0.11.2
Using minitest-reporters 1.1.8
Using activesupport 4.1.15
Using tzinfo-data 1.2016.1
Using axiom-types 0.1.1
Using coercible 1.0.0
Using rubocop 0.38.0
Using codeclimate-test-reporter 0.5.0
Using activemodel 4.1.15
Using actionview 4.1.15
Using virtus 1.0.5
Using activerecord 4.1.15
Using actionpack 4.1.15
Using grape 0.15.0
Using activerecord-jdbc-adapter 1.3.19
Using railties 4.1.15
Using kaminari 0.16.3
Using activerecord-jdbcsqlite3-adapter 1.3.19
Using active_model_serializers 0.10.0.rc4 from source at `.`
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Exception `ArgumentError' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/pathname.rb:508 - different prefix: "" and "/home/travis/build/rails-api/active_model_serializers"
Bundle complete! 21 Gemfile dependencies, 54 gems now installed.
Bundled gems are installed into ./vendor/bundle.
10.35s$ bundle exec rake ci
Exception `Gem::GemNotFoundException' at /home/travis/.rvm/rubies/jruby-9.0.4.0/lib/ruby/stdlib/rubygems.rb:244 - can't find gem bundler (["1.11.2"])
Using Ext extension for JSON.
/home/travis/.rvm/rubies/jruby-9.0.4.0/bin/jruby --verbose -w -I"lib:test" -r./test/test_helper.rb -I"/h
```