### PR TITLE
Fix warnings

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -54,7 +54,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'simplecov', '~> 0.11'
   spec.add_development_dependency 'timecop', '~> 0.7'
-  spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'grape', ['>= 0.13', '< 1.0']
   spec.add_development_dependency 'json_schema'
   spec.add_development_dependency 'rake', ['>= 10.0', '< 12.0']

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -38,6 +38,7 @@ module ActiveModel
         super
         @_links = {}
         @_include_data = true
+        @_meta = nil
       end
 
       def link(name, value = nil, &block)

--- a/lib/active_model_serializers/adapter/json_api/link.rb
+++ b/lib/active_model_serializers/adapter/json_api/link.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/module/delegation'
-
 module ActiveModelSerializers
   module Adapter
     class JsonApi
@@ -41,8 +39,7 @@ module ActiveModelSerializers
       #     meta: meta,
       #   }.reject! {|_,v| v.nil? }
       class Link
-        include SerializationContext.url_helpers
-        delegate :default_url_options, to: SerializationContext
+        include SerializationContext::UrlHelpers
 
         def initialize(serializer, value)
           @object = serializer.object
@@ -70,8 +67,8 @@ module ActiveModelSerializers
           return @value if @value
 
           hash = {}
-          hash[:href] = @href if @href
-          hash[:meta] = @meta if @meta
+          hash[:href] = @href if defined?(@href)
+          hash[:meta] = @meta if defined?(@meta)
 
           hash
         end

--- a/lib/active_model_serializers/serialization_context.rb
+++ b/lib/active_model_serializers/serialization_context.rb
@@ -2,6 +2,22 @@ module ActiveModelSerializers
   class SerializationContext
     class << self
       attr_writer :url_helpers, :default_url_options
+      def url_helpers
+        @url_helpers ||= Module.new
+      end
+
+      def default_url_options
+        @default_url_options ||= {}
+      end
+    end
+    module UrlHelpers
+      def self.included(base)
+        base.send(:include, SerializationContext.url_helpers)
+      end
+
+      def default_url_options
+        SerializationContext.default_url_options
+      end
     end
 
     attr_reader :request_url, :query_parameters, :key_transform
@@ -12,14 +28,6 @@ module ActiveModelSerializers
       @url_helpers = options.delete(:url_helpers) || self.class.url_helpers
       @default_url_options = options.delete(:default_url_options) || self.class.default_url_options
       @key_transform = options.delete(:key_transform)
-    end
-
-    def self.url_helpers
-      @url_helpers ||= Module.new
-    end
-
-    def self.default_url_options
-      @default_url_options ||= {}
     end
   end
 end

--- a/test/adapter/json_api/resource_identifier_test.rb
+++ b/test/adapter/json_api/resource_identifier_test.rb
@@ -42,7 +42,7 @@ module ActiveModelSerializers
         end
 
         def test_id_defined_on_fragmented
-          FragmentedSerializer.fragmented(WithDefinedIdSerializer.new(@author))
+          FragmentedSerializer.fragmented(WithDefinedIdSerializer.new(@model))
           test_id(FragmentedSerializer, 'special_id')
         end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -2,6 +2,7 @@ require 'active_record'
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 ActiveRecord::Schema.define do
+  self.verbose = false
   create_table :posts, force: true do |t|
     t.string :title
     t.text :body

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,8 +36,6 @@ else
   # https://github.com/seattlerb/minitest/blob/e21fdda9d/lib/minitest/autorun.rb
   # https://github.com/seattlerb/minitest/blob/e21fdda9d/lib/minitest.rb#L45-L59
 end
-require 'minitest/reporters'
-Minitest::Reporters.use!
 
 require 'support/rails_app'
 


### PR DESCRIPTION
CI output needs to be reviewed.

I'm also trying to figure out which tests cause
- `lib/action_dispatch/routing/route_set.rb:429: warning: instance variable @_routes not initialized`
and why.
- If we can silence all the grape warnings `gems/grape-0.15.0/lib/grape`


Also:
- Less hacky test routes setup
- Remove annoying progress reporter broken by warnings output