### PR TITLE
Add a way to disable JsonApi automatic pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Breaking changes:
 
 Features:
+- [#1596](https://github.com/rails-api/active_model_serializers/pull/1596) Provide a way to prevent links to
+  automatically rendered when using JSON API adapter. (@groyoh)
 - [#1574](https://github.com/rails-api/active_model_serializers/pull/1574) Provide key translation. (@remear)
 - [#1494](https://github.com/rails-api/active_model_serializers/pull/1494) Make serializers serializalbe
   (using the Attributes adapter by default). (@bf4)

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -2,7 +2,7 @@ require 'set'
 require 'active_model_serializers/adapter'
 module ActiveModel
   class SerializableResource
-    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links])
+    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links, :serialization_context])
     include ActiveModelSerializers::Logging
 
     delegate :serializable_hash, :as_json, :to_json, to: :adapter

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -1,5 +1,6 @@
 require 'thread_safe'
 require 'active_model/serializer/collection_serializer'
+require 'active_model/serializer/non_paginated_collection_serializer'
 require 'active_model/serializer/array_serializer'
 require 'active_model/serializer/error_serializer'
 require 'active_model/serializer/errors_serializer'

--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -32,8 +32,7 @@ module ActiveModel
 
       def paginated?
         object.respond_to?(:current_page) &&
-          object.respond_to?(:total_pages) &&
-          object.respond_to?(:size)
+          object.respond_to?(:total_pages)
       end
 
       protected

--- a/lib/active_model/serializer/non_paginated_collection_serializer.rb
+++ b/lib/active_model/serializer/non_paginated_collection_serializer.rb
@@ -1,0 +1,11 @@
+require 'active_model/serializer/collection_serializer'
+
+module ActiveModel
+  class Serializer
+    class NonPaginatedCollectionSerializer < CollectionSerializer
+      def paginated?
+        false
+      end
+    end
+  end
+end

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -38,6 +38,7 @@ module ActiveModel
         super
         @_links = {}
         @_include_data = true
+        @_meta = nil
       end
 
       def link(name, value = nil, &block)

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -3,97 +3,41 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class CollectionSerializerTest < ActiveSupport::TestCase
-      def setup
+      include CollectionSerializerTesting
+
+      setup do
         @comment = Comment.new
         @post = Post.new
         @resource = build_named_collection @comment, @post
         @serializer = collection_serializer.new(@resource, { some: :options })
       end
 
+      def test_pagined_when_collection_respond_to_current_page_total_pages_and_size
+        add_methods_to_resource(:total_pages, :size, :current_page)
+        serializer = collection_serializer.new(@resource, { some: :options })
+        assert(serializer.paginated?)
+      end
+
+      def test_not_paginated_when_collection_does_not_respond_to_current_page
+        add_methods_to_resource(:total_pages, :size)
+        refute(@serializer.paginated?)
+      end
+
+      def test_not_paginated_when_collection_does_not_respond_to_total_pages
+        add_methods_to_resource(:current_page, :size)
+        refute(@serializer.paginated?)
+      end
+
+      private
+
+      def add_methods_to_resource(*methods)
+        methods.each_with_object(@resource) do |method, resource|
+          resource.define_singleton_method(method) {}
+        end
+      end
+
       def collection_serializer
         CollectionSerializer
-      end
-
-      def build_named_collection(*resource)
-        resource.define_singleton_method(:name) { 'MeResource' }
-        resource
-      end
-
-      def test_has_object_reader_serializer_interface
-        assert_equal @serializer.object, @resource
-      end
-
-      def test_respond_to_each
-        assert_respond_to @serializer, :each
-      end
-
-      def test_each_object_should_be_serialized_with_appropriate_serializer
-        serializers =  @serializer.to_a
-
-        assert_kind_of CommentSerializer, serializers.first
-        assert_kind_of Comment, serializers.first.object
-
-        assert_kind_of PostSerializer, serializers.last
-        assert_kind_of Post, serializers.last.object
-
-        assert_equal :options, serializers.last.custom_options[:some]
-      end
-
-      def test_serializer_option_not_passed_to_each_serializer
-        serializers = collection_serializer.new([@post], { serializer: PostSerializer }).to_a
-
-        refute serializers.first.custom_options.key?(:serializer)
-      end
-
-      def test_root_default
-        @serializer = collection_serializer.new([@comment, @post])
-        assert_nil @serializer.root
-      end
-
-      def test_root
-        expected =  'custom_root'
-        @serializer = collection_serializer.new([@comment, @post], root: expected)
-        assert_equal expected, @serializer.root
-      end
-
-      def test_root_with_no_serializers
-        expected =  'custom_root'
-        @serializer = collection_serializer.new([], root: expected)
-        assert_equal expected, @serializer.root
-      end
-
-      def test_json_key_with_resource_with_serializer
-        singular_key = @serializer.send(:serializers).first.json_key
-        assert_equal singular_key.pluralize, @serializer.json_key
-      end
-
-      def test_json_key_with_resource_with_name_and_no_serializers
-        serializer = collection_serializer.new(build_named_collection)
-        assert_equal 'me_resources', serializer.json_key
-      end
-
-      def test_json_key_with_resource_with_nil_name_and_no_serializers
-        resource = []
-        resource.define_singleton_method(:name) { nil }
-        serializer = collection_serializer.new(resource)
-        assert_nil serializer.json_key
-      end
-
-      def test_json_key_with_resource_without_name_and_no_serializers
-        serializer = collection_serializer.new([])
-        assert_nil serializer.json_key
-      end
-
-      def test_json_key_with_root
-        expected = 'custom_root'
-        serializer = collection_serializer.new(@resource, root: expected)
-        assert_equal expected, serializer.json_key
-      end
-
-      def test_json_key_with_root_and_no_serializers
-        expected = 'custom_root'
-        serializer = collection_serializer.new(build_named_collection, root: expected)
-        assert_equal expected, serializer.json_key
       end
     end
   end

