### PR TITLE
[WIP] Allow users to opt-out from the ActionController extensions

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -13,6 +13,11 @@ module ActionController
       end
     end
 
+    class << self
+      attr_accessor :enabled
+    end
+    self.enabled = true
+
     included do
       class_attribute :_serialization_scope
       self._serialization_scope = :current_user

--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -9,12 +9,6 @@ module ActiveModelSerializers
       ActiveModel::Serializer.serializers_cache.clear
     end
 
-    initializer 'active_model_serializers.action_controller' do
-      ActiveSupport.on_load(:action_controller) do
-        include(::ActionController::Serialization)
-      end
-    end
-
     initializer 'active_model_serializers.prepare_serialization_context' do
       SerializationContext.url_helpers = Rails.application.routes.url_helpers
       SerializationContext.default_url_options = Rails.application.routes.default_url_options
@@ -29,6 +23,11 @@ module ActiveModelSerializers
       # We want this hook to run after the config has been set, even if ActionController has already loaded.
       ActiveSupport.on_load(:action_controller) do
         ActiveModelSerializers.config.cache_store = cache_store
+        # Only include controller mixin when enabled
+        # https://github.com/rails-api/active_model_serializers/issues/1500
+        # https://github.com/rails-api/active_model_serializers/pull/592
+        # Rails.configuration.action_controller.render_json_with_active_model_serializers
+        include ::ActionController::Serialization if ::ActionController::Serialization.enabled
       end
     end
 


### PR DESCRIPTION
#### Purpose
- Make it possible to require active_model_serializers without mixing `ActionController::Serialization` into the controller
#### Changes

Add `ActionController::Serialization.enabled = false` to an initializer and it won't be mixed in.
#### Caveats

This doesn't exactly solve #1500 since it doesn't include _any_ AMS code in the controller, and passing `serializer` or `each_serializer` won't work

Perhaps config should come from Rails, rather than be set on the mixin. e.g. 

`Rails.configuration.action_controller.render_json_with_active_model_serializers = false`
#### Related GitHub issues
- https://github.com/rails-api/active_model_serializers/issues/1500
- https://github.com/rails-api/active_model_serializers/pull/592

And many more
#### Additional helpful information

cc @trek 
