### PR TITLE
Make cache_store reference explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Breaking changes:
 
 Features:
+- [#1637](https://github.com/rails-api/active_model_serializers/pull/1637) Make references to 'ActionController::Base.cache_store' explicit
+  in order to avoid issues when application controllers inherit from 'ActionController::API'. (@ncuesta)
 - [#1633](https://github.com/rails-api/active_model_serializers/pull/1633) Yield 'serializer' to serializer association blocks. (@bf4)
 - [#1616](https://github.com/rails-api/active_model_serializers/pull/1616) SerializableResource handles no serializer like controller. (@bf4)
 - [#1618](https://github.com/rails-api/active_model_serializers/issues/1618) Get collection root key for

--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -28,7 +28,7 @@ module ActiveModelSerializers
       ActiveModelSerializers.config.perform_caching = Rails.configuration.action_controller.perform_caching
       # We want this hook to run after the config has been set, even if ActionController has already loaded.
       ActiveSupport.on_load(:action_controller) do
-        ActiveModelSerializers.config.cache_store = cache_store
+        ActiveModelSerializers.config.cache_store = ActionController::Base.cache_store
       end
     end
 


### PR DESCRIPTION
#### Purpose

Fix issue reported in [this comment](https://github.com/rails-api/active_model_serializers/issues/1634#issuecomment-203605139) from issue #1634.

#### Changes

Makes cache_store reference explicit.

#### Caveats

None.

#### Related GitHub issues

#1634 

#### Additional helpful information



This avoids an issue when the base class for application's controllers inherit from `ActionController::API` instead of `ActionController::Base`.