### PR TITLE
Move SerializableResource to ActiveModelSerializers namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Fixes:
 - [#1488](https://github.com/rails-api/active_model_serializers/pull/1488) Require ActiveSupport's string inflections (@nate00)
 
 Misc:
+- [#1608](https://github.com/rails-api/active_model_serializers/pull/1608) Move SerializableResource to ActiveModelSerializers (@groyoh)
 - [#1602](https://github.com/rails-api/active_model_serializers/pull/1602) Add output examples to Adapters docs (@remear)
 - [#1557](https://github.com/rails-api/active_model_serializers/pull/1557) Update docs regarding overriding the root key (@Jwan622)
 - [#1471](https://github.com/rails-api/active_model_serializers/pull/1471) [Cleanup] Serializer caching is its own concern. (@bf4)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ serializer. For example, the `Attributes` example represents each serializer as 
 unmodified attributes.  The `JsonApi` adapter represents the serializer as a [JSON
 API](http://jsonapi.org/) document.
 
-The **`ActiveModel::SerializableResource`** acts to coordinate the serializer(s) and adapter
+The **`ActiveModelSerializers::SerializableResource`** acts to coordinate the serializer(s) and adapter
 to an object that responds to `to_json`, and `as_json`.  It is used in the controller to
 encapsulate the serialization resource when rendered. However, it can also be used on its own
 to serialize a resource outside of a controller, as well.
@@ -62,16 +62,16 @@ High-level overview:
   - `:each_serializer` specifies the serializer for each resource in the collection.
 - For a single resource, the `:serializer` option is the resource serializer.
 - Options are partitioned in serializer options and adapter options.  Keys for adapter options are specified by
-    [`ADAPTER_OPTION_KEYS`](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializable_resource.rb#L4).
+    [`ADAPTER_OPTION_KEYS`](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model_serializers/serializable_resource.rb#L5).
     The remaining options are serializer options.
 
 Details:
 
 1. **ActionController::Serialization**
-  1. `serializable_resource = ActiveModel::SerializableResource.new(resource, options)`
+  1. `serializable_resource = ActiveModelSerializers::SerializableResource.new(resource, options)`
     1. `options` are partitioned into `adapter_opts` and everything else (`serializer_opts`).
-      The `adapter_opts`  keys are defined in `ActiveModel::SerializableResource::ADAPTER_OPTION_KEYS`.
-1. **ActiveModel::SerializableResource**
+      The `adapter_opts`  keys are defined in `ActiveModelSerializers::SerializableResource::ADAPTER_OPTION_KEYS`.
+1. **ActiveModelSerializers::SerializableResource**
   1. `if serializable_resource.serializer?` (there is a serializer for the resource, and an adapter is used.)
     - Where `serializer?` is `use_adapter? && !!(serializer)`
       - Where `use_adapter?`: 'True when no explicit adapter given, or explicit value is truthy (non-nil);
@@ -122,5 +122,5 @@ render json: MyModel.new(level: 'awesome'), adapter: :json
 would be serialized the same as
 
 ```ruby
-ActiveModel::SerializableResource.new(MyModel.new(level: 'awesome'), adapter: :json).as_json
+ActiveModelSerializers::SerializableResource.new(MyModel.new(level: 'awesome'), adapter: :json).as_json
 ```

--- a/docs/general/rendering.md
+++ b/docs/general/rendering.md
@@ -56,11 +56,11 @@ API for a plain-old Ruby object (PORO).
 
 ## SerializableResource options
 
-The `options` hash passed to `render` or `ActiveModel::SerializableResource.new(resource, options)`
+The `options` hash passed to `render` or `ActiveModelSerializers::SerializableResource.new(resource, options)`
 are partitioned into `serializer_opts` and `adapter_opts`. `adapter_opts` are passed to new Adapters;
 `serializer_opts` are passed to new Serializers.
 
-The `adapter_opts` are specified in [ActiveModel::SerializableResource::ADAPTER_OPTIONS](../../lib/active_model/serializable_resource.rb#L4).
+The `adapter_opts` are specified in [ActiveModelSerializers::SerializableResource::ADAPTER_OPTIONS](../../lib/active_model_serializers/serializable_resource.rb#L5).
 The `serializer_opts` are the remaining options.
 
 (In Rails, the `options` are also passed to the `as_json(options)` or `to_json(options)`

--- a/docs/howto/outside_controller_use.md
+++ b/docs/howto/outside_controller_use.md
@@ -14,7 +14,7 @@ post = Post.create(title: "Sample post", body: "I love Active Model Serializers!
 options = {}
 
 # Create a serializable resource instance
-serializable_resource = ActiveModel::SerializableResource.new(post, options)
+serializable_resource = ActiveModelSerializers::SerializableResource.new(post, options)
 
 # Convert your resource into json
 model_json = serializable_resource.as_json
@@ -38,20 +38,20 @@ serializer = ActiveModel::Serializer.serializer_for(post, options)
 You could also retrieve the serializer via:
 
 ```ruby
-ActiveModel::SerializableResource.new(post, options).serializer
+ActiveModelSerializers::SerializableResource.new(post, options).serializer
 ```
 
 Both approaches will return an instance, if any, of the resource's serializer.
 
 ## Serializing before controller render
 
-At times, you might want to use a serializer without rendering it to the view. For those cases, you can create an instance of `ActiveModel::SerializableResource` with
+At times, you might want to use a serializer without rendering it to the view. For those cases, you can create an instance of `ActiveModelSerializers::SerializableResource` with
 the resource you want to be serialized and call `.as_json`.
 
 ```ruby
 def create
   message = current_user.messages.create!(message_params)
-  message_json = ActiveModel::SerializableResource.new(message).as_json
+  message_json = ActiveModelSerializers::SerializableResource.new(message).as_json
   MessageCreationWorker.perform(message_json)
   head 204
 end

--- a/docs/jsonapi/errors.md
+++ b/docs/jsonapi/errors.md
@@ -40,7 +40,7 @@ options = nil
 resource = ModelWithErrors.new
 resource.errors.add(:name, 'must be awesome')
 
-serializable_resource = ActiveModel::SerializableResource.new(
+serializable_resource = ActiveModelSerializers::SerializableResource.new(
   resource, {
     serializer: ActiveModel::Serializer::ErrorSerializer,
     adapter: :json_api

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -7,9 +7,6 @@ module ActionController
 
     include ActionController::Renderers
 
-    # Deprecated
-    ADAPTER_OPTION_KEYS = ActiveModel::SerializableResource::ADAPTER_OPTION_KEYS
-
     module ClassMethods
       def serialization_scope(scope)
         self._serialization_scope = scope
@@ -32,7 +29,7 @@ module ActionController
           "Please pass 'adapter: false' or see ActiveSupport::SerializableResource.new"
         options[:adapter] = false
       end
-      serializable_resource = ActiveModel::SerializableResource.new(resource, options)
+      serializable_resource = ActiveModelSerializers::SerializableResource.new(resource, options)
       serializable_resource.serialization_scope ||= serialization_scope
       serializable_resource.serialization_scope_name = _serialization_scope
       # For compatibility with the JSON renderer: `json.to_json(options) if json.is_a?(String)`.

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -1,81 +1,11 @@
 require 'set'
-require 'active_model_serializers/adapter'
+
 module ActiveModel
   class SerializableResource
-    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links])
-    include ActiveModelSerializers::Logging
+    class << self
+      extend ActiveModelSerializers::Deprecate
 
-    delegate :serializable_hash, :as_json, :to_json, to: :adapter
-    notify :serializable_hash, :render
-    notify :as_json, :render
-    notify :to_json, :render
-
-    # Primary interface to composing a resource with a serializer and adapter.
-    # @return the serializable_resource, ready for #as_json/#to_json/#serializable_hash.
-    def initialize(resource, options = {})
-      @resource = resource
-      @adapter_opts, @serializer_opts =
-        options.partition { |k, _| ADAPTER_OPTION_KEYS.include? k }.map { |h| Hash[h] }
+      delegate_and_deprecate :new, ActiveModelSerializers::SerializableResource
     end
-
-    def serialization_scope=(scope)
-      serializer_opts[:scope] = scope
-    end
-
-    def serialization_scope
-      serializer_opts[:scope]
-    end
-
-    def serialization_scope_name=(scope_name)
-      serializer_opts[:scope_name] = scope_name
-    end
-
-    # NOTE: if no adapter is available, returns the resource itself. (i.e. adapter is a no-op)
-    def adapter
-      @adapter ||= find_adapter
-    end
-    alias adapter_instance adapter
-
-    def find_adapter
-      return resource unless serializer?
-      ActiveModelSerializers::Adapter.create(serializer_instance, adapter_opts)
-    rescue ActiveModel::Serializer::CollectionSerializer::NoSerializerError
-      resource
-    end
-
-    def serializer_instance
-      @serializer_instance ||= serializer.new(resource, serializer_opts)
-    end
-
-    # Get serializer either explicitly :serializer or implicitly from resource
-    # Remove :serializer key from serializer_opts
-    # Replace :serializer key with :each_serializer if present
-    def serializer
-      @serializer ||=
-        begin
-          @serializer = serializer_opts.delete(:serializer)
-          @serializer ||= ActiveModel::Serializer.serializer_for(resource)
-
-          if serializer_opts.key?(:each_serializer)
-            serializer_opts[:serializer] = serializer_opts.delete(:each_serializer)
-          end
-          @serializer
-        end
-    end
-    alias serializer_class serializer
-
-    # True when no explicit adapter given, or explicit appear is truthy (non-nil)
-    # False when explicit adapter is falsy (nil or false)
-    def use_adapter?
-      !(adapter_opts.key?(:adapter) && !adapter_opts[:adapter])
-    end
-
-    def serializer?
-      use_adapter? && !!serializer
-    end
-
-    protected
-
-    attr_reader :resource, :adapter_opts, :serializer_opts
   end
 end

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -1,3 +1,6 @@
+require 'active_model_serializers/adapter'
+require 'active_model_serializers/deprecate'
+
 module ActiveModel
   class Serializer
     # @deprecated Use ActiveModelSerializers::Adapter instead
@@ -5,25 +8,17 @@ module ActiveModel
       class << self
         extend ActiveModelSerializers::Deprecate
 
-        def self.delegate_and_deprecate(method)
-          delegate method, to: ActiveModelSerializers::Adapter
-          deprecate method, 'ActiveModelSerializers::Adapter.'
+        DEPRECATED_METHODS = [:create, :adapter_class, :adapter_map, :adapters, :register, :lookup].freeze
+        DEPRECATED_METHODS.each do |method|
+          delegate_and_deprecate method, ActiveModelSerializers::Adapter
         end
-        private_class_method :delegate_and_deprecate
-
-        delegate_and_deprecate :create
-        delegate_and_deprecate :adapter_class
-        delegate_and_deprecate :adapter_map
-        delegate_and_deprecate :adapters
-        delegate_and_deprecate :register
-        delegate_and_deprecate :lookup
       end
-
-      require 'active_model/serializer/adapter/base'
-      require 'active_model/serializer/adapter/null'
-      require 'active_model/serializer/adapter/attributes'
-      require 'active_model/serializer/adapter/json'
-      require 'active_model/serializer/adapter/json_api'
     end
   end
 end
+
+require 'active_model/serializer/adapter/base'
+require 'active_model/serializer/adapter/null'
+require 'active_model/serializer/adapter/attributes'
+require 'active_model/serializer/adapter/json'
+require 'active_model/serializer/adapter/json_api'

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -9,6 +9,7 @@ module ActiveModelSerializers
   autoload :FragmentCache
   autoload :Callbacks
   autoload :Deserialization
+  autoload :SerializableResource
   autoload :Logging
   autoload :Test
   autoload :Adapter

--- a/lib/active_model_serializers/adapter/json_api/link.rb
+++ b/lib/active_model_serializers/adapter/json_api/link.rb
@@ -46,7 +46,6 @@ module ActiveModelSerializers
           # actionpack-4.0.13/lib/action_dispatch/routing/route_set.rb:417: warning: instance variable @_routes not initialized
           @object = serializer.object
           @scope = serializer.scope
-
           # Use the return value of the block unless it is nil.
           if value.respond_to?(:call)
             @value = instance_eval(&value)

--- a/lib/active_model_serializers/callbacks.rb
+++ b/lib/active_model_serializers/callbacks.rb
@@ -24,7 +24,7 @@ module ActiveModelSerializers
       # Defines a callback that will get called around the render method,
       # whether it is as_json, to_json, or serializable_hash
       #
-      #   class ActiveModel::SerializableResource
+      #   class ActiveModelSerializers::SerializableResource
       #     include ActiveModelSerializers::Callbacks
       #
       #     around_render do |args, block|

--- a/lib/active_model_serializers/deprecate.rb
+++ b/lib/active_model_serializers/deprecate.rb
@@ -44,6 +44,12 @@ module ActiveModelSerializers
       end
     end
 
+    def delegate_and_deprecate(method, delegee)
+      delegate method, to: delegee
+      deprecate method, "#{delegee.name}."
+    end
+
     module_function :deprecate
+    module_function :delegate_and_deprecate
   end
 end

--- a/lib/active_model_serializers/fragment_cache.rb
+++ b/lib/active_model_serializers/fragment_cache.rb
@@ -32,7 +32,7 @@ module ActiveModelSerializers
     private
 
     def serialize(object, serializer_class)
-      ActiveModel::SerializableResource.new(
+      SerializableResource.new(
         object,
         serializer: serializer_class,
         adapter: adapter.class

--- a/lib/active_model_serializers/serializable_resource.rb
+++ b/lib/active_model_serializers/serializable_resource.rb
@@ -1,0 +1,81 @@
+require 'set'
+
+module ActiveModelSerializers
+  class SerializableResource
+    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links])
+    include ActiveModelSerializers::Logging
+
+    delegate :serializable_hash, :as_json, :to_json, to: :adapter
+    notify :serializable_hash, :render
+    notify :as_json, :render
+    notify :to_json, :render
+
+    # Primary interface to composing a resource with a serializer and adapter.
+    # @return the serializable_resource, ready for #as_json/#to_json/#serializable_hash.
+    def initialize(resource, options = {})
+      @resource = resource
+      @adapter_opts, @serializer_opts =
+        options.partition { |k, _| ADAPTER_OPTION_KEYS.include? k }.map { |h| Hash[h] }
+    end
+
+    def serialization_scope=(scope)
+      serializer_opts[:scope] = scope
+    end
+
+    def serialization_scope
+      serializer_opts[:scope]
+    end
+
+    def serialization_scope_name=(scope_name)
+      serializer_opts[:scope_name] = scope_name
+    end
+
+    # NOTE: if no adapter is available, returns the resource itself. (i.e. adapter is a no-op)
+    def adapter
+      @adapter ||= find_adapter
+    end
+    alias adapter_instance adapter
+
+    def find_adapter
+      return resource unless serializer?
+      ActiveModelSerializers::Adapter.create(serializer_instance, adapter_opts)
+    rescue ActiveModel::Serializer::CollectionSerializer::NoSerializerError
+      resource
+    end
+
+    def serializer_instance
+      @serializer_instance ||= serializer.new(resource, serializer_opts)
+    end
+
+    # Get serializer either explicitly :serializer or implicitly from resource
+    # Remove :serializer key from serializer_opts
+    # Replace :serializer key with :each_serializer if present
+    def serializer
+      @serializer ||=
+        begin
+          @serializer = serializer_opts.delete(:serializer)
+          @serializer ||= ActiveModel::Serializer.serializer_for(resource)
+
+          if serializer_opts.key?(:each_serializer)
+            serializer_opts[:serializer] = serializer_opts.delete(:each_serializer)
+          end
+          @serializer
+        end
+    end
+    alias serializer_class serializer
+
+    # True when no explicit adapter given, or explicit appear is truthy (non-nil)
+    # False when explicit adapter is falsy (nil or false)
+    def use_adapter?
+      !(adapter_opts.key?(:adapter) && !adapter_opts[:adapter])
+    end
+
+    def serializer?
+      use_adapter? && !serializer.nil?
+    end
+
+    protected
+
+    attr_reader :resource, :adapter_opts, :serializer_opts
+  end
+end

--- a/lib/grape/formatters/active_model_serializers.rb
+++ b/lib/grape/formatters/active_model_serializers.rb
@@ -8,7 +8,7 @@ module Grape
       def self.call(resource, env)
         serializer_options = {}
         serializer_options.merge!(env[:active_model_serializer_options]) if env[:active_model_serializer_options]
-        ActiveModel::SerializableResource.new(resource, serializer_options).to_json
+        ::ActiveModelSerializers::SerializableResource.new(resource, serializer_options).to_json
       end
     end
   end

--- a/test/active_model_serializers/logging_test.rb
+++ b/test/active_model_serializers/logging_test.rb
@@ -39,37 +39,37 @@ module ActiveModel
       end
 
       def test_uses_ams_as_tag
-        ActiveModel::SerializableResource.new(@post).serializable_hash
+        ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/\[active_model_serializers\]/, @logger.messages)
       end
 
       def test_logs_when_call_serializable_hash
-        ActiveModel::SerializableResource.new(@post).serializable_hash
+        ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/Rendered/, @logger.messages)
       end
 
       def test_logs_when_call_as_json
-        ActiveModel::SerializableResource.new(@post).as_json
+        ActiveModelSerializers::SerializableResource.new(@post).as_json
         assert_match(/Rendered/, @logger.messages)
       end
 
       def test_logs_when_call_to_json
-        ActiveModel::SerializableResource.new(@post).to_json
+        ActiveModelSerializers::SerializableResource.new(@post).to_json
         assert_match(/Rendered/, @logger.messages)
       end
 
       def test_logs_correct_serializer
-        ActiveModel::SerializableResource.new(@post).serializable_hash
+        ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/PostSerializer/, @logger.messages)
       end
 
       def test_logs_correct_adapter
-        ActiveModel::SerializableResource.new(@post).serializable_hash
+        ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/ActiveModelSerializers::Adapter::Attributes/, @logger.messages)
       end
 
       def test_logs_the_duration
-        ActiveModel::SerializableResource.new(@post).serializable_hash
+        ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/\(\d+\.\d+ms\)/, @logger.messages)
       end
     end

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -57,10 +57,10 @@ module ActiveModelSerializers
         end
 
         def test_limiting_fields
-          actual = ActiveModel::SerializableResource.new(
+          actual = ActiveModelSerializers::SerializableResource.new(
             [@first_post, @second_post], adapter: :json_api,
                                          fields: { posts: %w(title comments blog author) })
-                                                    .serializable_hash
+                                                               .serializable_hash
           expected = [
             {
               id: '1',

--- a/test/adapter/json_api/errors_test.rb
+++ b/test/adapter/json_api/errors_test.rb
@@ -18,7 +18,7 @@ module ActiveModelSerializers
 
           @resource.errors.add(:name, 'cannot be nil')
 
-          serializable_resource = ActiveModel::SerializableResource.new(@resource, options)
+          serializable_resource = ActiveModelSerializers::SerializableResource.new(@resource, options)
           assert_equal serializable_resource.serializer_instance.attributes, {}
           assert_equal serializable_resource.serializer_instance.object, @resource
 
@@ -44,7 +44,7 @@ module ActiveModelSerializers
           @resource.errors.add(:name, 'must be longer')
           @resource.errors.add(:id, 'must be a uuid')
 
-          serializable_resource = ActiveModel::SerializableResource.new(@resource, options)
+          serializable_resource = ActiveModelSerializers::SerializableResource.new(@resource, options)
           assert_equal serializable_resource.serializer_instance.attributes, {}
           assert_equal serializable_resource.serializer_instance.object, @resource
 

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -312,9 +312,9 @@ module ActiveModelSerializers
         end
 
         def test_no_duplicates
-          hash = ActiveModel::SerializableResource.new(@post1, adapter: :json_api,
-                                                               include: '*.*')
-                                                  .serializable_hash
+          hash = ActiveModelSerializers::SerializableResource.new(@post1, adapter: :json_api,
+                                                                          include: '*.*')
+                                                             .serializable_hash
           expected = [
             {
               type: 'authors', id: '1',
@@ -340,10 +340,10 @@ module ActiveModelSerializers
         end
 
         def test_no_duplicates_collection
-          hash = ActiveModel::SerializableResource.new(
+          hash = ActiveModelSerializers::SerializableResource.new(
             [@post1, @post2], adapter: :json_api,
                               include: '*.*')
-                                                  .serializable_hash
+                                                             .serializable_hash
           expected = [
             {
               type: 'authors', id: '1',
@@ -361,7 +361,7 @@ module ActiveModelSerializers
         end
 
         def test_no_duplicates_global
-          hash = ActiveModel::SerializableResource.new(
+          hash = ActiveModelSerializers::SerializableResource.new(
             @nestedpost1,
             adapter: :json_api,
             include: '*').serializable_hash
@@ -380,7 +380,7 @@ module ActiveModelSerializers
         end
 
         def test_no_duplicates_collection_global
-          hash = ActiveModel::SerializableResource.new(
+          hash = ActiveModelSerializers::SerializableResource.new(
             [@nestedpost1, @nestedpost2],
             adapter: :json_api,
             include: '*').serializable_hash

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -30,7 +30,7 @@ module ActiveModelSerializers
         end
 
         def test_toplevel_links
-          hash = ActiveModel::SerializableResource.new(
+          hash = ActiveModelSerializers::SerializableResource.new(
             @post,
             adapter: :json_api,
             links: {
@@ -53,7 +53,7 @@ module ActiveModelSerializers
         end
 
         def test_nil_toplevel_links
-          hash = ActiveModel::SerializableResource.new(
+          hash = ActiveModelSerializers::SerializableResource.new(
             @post,
             adapter: :json_api,
             links: nil
@@ -62,7 +62,7 @@ module ActiveModelSerializers
         end
 
         def test_nil_toplevel_links_json_adapter
-          hash = ActiveModel::SerializableResource.new(
+          hash = ActiveModelSerializers::SerializableResource.new(
             @post,
             adapter: :json,
             links: nil

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -32,7 +32,7 @@ module ActiveModelSerializers
 
         def load_adapter(paginated_collection, options = {})
           options = options.merge(adapter: :json_api)
-          ActiveModel::SerializableResource.new(paginated_collection, options)
+          ActiveModelSerializers::SerializableResource.new(paginated_collection, options)
         end
 
         def using_kaminari(page = 2)

--- a/test/adapter/json_api/resource_meta_test.rb
+++ b/test/adapter/json_api/resource_meta_test.rb
@@ -36,7 +36,7 @@ module ActiveModel
           end
 
           def test_meta_hash_object_resource
-            hash = ActiveModel::SerializableResource.new(
+            hash = ActiveModelSerializers::SerializableResource.new(
               @post,
               serializer: MetaHashPostSerializer,
               adapter: :json_api
@@ -48,7 +48,7 @@ module ActiveModel
           end
 
           def test_meta_block_object_resource
-            hash = ActiveModel::SerializableResource.new(
+            hash = ActiveModelSerializers::SerializableResource.new(
               @post,
               serializer: MetaBlockPostSerializer,
               adapter: :json_api
@@ -62,7 +62,7 @@ module ActiveModel
           def test_meta_object_resource_in_array
             post2 = Post.new(id: 1339, comments: [Comment.new])
             posts = [@post, post2]
-            hash = ActiveModel::SerializableResource.new(
+            hash = ActiveModelSerializers::SerializableResource.new(
               posts,
               each_serializer: MetaBlockPostSerializer,
               adapter: :json_api
@@ -77,7 +77,7 @@ module ActiveModel
           end
 
           def test_meta_object_blank_omitted
-            hash = ActiveModel::SerializableResource.new(
+            hash = ActiveModelSerializers::SerializableResource.new(
               @post,
               serializer: MetaBlockPostBlankMetaSerializer,
               adapter: :json_api
@@ -86,7 +86,7 @@ module ActiveModel
           end
 
           def test_meta_object_empty_string_omitted
-            hash = ActiveModel::SerializableResource.new(
+            hash = ActiveModelSerializers::SerializableResource.new(
               @post,
               serializer: MetaBlockPostEmptyStringSerializer,
               adapter: :json_api

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -257,7 +257,7 @@ module ActiveModelSerializers
     private
 
     def render_object_with_cache(obj, options = {})
-      ActiveModel::SerializableResource.new(obj, options).serializable_hash
+      SerializableResource.new(obj, options).serializable_hash
     end
   end
 end

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -1,12 +1,19 @@
 require 'test_helper'
 
-module ActiveModel
+module ActiveModelSerializers
   class SerializableResourceTest < ActiveSupport::TestCase
     def setup
       @resource = Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' })
       @serializer = ProfileSerializer.new(@resource)
       @adapter = ActiveModelSerializers::Adapter.create(@serializer)
-      @serializable_resource = ActiveModel::SerializableResource.new(@resource)
+      @serializable_resource = SerializableResource.new(@resource)
+    end
+
+    def test_deprecation
+      assert_output(nil, /deprecated/) do
+        deprecated_serializable_resource = ActiveModel::SerializableResource.new(@resource)
+        assert_equal(@serializable_resource.as_json, deprecated_serializable_resource.as_json)
+      end
     end
 
     def test_serializable_resource_delegates_serializable_hash_to_the_adapter
@@ -25,11 +32,11 @@ module ActiveModel
     end
 
     def test_use_adapter_with_adapter_option
-      assert ActiveModel::SerializableResource.new(@resource, { adapter: 'json' }).use_adapter?
+      assert SerializableResource.new(@resource, { adapter: 'json' }).use_adapter?
     end
 
     def test_use_adapter_with_adapter_option_as_false
-      refute ActiveModel::SerializableResource.new(@resource, { adapter: false }).use_adapter?
+      refute SerializableResource.new(@resource, { adapter: false }).use_adapter?
     end
 
     class SerializableResourceErrorsTest < Minitest::Test
@@ -37,7 +44,7 @@ module ActiveModel
         options = nil
         resource = ModelWithErrors.new
         resource.errors.add(:name, 'must be awesome')
-        serializable_resource = ActiveModel::SerializableResource.new(
+        serializable_resource = ActiveModelSerializers::SerializableResource.new(
           resource, {
             serializer: ActiveModel::Serializer::ErrorSerializer,
             adapter: :json_api
@@ -57,7 +64,7 @@ module ActiveModel
         resources << resource = ModelWithErrors.new
         resource.errors.add(:title, 'must be amazing')
         resources << ModelWithErrors.new
-        serializable_resource = ActiveModel::SerializableResource.new(
+        serializable_resource = SerializableResource.new(
           resources, {
             serializer: ActiveModel::Serializer::ErrorsSerializer,
             each_serializer: ActiveModel::Serializer::ErrorSerializer,

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -76,7 +76,7 @@ module ActiveModel
           attribute :id
         end
 
-        hash = ActiveModel::SerializableResource.new(@blog, adapter: :json, serializer: serializer).serializable_hash
+        hash = ActiveModelSerializers::SerializableResource.new(@blog, adapter: :json, serializer: serializer).serializable_hash
 
         assert_equal('custom', hash[:blog][:id])
       end

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -11,7 +11,7 @@ module ActiveModel
       end
 
       def test_meta_is_present_with_root
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json,
           serializer: AlternateBlogSerializer,
@@ -29,7 +29,7 @@ module ActiveModel
       end
 
       def test_meta_is_not_included_when_blank
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json,
           serializer: AlternateBlogSerializer,
@@ -45,7 +45,7 @@ module ActiveModel
       end
 
       def test_meta_is_not_included_when_empty_string
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json,
           serializer: AlternateBlogSerializer,
@@ -61,7 +61,7 @@ module ActiveModel
       end
 
       def test_meta_is_not_included_when_root_is_missing
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :attributes,
           serializer: AlternateBlogSerializer,
@@ -74,7 +74,7 @@ module ActiveModel
       end
 
       def test_meta_key_is_used
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json,
           serializer: AlternateBlogSerializer,
@@ -93,7 +93,7 @@ module ActiveModel
       end
 
       def test_meta_key_is_used_with_json_api
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
           serializer: AlternateBlogSerializer,
@@ -111,7 +111,7 @@ module ActiveModel
       end
 
       def test_meta_key_is_not_present_when_blank_object_with_json_api
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
           serializer: AlternateBlogSerializer,
@@ -129,7 +129,7 @@ module ActiveModel
       end
 
       def test_meta_key_is_not_present_when_empty_string_with_json_api
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
           serializer: AlternateBlogSerializer,
@@ -147,7 +147,7 @@ module ActiveModel
       end
 
       def test_meta_is_not_present_on_arrays_without_root
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           [@blog],
           adapter: :attributes,
           meta: { total: 10 }).as_json
@@ -168,7 +168,7 @@ module ActiveModel
       end
 
       def test_meta_is_present_on_arrays_with_root
-        actual = ActiveModel::SerializableResource.new(
+        actual = ActiveModelSerializers::SerializableResource.new(
           [@blog],
           adapter: :json,
           meta: { total: 10 },

--- a/test/serializers/serialization_test.rb
+++ b/test/serializers/serialization_test.rb
@@ -21,7 +21,7 @@ module ActiveModel
         @authors = [Author.new(id: 1, name: 'Blog Author')]
         @blog = Blog.new(id: 2, name: 'The Blog', authors: @authors)
         @serializer_instance = BlogSerializer.new(@blog)
-        @serializable = ActiveModel::SerializableResource.new(@blog, serializer: BlogSerializer, adapter: :attributes)
+        @serializable = ActiveModelSerializers::SerializableResource.new(@blog, serializer: BlogSerializer, adapter: :attributes)
         @expected_hash = { id: 2, title: 'The Blog', authors: [{ id: 1, name: 'Blog Author' }] }
         @expected_json = '{"id":2,"title":"The Blog","authors":[{"id":1,"name":"Blog Author"}]}'
       end

--- a/test/support/serialization_testing.rb
+++ b/test/support/serialization_testing.rb
@@ -6,14 +6,14 @@ module SerializationTesting
   private
 
   def generate_cached_serializer(obj)
-    ActiveModel::SerializableResource.new(obj).to_json
+    ActiveModelSerializers::SerializableResource.new(obj).to_json
   end
 
   # Aliased as :with_configured_adapter to clarify that
   # this method tests the configured adapter.
   # When not testing configuration, it may be preferable
-  # to pass in the +adapter+ option to <tt>ActiveModel::SerializableResource</tt>.
-  # e.g ActiveModel::SerializableResource.new(resource, adapter: :json_api)
+  # to pass in the +adapter+ option to <tt>ActiveModelSerializers::SerializableResource</tt>.
+  # e.g ActiveModelSerializers::SerializableResource.new(resource, adapter: :json_api)
   def with_adapter(adapter)
     old_adapter = ActiveModelSerializers.config.adapter
     ActiveModelSerializers.config.adapter = adapter
@@ -40,7 +40,7 @@ module SerializationTesting
   end
 
   def serializable(resource, options = {})
-    ActiveModel::SerializableResource.new(resource, options)
+    ActiveModelSerializers::SerializableResource.new(resource, options)
   end
 end
 


### PR DESCRIPTION
#### Purpose
Moves `SerializableResource` to `ActiveModelSerializers` namespace based on https://github.com/groyoh/active_model_serializers/blob/master/docs/rfcs/0000-namespace.md

#### Changes
* `ActiveModel::SerializableResource` code was moved to `ActiveModelSerializers::SerializableResource`
* `ActiveModel::SerializableResource` is flagged as deprecated.
* All the references were updated

#### Related GitHub issues
#1310