### PR TITLE
[WIP] Move ActiveModel::Serializer::* to ActiveModelSerializers namespace

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -10,7 +10,7 @@ require 'active_model/serializer/caching'
 require 'active_model/serializer/configuration'
 require 'active_model/serializer/fieldset'
 require 'active_model/serializer/lint'
-require 'active_model/serializer/links'
+require 'active_model_serializers/resource/links'
 require 'active_model/serializer/meta'
 require 'active_model/serializer/type'
 
@@ -25,7 +25,7 @@ module ActiveModel
     include Associations
     include Attributes
     include Caching
-    include Links
+    include ActiveModelSerializers::Resource::Links
     include Meta
     include Type
 

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -16,6 +16,7 @@ module ActiveModelSerializers
   autoload :Adapter
   autoload :JsonPointer
   autoload :Deprecate
+  autoload :Resource
 
   class << self; attr_accessor :logger; end
   self.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))

--- a/lib/active_model_serializers/resource.rb
+++ b/lib/active_model_serializers/resource.rb
@@ -1,0 +1,4 @@
+module ActiveModelSerializers
+  module Resource
+  end
+end

--- a/lib/active_model_serializers/resource/links.rb
+++ b/lib/active_model_serializers/resource/links.rb
@@ -1,5 +1,5 @@
-module ActiveModel
-  class Serializer
+module ActiveModelSerializers
+  module Resource
     module Links
       extend ActiveSupport::Concern
 


### PR DESCRIPTION
#### Purpose

Per https://github.com/rails-api/active_model_serializers/blob/master/docs/rfcs/0000-namespace.md
#### Changes

I moved the following to `ActiveModelSerializers::Resource` namespace:
- `ActiveModel::Serializer::Links`
#### Additional informations

I've updated the PR to only move one file at once based on @bf4 comments. I will either move the remaining file with new commits once the current commit is approved or create a new PR for them.

The original PR description is available below.
# Original PR description
#### Purpose

Per https://github.com/rails-api/active_model_serializers/blob/master/docs/rfcs/0000-namespace.md
#### Changes

The changes seems to be huge but you can easily go through each commit and check them one by one. No deprecation warning needed to be done. I mainly moved the following to `ActiveModelSerializers` namespace:
- `ActiveModel::Serializer::Links`
- `ActiveModel::Serializer::Meta`
- `ActiveModel::Serializer::Type`
- `ActiveModel::Serializer::Field`
- `ActiveModel::Serializer::Attributes`
- `ActiveModel::Serializer::Attribute`
- `ActiveModel::Serializer::Associations`
- `ActiveModel::Serializer::Association`
- `ActiveModel::Serializer::Reflection`
- `ActiveModel::Serializer::HasOneReflection`
- `ActiveModel::Serializer::HasManyReflection`
- `ActiveModel::Serializer::BelongsToReflection`
- `ActiveModel::Serializer::VERSION`
- `ActiveModel::Serializer::Configuration`

`ActiveModel::Serializer::VERSION` now references `ActiveModelSerializers::VERSION`.

Only two tests needed to be changed because they then referenced the wrong class.
### Caveats

From the RFC I'm not sure if they should actually go under `ActiveModelSerializers::Serializer` instead of `ActiveModelSerializers`.

There are still a few files that I didn't move cause I feel it would be more appropriate to handle it their own PR due to the changes needed to move them (e.g. `FieldsSet`)
