### PR TITLE
deserialize nested attributes

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -181,7 +181,9 @@ module ActiveModelSerializers
         def parse_relationship(assoc_name, assoc_data, options)
           prefix_key = field_key(assoc_name, options).to_s.singularize
           hash =
-            if assoc_data.is_a?(Array)
+            if (options[:nested_attributes] || []).include?(assoc_name.to_sym)
+              parse_nested_attributes(assoc_name, assoc_data, options)
+            elsif assoc_data.is_a?(Array)
               { "#{prefix_key}_ids".to_sym => assoc_data.map { |ri| ri['id'] } }
             else
               { "#{prefix_key}_id".to_sym => assoc_data ? assoc_data['id'] : nil }
@@ -191,6 +193,16 @@ module ActiveModelSerializers
           hash["#{prefix_key}_type".to_sym] = assoc_data['type'] if polymorphic
 
           hash
+        end
+
+        def parse_nested_attributes(assoc_name, assoc_data, options)
+          data =
+            if assoc_data.is_a?(Array)
+              assoc_data.map { |ri| parse({ 'data' => ri }, options) }
+            else
+              parse({ 'data' => assoc_data }, options)
+            end
+          { "#{assoc_name}_attributes".to_sym => data }
         end
 
         # @api private

--- a/test/action_controller/json_api/deserialization_test.rb
+++ b/test/action_controller/json_api/deserialization_test.rb
@@ -9,6 +9,12 @@ module ActionController
             parsed_hash = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
             render json: parsed_hash
           end
+
+          def render_parsed_payload_with_nested_attributes
+            options     = { nested_attributes: [:author, :cameras] }
+            parsed_hash = ActiveModelSerializers::Deserialization.jsonapi_parse(params, options)
+            render json: parsed_hash
+          end
         end
 
         tests DeserializationTestController
@@ -47,6 +53,122 @@ module ActionController
             'title' => 'Ember Hamster',
             'src' => 'http://example.com/images/productivity.png',
             'author_id' => nil,
+            'photographer_id' => '9',
+            'comment_ids' => %w(1 2)
+          }
+
+          assert_equal(expected, response)
+        end
+
+        def test_nested_attributes_deserialization
+          hash = {
+            'data' => {
+              'type' => 'photos',
+              'id' => 'zorglub',
+              'attributes' => {
+                'title' => 'Ember Hamster',
+                'src' => 'http://example.com/images/productivity.png'
+              },
+              'relationships' => {
+                'author' => {
+                  'data' => {
+                    'type' => 'author',
+                    'attributes' => {
+                      'name' => 'John Doe'
+                    }
+                  }
+                },
+                'photographer' => {
+                  'data' => { 'type' => 'people', 'id' => '9' }
+                },
+                'comments' => {
+                  'data' => [
+                    { 'type' => 'comments', 'id' => '1' },
+                    { 'type' => 'comments', 'id' => '2' }
+                  ]
+                }
+              }
+            }
+          }
+
+          post :render_parsed_payload_with_nested_attributes, params: hash
+
+          response = JSON.parse(@response.body)
+          expected = {
+            'id' => 'zorglub',
+            'title' => 'Ember Hamster',
+            'src' => 'http://example.com/images/productivity.png',
+            'author_attributes' => {
+              'name' => 'John Doe'
+            },
+            'photographer_id' => '9',
+            'comment_ids' => %w(1 2)
+          }
+
+          assert_equal(expected, response)
+        end
+
+        def test_deeply_nested_attributes_deserialization
+          hash = {
+            'data' => {
+              'type' => 'photos',
+              'id' => 'zorglub',
+              'attributes' => {
+                'title' => 'Ember Hamster',
+                'src' => 'http://example.com/images/productivity.png'
+              },
+              'relationships' => {
+                'author' => {
+                  'data' => {
+                    'type' => 'author',
+                    'attributes' => {
+                      'name' => 'John Doe'
+                    },
+                    'relationships' => {
+                      'cameras' => {
+                        'data' => [{
+                          'type' => 'cameras',
+                          'id' => 'nikon',
+                          'attributes' => {
+                            'manifacturer' => 'Nikon'
+                          }
+                        }, {
+                          'type' => 'cameras',
+                          'attributes' => {
+                            'manifacturer' => 'Canon'
+                          }
+                        }]
+                      }
+                    }
+                  }
+                },
+                'photographer' => {
+                  'data' => { 'type' => 'people', 'id' => '9' }
+                },
+                'comments' => {
+                  'data' => [
+                    { 'type' => 'comments', 'id' => '1' },
+                    { 'type' => 'comments', 'id' => '2' }
+                  ]
+                }
+              }
+            }
+          }
+
+          post :render_parsed_payload_with_nested_attributes, params: hash
+
+          response = JSON.parse(@response.body)
+          expected = {
+            'id' => 'zorglub',
+            'title' => 'Ember Hamster',
+            'src' => 'http://example.com/images/productivity.png',
+            'author_attributes' => {
+              'name' => 'John Doe',
+              'cameras_attributes' => [
+                { 'id' => 'nikon', 'manifacturer' => 'Nikon' },
+                { 'manifacturer' => 'Canon' }
+              ]
+            },
             'photographer_id' => '9',
             'comment_ids' => %w(1 2)
           }


### PR DESCRIPTION
#### Purpose

Event though it's not yet part of the JSONAPI spec, EmberJS supports to embed data within a relationship. This mimics the behaviour of ActiveRecords nested attributes. With this pull request, active model serialisers is supporting the deserialization of data sent by the JSONAPISerializer of EmberJS when enabling embedded records for the relationship.

The behavior of EmberJS can be seen in this Twiddle: https://ember-twiddle.com/24893e21e87f065b1d48

#### Changes

An option `nested_attributes` is added to the JSONAPI deserializer of active model serializers, that can receive an array containing relationships that should be deserialized as `..._attributes` so it can be used with `accepts_nested_attributes_for` of ActiveRecord.

```ruby
def author_params
  ActiveModelSerializers::Deserialization.jsonapi_parse!(params, nested_attributes: [:author, :cameras])
end
```

#### Caveats
-

#### Related GitHub issues
-

#### Additional helpful information
-


