### PR TITLE
Omit meta when blank

### DIFF
--- a/lib/active_model_serializers/adapter/base.rb
+++ b/lib/active_model_serializers/adapter/base.rb
@@ -48,7 +48,7 @@ module ActiveModelSerializers
       end
 
       def include_meta(json)
-        json[meta_key] = meta if meta
+        json[meta_key] = meta unless meta.blank?
         json
       end
     end

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -320,7 +320,7 @@ module ActiveModelSerializers
         #     :'git-ref' => 'abc123'
         #   }
         meta = meta_for(serializer)
-        resource_object[:meta] = meta unless meta.nil?
+        resource_object[:meta] = meta unless meta.blank?
 
         resource_object
       end

--- a/test/adapter/json_api/resource_meta_test.rb
+++ b/test/adapter/json_api/resource_meta_test.rb
@@ -17,6 +17,20 @@ module ActiveModel
             end
           end
 
+          class MetaBlockPostBlankMetaSerializer < ActiveModel::Serializer
+            attributes :id
+            meta do
+              {}
+            end
+          end
+
+          class MetaBlockPostEmptyStringSerializer < ActiveModel::Serializer
+            attributes :id
+            meta do
+              ''
+            end
+          end
+
           def setup
             @post = Post.new(id: 1337, comments: [], author: nil)
           end
@@ -60,6 +74,24 @@ module ActiveModel
               ]
             }
             assert_equal(expected, hash)
+          end
+
+          def test_meta_object_blank_omitted
+            hash = ActiveModel::SerializableResource.new(
+              @post,
+              serializer: MetaBlockPostBlankMetaSerializer,
+              adapter: :json_api
+            ).serializable_hash
+            refute hash[:data].key? :meta
+          end
+
+          def test_meta_object_empty_string_omitted
+            hash = ActiveModel::SerializableResource.new(
+              @post,
+              serializer: MetaBlockPostEmptyStringSerializer,
+              adapter: :json_api
+            ).serializable_hash
+            refute hash[:data].key? :meta
           end
         end
       end

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -28,6 +28,38 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
+      def test_meta_is_not_included_when_blank
+        actual = ActiveModel::SerializableResource.new(
+          @blog,
+          adapter: :json,
+          serializer: AlternateBlogSerializer,
+          meta: {}
+        ).as_json
+        expected = {
+          blog: {
+            id: 1,
+            title: 'AMS Hints'
+          }
+        }
+        assert_equal(expected, actual)
+      end
+
+      def test_meta_is_not_included_when_empty_string
+        actual = ActiveModel::SerializableResource.new(
+          @blog,
+          adapter: :json,
+          serializer: AlternateBlogSerializer,
+          meta: ''
+        ).as_json
+        expected = {
+          blog: {
+            id: 1,
+            title: 'AMS Hints'
+          }
+        }
+        assert_equal(expected, actual)
+      end
+
       def test_meta_is_not_included_when_root_is_missing
         actual = ActiveModel::SerializableResource.new(
           @blog,
@@ -74,6 +106,42 @@ module ActiveModel
             attributes: { title: 'AMS Hints' }
           },
           'haha_meta' => { total: 10 }
+        }
+        assert_equal(expected, actual)
+      end
+
+      def test_meta_key_is_not_present_when_blank_object_with_json_api
+        actual = ActiveModel::SerializableResource.new(
+          @blog,
+          adapter: :json_api,
+          serializer: AlternateBlogSerializer,
+          meta: {},
+          meta_key: 'haha_meta'
+        ).as_json
+        expected = {
+          data: {
+            id: '1',
+            type: 'blogs',
+            attributes: { title: 'AMS Hints' }
+          }
+        }
+        assert_equal(expected, actual)
+      end
+
+      def test_meta_key_is_not_present_when_empty_string_with_json_api
+        actual = ActiveModel::SerializableResource.new(
+          @blog,
+          adapter: :json_api,
+          serializer: AlternateBlogSerializer,
+          meta: '',
+          meta_key: 'haha_meta'
+        ).as_json
+        expected = {
+          data: {
+            id: '1',
+            type: 'blogs',
+            attributes: { title: 'AMS Hints' }
+          }
         }
         assert_equal(expected, actual)
       end


### PR DESCRIPTION
#### Purpose

Given:

```ruby
meta do
  {
    status_details: object.status_details
  }.reject { |k,v| v.nil? }
end
```

When `object.status_details` is null, an empty `meta` member is added to the response, `meta: {}`. These changes alter the behavior to not include `meta` if it's blank. This applies to the `JsonApi` and `Json` adapters.