--- a/test/non_paginated_collection_serializer_test.rb
+++ b/test/non_paginated_collection_serializer_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class NonPaginatedCollectionSerializerTest < ActiveSupport::TestCase
+      include CollectionSerializerTesting
+
+      setup do
+        @comment = Comment.new
+        @post = Post.new
+        @resource = build_named_collection @comment, @post
+        @serializer = collection_serializer.new(@resource, some: :options)
+      end
+
+      def test_not_paginated
+        refute(@serializer.paginated?)
+      end
+
+      private
+
+      def collection_serializer
+        NonPaginatedCollectionSerializer
+      end
+    end
+  end
+end

--- a/test/support/collection_serializer_testing.rb
+++ b/test/support/collection_serializer_testing.rb
@@ -1,0 +1,89 @@
+module CollectionSerializerTesting
+  def test_has_object_reader_serializer_interface
+    assert_equal @serializer.object, @resource
+  end
+
+  def test_respond_to_each
+    assert_respond_to @serializer, :each
+  end
+
+  def test_each_object_should_be_serialized_with_appropriate_serializer
+    serializers =  @serializer.to_a
+
+    assert_kind_of CommentSerializer, serializers.first
+    assert_kind_of Comment, serializers.first.object
+
+    assert_kind_of PostSerializer, serializers.last
+    assert_kind_of Post, serializers.last.object
+
+    assert_equal :options, serializers.last.custom_options[:some]
+  end
+
+  def test_serializer_option_not_passed_to_each_serializer
+    serializers = collection_serializer.new([@post], serializer: PostSerializer).to_a
+
+    refute serializers.first.custom_options.key?(:serializer)
+  end
+
+  def test_root_default
+    @serializer = collection_serializer.new([@comment, @post])
+    assert_nil @serializer.root
+  end
+
+  def test_root
+    expected =  'custom_root'
+    @serializer = collection_serializer.new([@comment, @post], root: expected)
+    assert_equal expected, @serializer.root
+  end
+
+  def test_root_with_no_serializers
+    expected =  'custom_root'
+    @serializer = collection_serializer.new([], root: expected)
+    assert_equal expected, @serializer.root
+  end
+
+  def test_json_key_with_resource_with_serializer
+    singular_key = @serializer.send(:serializers).first.json_key
+    assert_equal singular_key.pluralize, @serializer.json_key
+  end
+
+  def test_json_key_with_resource_with_name_and_no_serializers
+    serializer = collection_serializer.new(build_named_collection)
+    assert_equal 'me_resources', serializer.json_key
+  end
+
+  def test_json_key_with_resource_with_nil_name_and_no_serializers
+    resource = []
+    resource.define_singleton_method(:name) { nil }
+    serializer = collection_serializer.new(resource)
+    assert_nil serializer.json_key
+  end
+
+  def test_json_key_with_resource_without_name_and_no_serializers
+    serializer = collection_serializer.new([])
+    assert_nil serializer.json_key
+  end
+
+  def test_json_key_with_root
+    expected = 'custom_root'
+    serializer = collection_serializer.new(@resource, root: expected)
+    assert_equal expected, serializer.json_key
+  end
+
+  def test_json_key_with_root_and_no_serializers
+    expected = 'custom_root'
+    serializer = collection_serializer.new(build_named_collection, root: expected)
+    assert_equal expected, serializer.json_key
+  end
+
+  def test_success
+    assert(@serializer.success?)
+  end
+
+  private
+
+  def build_named_collection(*resource)
+    resource.define_singleton_method(:name) { 'MeResource' }
+    resource
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,6 +49,8 @@ require 'support/test_case'
 
 require 'support/serialization_testing'
 
+require 'support/collection_serializer_testing'
+
 require 'support/rails5_shims'
 
 require 'fixtures/active_record'


### PR DESCRIPTION
#### Purpose
Provides a way to prevent automatic links rendering when using kaminari or will_paginate. See #1549 and https://github.com/rails-api/active_model_serializers/issues/1549#issuecomment-191568335.

#### Changes
Added a `NonPaginatedCollectionSerializer` with tests and documentation for it. 

#### Related GitHub issues
Solves #1549 
Should solve #1268 too