### PR TITLE
Namespace separator setting

### DIFF
--- a/docs/general/configuration_options.md
+++ b/docs/general/configuration_options.md
@@ -63,6 +63,21 @@ Possible values:
 - `:singular`
 - `:plural` (default)
 
+##### jsonapi_namespace_separator
+
+Sets separator string for namespaced models to render `type` attribute. Default value is `--`.
+
+##### jsonapi_type_transform
+
+Provides transform for `type` attribute. Class name `NicePost` gets converted into `nice_post`, `nice-post`, `NicePost` or `nicePost` depending on selected setting.
+
+Possible values:
+
+- `:underscore` (default)
+- `:dashed`
+- `:camel`
+- `:snake`
+
 ##### jsonapi_include_toplevel_object
 
 Include a [top level jsonapi member](http://jsonapi.org/format/#document-jsonapi-object)

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -21,6 +21,8 @@ module ActiveModel
 
         config.adapter = :attributes
         config.jsonapi_resource_type = :plural
+        config.jsonapi_namespace_separator = '--'.freeze
+        config.jsonapi_type_transform = :underscore
         config.jsonapi_version = '1.0'
         config.jsonapi_toplevel_meta = {}
         # Make JSON API top-level jsonapi member opt-in

--- a/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
@@ -20,11 +20,13 @@ module ActiveModelSerializers
 
         def type_for(serializer)
           return serializer._type if serializer._type
-          if ActiveModelSerializers.config.jsonapi_resource_type == :singular
-            serializer.object.class.model_name.singular
-          else
-            serializer.object.class.model_name.plural
+          type = serializer.object.class.to_s.split('::')
+          type.map! { |t| KeyTransform.transform(t, ActiveModelSerializers.config.jsonapi_type_transform) }
+          type = type.join ActiveModelSerializers.config.jsonapi_namespace_separator
+          if ActiveModelSerializers.config.jsonapi_resource_type == :plural
+            type = type.pluralize
           end
+          type
         end
 
         def id_for(serializer)

--- a/lib/active_model_serializers/key_transform.rb
+++ b/lib/active_model_serializers/key_transform.rb
@@ -46,5 +46,26 @@ module ActiveModelSerializers
     def unaltered(hash)
       hash
     end
+
+    # Transforms string to selected case
+    # Accepts string in any case: 'camel', 'undescore', 'dashed'.
+    #
+    # @example:
+    #   transform('SomeClass', :underscore) => 'some_class'
+    #   transform('some_class', :snake) => 'someClass'
+    #   etc...
+    def transform(string, type)
+      string = string.underscore
+      case type.to_sym
+      when :dashed
+        string.dasherize
+      when :camel
+        string.camelize
+      when :snake
+        string.camelize(:lower)
+      else
+        string
+      end
+    end
   end
 end

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -216,7 +216,7 @@ module ActiveModelSerializers
           expected = {
             related: {
               data: [{
-                type: 'spam_unrelated_links',
+                type: 'spam--unrelated_links',
                 id: '456'
               }]
             }

--- a/test/adapter/json_api/resource_identifier_test.rb
+++ b/test/adapter/json_api/resource_identifier_test.rb
@@ -22,62 +22,60 @@ module ActiveModelSerializers
         end
 
         def test_defined_type
-          test_type(WithDefinedTypeSerializer, 'with_defined_type')
+          assert_identifier(WithDefinedTypeSerializer.new(@model), type: 'with_defined_type')
         end
 
         def test_singular_type
-          test_type_inflection(AuthorSerializer, 'author', :singular)
+          assert_with_confing(AuthorSerializer.new(@model), type: 'author', inflection: :singular)
         end
 
         def test_plural_type
-          test_type_inflection(AuthorSerializer, 'authors', :plural)
+          assert_with_confing(AuthorSerializer.new(@model), type: 'authors', inflection: :plural)
+        end
+
+        def test_type_with_namespace
+          spam = Spam::UnrelatedLink.new
+          assert_identifier(Spam::UnrelatedLinkSerializer.new(spam), type: 'spam--unrelated_links')
+        end
+
+        def test_type_with_custom_namespace
+          spam = Spam::UnrelatedLink.new
+          assert_with_confing(Spam::UnrelatedLinkSerializer.new(spam), type: 'spam/unrelated_links', namespace_separator: '/')
         end
 
         def test_id_defined_on_object
-          test_id(AuthorSerializer, @model.id.to_s)
+          assert_identifier(AuthorSerializer.new(@model), id: @model.id.to_s)
         end
 
         def test_id_defined_on_serializer
-          test_id(WithDefinedIdSerializer, 'special_id')
+          assert_identifier(WithDefinedIdSerializer.new(@model), id: 'special_id')
         end
 
         def test_id_defined_on_fragmented
           FragmentedSerializer.fragmented(WithDefinedIdSerializer.new(@model))
-          test_id(FragmentedSerializer, 'special_id')
+          assert_identifier(FragmentedSerializer.new(@model), id: 'special_id')
         end
 
         private
 
-        def test_type_inflection(serializer_class, expected_type, inflection)
-          original_inflection = ActiveModelSerializers.config.jsonapi_resource_type
-          ActiveModelSerializers.config.jsonapi_resource_type = inflection
-          test_type(serializer_class, expected_type)
-        ensure
-          ActiveModelSerializers.config.jsonapi_resource_type = original_inflection
-        end
-
-        def test_type(serializer_class, expected_type)
-          serializer = serializer_class.new(@model)
-          resource_identifier = ResourceIdentifier.new(serializer)
-          expected = {
-            id: @model.id.to_s,
-            type: expected_type
-          }
-
-          assert_equal(expected, resource_identifier.as_json)
-        end
-
-        def test_id(serializer_class, id)
-          serializer = serializer_class.new(@model)
-          resource_identifier = ResourceIdentifier.new(serializer)
+        def assert_with_confing(serializer, opts = {})
           inflection = ActiveModelSerializers.config.jsonapi_resource_type
-          type = @model.class.model_name.send(inflection)
-          expected = {
-            id: id,
-            type: type
-          }
+          namespace_separator = ActiveModelSerializers.config.jsonapi_namespace_separator
+          ActiveModelSerializers.config.jsonapi_resource_type = opts.fetch(:inflection, inflection)
+          ActiveModelSerializers.config.jsonapi_namespace_separator = opts.fetch(:namespace_separator, namespace_separator)
+          assert_identifier(serializer, opts)
+        ensure
+          ActiveModelSerializers.config.jsonapi_resource_type = inflection
+          ActiveModelSerializers.config.jsonapi_namespace_separator = namespace_separator
+        end
 
-          assert_equal(expected, resource_identifier.as_json)
+        def assert_identifier(serializer, opts = {})
+          identifier = ResourceIdentifier.new(serializer)
+          expected = {
+            id: opts.fetch(:id, identifier.as_json[:id]),
+            type: opts.fetch(:type, identifier.as_json[:type])
+          }
+          assert_equal(expected, identifier.as_json)
         end
       end
     end


### PR DESCRIPTION
#### Purpose
Introduces a global setting to control namespace separator for generating `type` attribute when using `json-api`.
`Cool::Author` becomes `cool--authors` with the default value `--`.
Using custom separator:
```
ActiveModelSerializers.config.jsonapi_namespace_separator = '/'
```
This will make for `cool/authors` which is supported by Ember by default.

#### Changes
`ActiveModelSerializers::Adapter::JsonApi::ResourceIdentifier.type_for`

#### Caveats
As a proposal, we may need to introduce type_transform setting, like key_transform. To provide ways to chose between undersored and dasherized types.

#### Related GitHub issues
Reimplementation of:
https://github.com/rails-api/active_model_serializers/pull/1216