### PR TITLE
Optional fields in associations (priority on serializer)

### DIFF
--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -20,6 +20,7 @@ module ActiveModel
         end
 
         config.adapter = :attributes
+        config.attributes_adapter_include_default = '*'
         config.jsonapi_resource_type = :plural
         config.jsonapi_version = '1.0'
         config.jsonapi_toplevel_meta = {}

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -103,7 +103,11 @@ module ActiveModel
           begin
             serializer = serializer_class.new(
               association_value,
-              serializer_options(subject, parent_serializer_options, reflection_options)
+              serializer_options(
+                subject,
+                parent_serializer_options,
+                reflection_options.merge(options)
+              )
             )
           rescue ActiveModel::Serializer::CollectionSerializer::NoSerializerError
             reflection_options[:virtual_value] = association_value.try(:as_json) || association_value

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -84,6 +84,72 @@ module ActiveModelSerializers
 
           assert_equal(expected, actual)
         end
+
+        def test_fields_option
+          serializer = ActiveModel::Serializer::CollectionSerializer.new([@first_post, @second_post])
+          adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
+          actual = adapter.serializable_hash(fields: [:id])
+
+          expected = { posts: [{
+            id: 1,
+            comments: [],
+            author: {
+              id: 1,
+              name: 'Steve K.'
+            },
+            blog: {
+              id: 999,
+              name: 'Custom blog'
+            }
+          }, {
+            id: 2,
+            comments: [],
+            author: {
+              id: 1,
+              name: 'Steve K.'
+            },
+            blog: {
+              id: 999,
+              name: 'Custom blog'
+            }
+          }] }
+
+          assert_equal(expected, actual)
+        end
+
+        def test_fields_with_no_associations_include_option
+          serializer = ActiveModel::Serializer::CollectionSerializer.new([@first_post, @second_post])
+          adapter = ActiveModelSerializers::Adapter::Json.new(serializer, include: [])
+          actual = adapter.serializable_hash(fields: [:id])
+
+          expected = { posts: [{
+            id: 1
+          }, {
+            id: 2
+          }] }
+
+          assert_equal(expected, actual)
+        end
+
+        def test_fields_with_associations_fields_option
+          serializer = ActiveModel::Serializer::CollectionSerializer.new([@first_post, @second_post])
+          adapter = ActiveModelSerializers::Adapter::Json.new(serializer, include: [:author])
+          actual = adapter.serializable_hash(fields: [:id, author: [:name]])
+
+          expected = { posts: [{
+            id: 1,
+            author: {
+              name: 'Steve K.'
+            }
+          }, {
+            id: 2,
+            author: {
+              name: 'Steve K.'
+            }
+          }] }
+
+          assert_equal(expected, actual)
+        end
       end
     end
   end


### PR DESCRIPTION
#### Purpose
The purpose of this PR is to have a graphql-like support in Attributes/JSON adapters. With this PR, you can filter fields on nested resources on those adapters.

Currently, there is a minor bug in the fields option in master branch. If you have:

```ruby
render json: @videos.limit(1), each_serializer: VideoSerializer,  fields: [:id],
```

This will apply the fields to all associations too. We don't want that. What we want is:

If there is a fields param, apply it to the main resource. If there are associations, serialize the associations without removing any attributes. For instance:

```ruby
render json: @videos.limit(1), each_serializer: VideoSerializer,  fields: [:id]
```

Then this should apply the `fields: [:id]` only in the VideoSerializer and not in any association.

If there are associations in the fields array (just like in StrongParams) and these also exist in the main resource, apply the associations fields there. For instance:

```ruby
render json: @videos.limit(1), each_serializer: VideoSerializer,  fields: [:id, user: [:name]]
```

Then this should apply the `fields: [:id]` only in the VideoSerializer and if there is a user association, apply `fields: [:name]` in the UserSerializer.

Also, a config option was also added (attributes_adapter_include_default) to denote the number of nested level is supported by the adapter. Default value is `'*.*'` which means 2 levels but this can change by the user.


**Options on the serializer level have higher priority.** So whatever you passed in the serializer constructor regarding associations, serializer's associations will render only id:

```ruby
  class VideoSerializer
    attributes :id, :video_id

    belongs_to :user, serializer: UserSerializer, fields: [:id], includes: []
  end
```

#### Changes
A config option was also added (attributes_adapter_include_default) to denote the number of nested level is supported by the adapter. Default value is ('*.*') which means 2 levels but this can change by the user.

#### Caveats
Please note that you can pass an array to fields. If you want to filter a nested resource, then an element of the array must be a hash with key the name of the association and value an array with the fields that you would like to pass.

So for instance, to have only id in the primary resource and in the likes association you should do:

```ruby
render json: @videos.limit(1), each_serializer: VideoSerializer,  fields: [:id, likes: [:id]]
```

**We need a helper function to convert url params to this structure**

Unfortunately, url params do not support this kind of structure due to limitation in the rack parse_nested_query method (https://github.com/rack/rack/issues/524).
Does it mean that this PR is useless ? No at all. Because you can manually exclude fields in the association level from the controller as well as in the serializer level.

And when rack issue is fixed (or someone monkey patches it) we have support for a graphql-like API.


#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/pull/1287
https://github.com/rails-api/active_model_serializers/pull/1285
https://github.com/rails-api/active_model_serializers/pull/1284
https://github.com/rails-api/active_model_serializers/issues/1243
https://github.com/rails-api/active_model_serializers/pull/1141


#### Additional helpful information



Also add default nested level in config for attributes/json adapters

wip

wip

wip

wip

Add default nested level in config for attributes/json adapters