### PR TITLE
Fix for Deserialization erroring when a relationship is null in the json api document.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Features:
 - [#1340](https://github.com/rails-api/active_model_serializers/pull/1340) Add support for resource-level meta. (@beauby)
 
 Fixes:
+- [#1651](https://github.com/rails-api/active_model_serializers/pull/1651) Fix deserialization of nil relationships. (@NullVoxPopuli)
 - [#1480](https://github.com/rails-api/active_model_serializers/pull/1480) Fix setting of cache_store from Rails configuration. (@bf4)
   Fix uninentional mutating of value in memory cache store. (@groyoh)
 - [#1622](https://github.com/rails-api/active_model_serializers/pull/1622) Fragment cache changed from per-record to per-serializer.

--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -188,7 +188,9 @@ module ActiveModelSerializers
             end
 
           polymorphic = (options[:polymorphic] || []).include?(assoc_name.to_sym)
-          hash["#{prefix_key}_type".to_sym] = assoc_data[:type] if polymorphic
+          if polymorphic
+            hash["#{prefix_key}_type".to_sym] = assoc_data.present? ? assoc_data[:type] : nil
+          end
 
           hash
         end


### PR DESCRIPTION
#### Purpose

I noticed when I was trying to parse the request for building a join model, I had this error:

```
NoMethodError - undefined method `[]' for nil:NilClass:
   () home/me/.rvm/gems/ruby-2.3.0/bundler/gems/active_model_serializers-96c5516d217a/lib/active_model_serializers/adapter/json_api/deserialization.rb:191:in `parse_relationship'
   () home/me/.rvm/gems/ruby-2.3.0/bundler/gems/active_model_serializers-96c5516d217a/lib/active_model_serializers/adapter/json_api/deserialization.rb:199:in `block in parse_relationships'
   () home/me/.rvm/gems/ruby-2.3.0/bundler/gems/active_model_serializers-96c5516d217a/lib/active_model_serializers/adapter/json_api/deserialization.rb:199:in `parse_relationships'
   () home/me/.rvm/gems/ruby-2.3.0/bundler/gems/active_model_serializers-96c5516d217a/lib/active_model_serializers/adapter/json_api/deserialization.rb:101:in `parse'
   () home/me/.rvm/gems/ruby-2.3.0/bundler/gems/active_model_serializers-96c5516d217a/lib/active_model_serializers/deserialization.rb:6:in `jsonapi_parse'
  app/controllers/api/restraints_controller.rb:35:in `create_restraint_params'

```

#### Changes

added test

#### Caveats


#### Related GitHub issues


#### Additional helpful information

How I'm parsing the params

```ruby
    ActiveModelSerializers::Deserialization.jsonapi_parse(
      params,
      polymorphic: [:restriction_for, :restricted_to]
    )
```


This happened with the latest (as of this time) version of AMS.