### PR TITLE
changes plural to pluralize in json_api resource identifier

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
@@ -23,7 +23,7 @@ module ActiveModelSerializers
           if ActiveModelSerializers.config.jsonapi_resource_type == :singular
             serializer.object.class.model_name.singular
           else
-            serializer.object.class.model_name.plural
+            serializer.object.class.model_name.pluralize
           end
         end
 


### PR DESCRIPTION
#### Purpose
Fixes typo that was failing using Json_api adapter

#### Changes
Changes plural to pluralize

#### Caveats


#### Related GitHub issues


#### Additional helpful information



