### PR TITLE
Revert "Safe to using rake 11.0.1 now."

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -57,5 +57,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'grape', ['>= 0.13', '< 1.0']
   spec.add_development_dependency 'json_schema'
-  spec.add_development_dependency 'rake', ['>= 10.0', '< 12.0']
+  # https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11/35893625#35893625
+  spec.add_development_dependency 'rake', '< 11.0'
 end

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -57,6 +57,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'grape', ['>= 0.13', '< 1.0']
   spec.add_development_dependency 'json_schema'
-  # https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11/35893625#35893625
-  spec.add_development_dependency 'rake', '< 11.0'
+  spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Reverts rails-api/active_model_serializers#1573

Is causing JRuby failures.

https://travis-ci.org/rails-api/active_model_serializers/jobs/115622797

```plain
Coverage may be inaccurate; set "cli.debug=true" ("-Xcli.debug=true") in your .jrubyrc or do JRUBY_OPTS="-d"
/home/travis/build/rails-api/active_model_serializers/.simplecov:48: warning: tracing (e.g. set_trace_func) will not capture all events without --debug flag
/home/travis/.rvm/rubies/jruby-9.0.4.0/bin/jruby --verbose -w -I"lib:test" -r./test/test_helper.rb -I"/home/travis/build/rails-api/active_model_serializers/vendor/bundle/jruby/2.2.0/gems/rake-11.1.0/lib" "/home/travis/build/rails-api/active_model_serializers/vendor/bundle/jruby/2.2.0/gems/rake-11.1.0/lib/rake/rake_test_loader.rb" "test/action_controller/adapter_selector_test.rb" "test/action_controller/explicit_serializer_test.rb" "test/action_controller/json/include_test.rb" "test/action_controller/json_api/deserialization_test.rb" "test/action_controller/json_api/errors_test.rb" "test/action_controller/json_api/linked_test.rb" "test/action_controller/json_api/pagination_test.rb" "test/action_controller/serialization_scope_name_test.rb" "test/action_controller/serialization_test.rb" "test/active_model_serializers/adapter_for_test.rb" "test/active_model_serializers/json_pointer_test.rb" "test/active_model_serializers/logging_test.rb" "test/active_model_serializers/model_test.rb" "test/active_model_serializers/test/schema_test.rb" "test/active_model_serializers/test/serializer_test.rb" "test/active_record_test.rb" "test/adapter/deprecation_test.rb" "test/adapter/fragment_cache_test.rb" "test/adapter/json/belongs_to_test.rb" "test/adapter/json/collection_test.rb" "test/adapter/json/has_many_test.rb" "test/adapter/json_api/belongs_to_test.rb" "test/adapter/json_api/collection_test.rb" "test/adapter/json_api/errors_test.rb" "test/adapter/json_api/fields_test.rb" "test/adapter/json_api/has_many_embed_ids_test.rb" "test/adapter/json_api/has_many_explicit_serializer_test.rb" "test/adapter/json_api/has_many_test.rb" "test/adapter/json_api/has_one_test.rb" "test/adapter/json_api/json_api_test.rb" "test/adapter/json_api/linked_test.rb" "test/adapter/json_api/links_test.rb" "test/adapter/json_api/pagination_links_test.rb" "test/adapter/json_api/parse_test.rb" "test/adapter/json_api/relationship_test.rb" "test/adapter/json_api/relationships_test.rb" "test/adapter/json_api/resource_identifier_test.rb" "test/adapter/json_api/resource_meta_test.rb" "test/adapter/json_api/toplevel_jsonapi_test.rb" "test/adapter/json_api/type_test.rb" "test/adapter/json_test.rb" "test/adapter/null_test.rb" "test/adapter_test.rb" "test/array_serializer_test.rb" "test/collection_serializer_test.rb" "test/generators/scaffold_controller_generator_test.rb" "test/generators/serializer_generator_test.rb" "test/grape_test.rb" "test/include_tree/from_include_args_test.rb" "test/include_tree/from_string_test.rb" "test/include_tree/include_args_to_hash_test.rb" "test/lint_test.rb" "test/logger_test.rb" "test/poro_test.rb" "test/serializable_resource_test.rb" "test/serializers/association_macros_test.rb" "test/serializers/associations_test.rb" "test/serializers/attribute_test.rb" "test/serializers/attributes_test.rb" "test/serializers/cache_test.rb" "test/serializers/cached_serializer_test.rb" "test/serializers/configuration_test.rb" "test/serializers/fieldset_test.rb" "test/serializers/meta_test.rb" "test/serializers/options_test.rb" "test/serializers/root_test.rb" "test/serializers/serializer_for_test.rb" 
jruby: unknown option --verbose
rake aborted!
Command failed with status (1): [ruby --verbose -w -I"lib:test" -r./test/test_helper.rb -I"/home/travis/build/rails-api/active_model_serializers/vendor/bundle/jruby/2.2.0/gems/rake-11.1.0/lib" "/home/travis/build/rails-api/active_model_serializers/vendor/bundle/jruby/2.2.0/gems/rake-11.1.0/lib/rake/rake_test_loader.rb" "test/action_controller/adapter_selector_test.rb" 
```