### PR TITLE
Allow devs to opt out of test warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,8 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-  t.ruby_opts = ['-w -r./test/test_helper.rb']
+  t.ruby_opts = ['-r./test/test_helper.rb']
+  t.ruby_opts << ' -w' unless ENV['NO_WARN'] == 'true'
   t.verbose = true
 end
 

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -454,7 +454,7 @@ module ActionController
       end
 
       def test_render_event_is_emmited
-        ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |name|
+        ::ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |name|
           @name = name
         end
 

--- a/test/active_model_serializers/adapter_for_test.rb
+++ b/test/active_model_serializers/adapter_for_test.rb
@@ -1,5 +1,7 @@
+require 'test_helper'
+
 module ActiveModelSerializers
-  class AdapterForTest < ActiveSupport::TestCase
+  class AdapterForTest < ::ActiveSupport::TestCase
     UnknownAdapterError = ::ActiveModelSerializers::Adapter::UnknownAdapterError
 
     def test_serializer_adapter_returns_configured_adapter


### PR DESCRIPTION
`NO_WARN=true bundle exec rake`

Also, I don't think warnings and the minitest reporter
play well together.

Extracted from #1478  