### PR TITLE
Fixed deserialization of attributes/relationships with multiple words

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -150,7 +150,7 @@ module ActiveModelSerializers
 
         # @api private
         def field_key(field, options)
-          (options[:keys] || {}).fetch(field.to_sym, field).to_sym
+          (options[:keys] || {}).fetch(field.to_sym, field).underscore.to_sym
         end
 
         # @api private
@@ -179,7 +179,7 @@ module ActiveModelSerializers
         #
         # @api private
         def parse_relationship(assoc_name, assoc_data, options)
-          prefix_key = field_key(assoc_name, options).to_s.singularize
+          prefix_key = field_key(assoc_name, options).to_s.underscore.singularize
           hash =
             if assoc_data.is_a?(Array)
               { "#{prefix_key}_ids".to_sym => assoc_data.map { |ri| ri['id'] } }

--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -28,7 +28,7 @@ module ActiveModelSerializers
       ActiveModelSerializers.config.perform_caching = Rails.configuration.action_controller.perform_caching
       # We want this hook to run after the config has been set, even if ActionController has already loaded.
       ActiveSupport.on_load(:action_controller) do
-        ActiveModelSerializers.config.cache_store = cache_store
+        ActiveModelSerializers.config.cache_store = ActionController::Base.cache_store
       end
     end
 

--- a/test/action_controller/json_api/deserialization_test.rb
+++ b/test/action_controller/json_api/deserialization_test.rb
@@ -20,7 +20,8 @@ module ActionController
               'id' => 'zorglub',
               'attributes' => {
                 'title' => 'Ember Hamster',
-                'src' => 'http://example.com/images/productivity.png'
+                'src' => 'http://example.com/images/productivity.png',
+                'photo-url' => 'http://placehold.it/350x150'
               },
               'relationships' => {
                 'author' => {
@@ -34,6 +35,11 @@ module ActionController
                     { 'type' => 'comments', 'id' => '1' },
                     { 'type' => 'comments', 'id' => '2' }
                   ]
+                },
+                'two-words' => {
+                  'data' => [
+                    { 'type' => 'two-words', 'id' => '1' }
+                  ]
                 }
               }
             }
@@ -43,12 +49,14 @@ module ActionController
 
           response = JSON.parse(@response.body)
           expected = {
-            'id' => 'zorglub',
             'title' => 'Ember Hamster',
             'src' => 'http://example.com/images/productivity.png',
+            'photo_url' => 'http://placehold.it/350x150',
+            'id' => 'zorglub',
             'author_id' => nil,
             'photographer_id' => '9',
-            'comment_ids' => %w(1 2)
+            'comment_ids' => %w(1 2),
+            'two_word_ids' => %w(1)
           }
 
           assert_equal(expected, response)


### PR DESCRIPTION
#### Purpose

Before the fix, deserialization didn't work for attributes/relationships with multiple words. For example `itinerary-items` relationship would deserialize into `itinerary-item_ids` instead of `itinerary_item_ids`. Or `photo-url` attribute would be `photo-url` instead of `photo_url`.

#### Changes

I just made sure that `field_key` and `prefix_key` were underscored.
