### PR TITLE
Raise better exception when no Serializer is defined or found via lookup

### DIFF
--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -36,7 +36,13 @@ module ActiveModel
     alias adapter_instance adapter
 
     def serializer_instance
-      @serializer_instance ||= serializer.new(resource, serializer_opts)
+      if @serializer_instance
+        @serializer_instance
+      else
+        # TODO define error to raise here
+        raise "No Serializer found" unless serializer
+        @serializer_instance = serializer.new(resource, serializer_opts)
+      end
     end
 
     # Get serializer either explicitly :serializer or implicitly from resource

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -71,6 +71,13 @@ module ActiveModel
         }
         assert_equal serializable_resource.as_json(options), expected_response_document
       end
+
+      def test_serializable_resource_when_no_serializer_found
+        resource = ModelWithErrors.new
+        serializable_resource = ActiveModel::SerializableResource.new(resource)
+        # TODO define error to raise here
+        assert_raises { serializable_resource.as_json }
+      end
     end
   end
 end


### PR DESCRIPTION
#### Purpose
When calling ```ActiveModel::SerializableResource.new(resource, {})``` and no Serializer can be found it was raising the following error:

```
ERROR["test_serializable_resource_when_no_serializer_found", ActiveModel::SerializableResourceTest::SerializableResourceErrorsTest, 5.4571671259909635]
 test_serializable_resource_when_no_serializer_found#ActiveModel::SerializableResourceTest::SerializableResourceErrorsTest (5.46s)
NoMethodError:         NoMethodError: undefined method `new' for nil:NilClass
            /app/lib/active_model/serializable_resource.rb:39:in `serializer_instance'
            /app/lib/active_model/serializable_resource.rb:34:in `adapter'
            /app/lib/active_model_serializers/logging.rb:84:in `notify_render_payload'
            /app/lib/active_model_serializers/logging.rb:78:in `notify_render'
            /app/lib/active_model_serializers/logging.rb:21:in `block (2 levels) in instrument_rendering'
            /app/lib/active_model_serializers/logging.rb:94:in `tag_logger'
            /app/lib/active_model_serializers/logging.rb:20:in `block in instrument_rendering'
            /usr/local/bundle/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:441:in `instance_exec'
            /usr/local/bundle/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:441:in `block in make_lambda'
            /usr/local/bundle/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:342:in `block in simple'
            /usr/local/bundle/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:497:in `block in around'
            /usr/local/bundle/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:505:in `call'
            /usr/local/bundle/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:92:in `__run_callbacks__'
            /usr/local/bundle/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:778:in `_run_render_callbacks'
            /usr/local/bundle/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:81:in `run_callbacks'
            /app/lib/active_model_serializers/logging.rb:68:in `block (2 levels) in notify'
            /app/test/serializable_resource_test.rb:78:in `test_serializable_resource_when_no_serializer_found'
```

#### Changes
Changed code to raise a better error with some useful explanation. Please tell me what error and message to raise and I will update this PR.



