### PR TITLE
Ensure running 'bundle exec' before 'rake'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@ begin
 rescue LoadError
 end
 
+require 'bundler'
+Bundler.setup
 require 'bundler/gem_tasks'
 
 begin


### PR DESCRIPTION
Otherwise, depending on your gem setup, you end up accidentally
running the wrong version of gems, such as was happening to me,
where I was running an older version of RuboCop installed outside the bundle.