### PR TITLE
Include adapter in cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Breaking changes:
 
 Features:
+- [#1644](https://github.com/rails-api/active_model_serializers/pull/1644) Include adapter name in cache key so
+  that the same serializer can be cached per adapter. (@bf4 via #1346 by @kevintyll)
 - [#1642](https://github.com/rails-api/active_model_serializers/pull/1642) Prefer object.cache_key over the generated
   cache key. (@bf4 via #1346 by @kevintyll)
 - [#1637](https://github.com/rails-api/active_model_serializers/pull/1637) Make references to 'ActionController::Base.cache_store' explicit

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -58,6 +58,10 @@ module ActiveModel
           ''.freeze
         end
 
+        def _skip_digest?
+          _cache_options && _cache_options[:skip_digest]
+        end
+
         # @api private
         # Used by FragmentCache on the CachedSerializer
         #  to call attribute methods on the fragmented cached serializer.

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -30,7 +30,7 @@ module ActiveModelSerializers
       def cache_read_multi
         return {} if ActiveModelSerializers.config.cache_store.blank?
 
-        keys = CachedSerializer.object_cache_keys(serializer, @include_tree)
+        keys = CachedSerializer.object_cache_keys(serializer, self, @include_tree)
 
         return {} if keys.blank?
 
@@ -49,7 +49,7 @@ module ActiveModelSerializers
       def cached_attributes(cached_serializer)
         return yield unless cached_serializer.cached?
 
-        @cached_attributes.fetch(cached_serializer.cache_key) { yield }
+        @cached_attributes.fetch(cached_serializer.cache_key(self)) { yield }
       end
 
       def serializable_hash_for_single_resource(options)

--- a/lib/active_model_serializers/adapter/base.rb
+++ b/lib/active_model_serializers/adapter/base.rb
@@ -15,6 +15,10 @@ module ActiveModelSerializers
         @instance_options = options
       end
 
+      def cached_name
+        @cached_name ||= self.class.name.demodulize.underscore
+      end
+
       def serializable_hash(_options = nil)
         fail NotImplementedError, 'This is an abstract method. Should be implemented at the concrete adapter.'
       end

--- a/lib/active_model_serializers/cached_serializer.rb
+++ b/lib/active_model_serializers/cached_serializer.rb
@@ -9,7 +9,7 @@ module ActiveModelSerializers
 
     def cache_check(adapter_instance)
       if cached?
-        @klass._cache.fetch(cache_key, @klass._cache_options) do
+        @klass._cache.fetch(cache_key(adapter_instance), @klass._cache_options) do
           yield
         end
       elsif fragment_cached?
@@ -27,12 +27,13 @@ module ActiveModelSerializers
       @klass.fragment_cache_enabled?
     end
 
-    def cache_key
+    def cache_key(adapter_instance)
       return @cache_key if defined?(@cache_key)
 
       parts = []
       parts << object_cache_key
-      parts << @klass._cache_digest unless @klass._cache_options && @klass._cache_options[:skip_digest]
+      parts << adapter_instance.cached_name
+      parts << @klass._cache_digest unless @klass._skip_digest?
       @cache_key = parts.join('/')
     end
 
@@ -54,19 +55,19 @@ module ActiveModelSerializers
     # @param collection_serializer
     # @param include_tree
     # @return [Array] all cache_key of collection_serializer
-    def self.object_cache_keys(serializers, include_tree)
+    def self.object_cache_keys(serializers, adapter_instance, include_tree)
       cache_keys = []
 
       serializers.each do |serializer|
-        cache_keys << object_cache_key(serializer)
+        cache_keys << object_cache_key(serializer, adapter_instance)
 
         serializer.associations(include_tree).each do |association|
           if association.serializer.respond_to?(:each)
             association.serializer.each do |sub_serializer|
-              cache_keys << object_cache_key(sub_serializer)
+              cache_keys << object_cache_key(sub_serializer, adapter_instance)
             end
           else
-            cache_keys << object_cache_key(association.serializer)
+            cache_keys << object_cache_key(association.serializer, adapter_instance)
           end
         end
       end
@@ -75,11 +76,11 @@ module ActiveModelSerializers
     end
 
     # @return [String, nil] the cache_key of the serializer or nil
-    def self.object_cache_key(serializer)
+    def self.object_cache_key(serializer, adapter_instance)
       return unless serializer.present? && serializer.object.present?
 
       cached_serializer = new(serializer)
-      cached_serializer.cached? ? cached_serializer.cache_key : nil
+      cached_serializer.cached? ? cached_serializer.cache_key(adapter_instance) : nil
     end
   end
 end


### PR DESCRIPTION
Continues work in #1346, #1642

> Add the Adapter type to the cache key.

> This prevents incorrect results when the same object is serialized with different adapters.

Fixes #1344

Cherry-pick of
https://github.com/bf4/active_model_serializers/commit/040a97b9e9005ee6cb55f5a3d9088098407f54c2
which was a squash of
https://github.com/rails-api/active_model_serializers/commits/f89ed71058322fe7dd35d5c8b209856f8e03ad14

