### PR TITLE
add require for active_support/json to fix #1656

### DIFF
--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -2,6 +2,7 @@ require 'active_model'
 require 'active_support'
 require 'active_support/core_ext/object/with_options'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/json'
 module ActiveModelSerializers
   extend ActiveSupport::Autoload
   autoload :Model

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,6 @@ require 'rails'
 require 'action_controller'
 require 'action_controller/test_case'
 require 'action_controller/railtie'
-require 'active_support/json'
 require 'active_model_serializers'
 require 'fileutils'
 FileUtils.mkdir_p(File.expand_path('../../tmp/cache', __FILE__))


### PR DESCRIPTION
#### Purpose
fixes the missing `require "active_support/json"` mentioned in #1656 

#### Changes

- remove explicit `require "active_support/json"` from test_helper.
- add `require "active_support/json"` to `lib/active_model_serializers.rb`

#### Caveats

Given all the other rails stuff required in the tests simply removing the active_support json extension from the test won't make any tests fail.

#### Related GitHub issues

#1656 