### PR TITLE
SerializableResource handles no serializer like controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Breaking changes:
 
 Features:
+- [#1616](https://github.com/rails-api/active_model_serializers/pull/1616) SerializableResource handles no serializer like controller. (@bf4)
 - [#1618](https://github.com/rails-api/active_model_serializers/issues/1618) Get collection root key for
   empty collection from explicit serializer option, when possible. (@bf4)
 - [#1574](https://github.com/rails-api/active_model_serializers/pull/1574) Provide key translation. (@remear)

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -33,20 +33,12 @@ module ActionController
         options[:adapter] = false
       end
       serializable_resource = ActiveModel::SerializableResource.new(resource, options)
-      if serializable_resource.serializer?
-        serializable_resource.serialization_scope ||= serialization_scope
-        serializable_resource.serialization_scope_name = _serialization_scope
-        begin
-          # Necessary to ensure we have an adapter for the serializable resource
-          # after it has been figured.
-          # TODO: This logic should be less opaque and probably moved into the SerializableResource.
-          serializable_resource.tap(&:adapter)
-        rescue ActiveModel::Serializer::CollectionSerializer::NoSerializerError
-          resource
-        end
-      else
-        resource
-      end
+      serializable_resource.serialization_scope ||= serialization_scope
+      serializable_resource.serialization_scope_name = _serialization_scope
+      # For compatibility with the JSON renderer: `json.to_json(options) if json.is_a?(String)`.
+      # Otherwise, since `serializable_resource` is not a string, the renderer would call
+      # `to_json` on a String and given odd results, such as `"".to_json #=> '""'`
+      serializable_resource.adapter.is_a?(String) ? serializable_resource.adapter : serializable_resource
     end
 
     # Deprecated

--- a/lib/active_model/serializable_resource.rb
+++ b/lib/active_model/serializable_resource.rb
@@ -30,10 +30,18 @@ module ActiveModel
       serializer_opts[:scope_name] = scope_name
     end
 
+    # NOTE: if no adapter is available, returns the resource itself. (i.e. adapter is a no-op)
     def adapter
-      @adapter ||= ActiveModelSerializers::Adapter.create(serializer_instance, adapter_opts)
+      @adapter ||= find_adapter
     end
     alias adapter_instance adapter
+
+    def find_adapter
+      return resource unless serializer?
+      ActiveModelSerializers::Adapter.create(serializer_instance, adapter_opts)
+    rescue ActiveModel::Serializer::CollectionSerializer::NoSerializerError
+      resource
+    end
 
     def serializer_instance
       @serializer_instance ||= serializer.new(resource, serializer_opts)

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -20,6 +20,7 @@ module ActiveModel
   class Serializer
     extend ActiveSupport::Autoload
     autoload :Adapter
+    autoload :Null
     include Configuration
     include Associations
     include Attributes

--- a/lib/active_model/serializer/null.rb
+++ b/lib/active_model/serializer/null.rb
@@ -1,0 +1,17 @@
+module ActiveModel
+  class Serializer
+    class Null < Serializer
+      def attributes(*)
+        {}
+      end
+
+      def associations(*)
+        {}
+      end
+
+      def serializable_hash(*)
+        {}
+      end
+    end
+  end
+end

--- a/lib/active_model_serializers/logging.rb
+++ b/lib/active_model_serializers/logging.rb
@@ -81,7 +81,10 @@ module ActiveModelSerializers
     end
 
     def notify_render_payload
-      { serializer: serializer, adapter: adapter }
+      {
+        serializer: serializer || ActiveModel::Serializer::Null,
+        adapter: adapter || ActiveModelSerializers::Adapter::Null
+      }
     end
 
     private


### PR DESCRIPTION
Fixes when passing in a resource to SerializableResource outside of a controller, a
resource without a known Serializer will no longer raise
`NoMethodError: undefined method 'new' for nil:NilClass`, but will behave like the
controller and just use the resource, as is.

Follows https://github.com/rails-api/active_model_serializers/pull/1580#discussion_r55843774