### PR TITLE
Add serializer to association block context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Breaking changes:
 
 Features:
+- [#1633](https://github.com/rails-api/active_model_serializers/pull/1633) Yield 'serializer' to serializer association blocks. (@bf4)
 - [#1616](https://github.com/rails-api/active_model_serializers/pull/1616) SerializableResource handles no serializer like controller. (@bf4)
 - [#1618](https://github.com/rails-api/active_model_serializers/issues/1618) Get collection root key for
   empty collection from explicit serializer option, when possible. (@bf4)

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -48,6 +48,18 @@ has_one :blog, key: :site
 has_one :maker, virtual_value: { id: 1 }
 ```
 
+``ruby
+has_one :blog do |serializer|
+  serializer.cached_blog
+end
+
+def cached_blog
+  cache_store.fetch("cached_blog:#{object.updated_at}") do
+    Blog.find(object.blog_id)
+  end
+end
+```
+
 #### ::has_many
 
 e.g.

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -56,14 +56,25 @@ module ActiveModel
         :nil
       end
 
+      # @param serializer [ActiveModel::Serializer]
+      # @yield [ActiveModel::Serializer]
+      # @return [:nil, associated resource or resource collection]
+      # @example
+      #   has_one :blog do |serializer|
+      #     serializer.cached_blog
+      #   end
+      #
+      #   def cached_blog
+      #     cache_store.fetch("cached_blog:#{object.updated_at}") do
+      #       Blog.find(object.blog_id)
+      #     end
+      #   end
       def value(serializer)
         @object = serializer.object
         @scope = serializer.scope
-        # Add '@serializer' to binding for use in association block as 'serializer'
-        @serializer = serializer
 
         if block
-          block_value = instance_eval(&block)
+          block_value = instance_exec(serializer, &block)
           if block_value == :nil
             serializer.read_attribute_for_serialization(name)
           else
@@ -119,7 +130,7 @@ module ActiveModel
 
       protected
 
-      attr_accessor :object, :scope, :serializer
+      attr_accessor :object, :scope
 
       private
 

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -59,6 +59,8 @@ module ActiveModel
       def value(serializer)
         @object = serializer.object
         @scope = serializer.scope
+        # Add '@serializer' to binding for use in association block as 'serializer'
+        @serializer = serializer
 
         if block
           block_value = instance_eval(&block)
@@ -117,7 +119,7 @@ module ActiveModel
 
       protected
 
-      attr_accessor :object, :scope
+      attr_accessor :object, :scope, :serializer
 
       private
 

--- a/test/adapter/json_api/relationships_test.rb
+++ b/test/adapter/json_api/relationships_test.rb
@@ -38,7 +38,7 @@ module ActiveModel
               end
             end
 
-            has_many :roles do
+            has_many :roles do |serializer|
               meta count: object.posts.count
               serializer.cached_roles
             end

--- a/test/adapter/json_api/relationships_test.rb
+++ b/test/adapter/json_api/relationships_test.rb
@@ -40,6 +40,7 @@ module ActiveModel
 
             has_many :roles do
               meta count: object.posts.count
+              serializer.cached_roles
             end
 
             has_one :blog do
@@ -60,6 +61,12 @@ module ActiveModel
               end
               meta liked: object.likes.any?
             end
+
+            def cached_roles
+              [
+                Role.new(id: 'from-serializer-method')
+              ]
+            end
           end
 
           def setup
@@ -67,7 +74,7 @@ module ActiveModel
             @blog = Blog.new(id: 1337, name: 'extra')
             @bio = Bio.new(id: 1337)
             @like = Like.new(id: 1337)
-            @role = Role.new(id: 1337)
+            @role = Role.new(id: 'from-record')
             @profile = Profile.new(id: 1337)
             @location = Location.new(id: 1337)
             @reviewer = Author.new(id: 1337)
@@ -144,7 +151,7 @@ module ActiveModel
 
           def test_relationship_meta
             expected = {
-              data: [{ id: '1337', type: 'roles' }],
+              data: [{ id: 'from-serializer-method', type: 'roles' }],
               meta: { count: 1 }
             }
             assert_relationship(:roles, expected)


### PR DESCRIPTION
Perhaps there some method on the serializer that I want to use in the association block.
I couldn't because it is being evaluated in the 'Reflection' object.

- [x] Add serializer to Reflection evaluation binding
- [x] Test that we can a serializer method from an association block
- [x] Document usage
- [x] Add changelog