### PR TITLE
ActiveModel::Serializer _fast_attributes - raise NameError without ba…

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -107,9 +107,8 @@ module ActiveModel
         #  attributes are added later in a classes lifecycle
         # poison the cache
         define_method :_fast_attributes do
-          raise NameError
+          raise NameError, nil, []
         end
-
       end
 
       def associate(klass, attrs) #:nodoc:


### PR DESCRIPTION
#### Purpose

_fast_attributes - raise NameError without backtrace

Rebased version of #1305

#### Related GitHub issues

#1305