### PR TITLE
Drop support for Rails 4.0 and Ruby 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2.3
   - 2.3.0
@@ -26,25 +25,18 @@ env:
   global:
     - "JRUBY_OPTS='--dev -J-Xmx1024M --debug'"
   matrix:
-    - "RAILS_VERSION=4.0"
     - "RAILS_VERSION=4.1"
     - "RAILS_VERSION=4.2"
     - "RAILS_VERSION=master"
 
 matrix:
   exclude:
-  - rvm: 2.0.0
-    env: RAILS_VERSION=master
   - rvm: 2.1
     env: RAILS_VERSION=master
   - rvm: jruby-9.0.4.0
     env: RAILS_VERSION=master
-  - rvm: jruby-9.0.4.0
-    env: RAILS_VERSION=4.0
   - rvm: jruby-head
     env: RAILS_VERSION=master
-  - rvm: jruby-head
-    env: RAILS_VERSION=4.0
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ end
 group :test do
   gem 'sqlite3',                          platform: (@windows_platforms + [:ruby])
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-
   gem 'codeclimate-test-reporter', require: false
 end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ skip_tags: true
 
 environment:
   matrix:
-    - ruby_version: "200"
-    - ruby_version: "200-x64"
     - ruby_version: "21"
     - ruby_version: "21-x64"
     - ruby_version: "jruby-9.0.4.0"

--- a/lib/active_model/serializer/lint.rb
+++ b/lib/active_model/serializer/lint.rb
@@ -76,20 +76,17 @@ module ActiveModel::Serializer::Lint
       resource.to_json(nil)
     end
 
-    # Passes if the object responds to <tt>cache_key</tt> and if it takes no
-    # arguments (Rails 4.0) or a splat (Rails 4.1+).
+    # Passes if the object responds to <tt>cache_key</tt>
     # Fails otherwise.
     #
-    # <tt>cache_key</tt> returns a (self-expiring) unique key for the object, and
-    # is part of the (self-expiring) cache_key, which is used by the adapter.
-    # It is not required unless caching is enabled.
+    # <tt>cache_key</tt> returns a (self-expiring) unique key for the object,
+    # and is part of the (self-expiring) cache_key, which is used by the
+    # adapter. It is not required unless caching is enabled.
     def test_cache_key
       assert_respond_to resource, :cache_key
       actual_arity = resource.method(:cache_key).arity
-      # using absolute value since arity is:
-      #   0 for Rails 4.1+, *timestamp_names
-      #  -1 for Rails 4.0, no arguments
-      assert_includes [-1, 0], actual_arity, "expected #{actual_arity.inspect} to be 0 or -1"
+      assert_includes [-1, 0], actual_arity,
+        "expected #{actual_arity.inspect} to be 0 or -1"
     end
 
     # Passes if the object responds to <tt>updated_at</tt> and if it takes no

--- a/test/active_model_serializers/test/serializer_test.rb
+++ b/test/active_model_serializers/test/serializer_test.rb
@@ -10,9 +10,8 @@ module ActiveModelSerializers
           render json: Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
         end
 
-        # For Rails4.0
         def render_some_text
-          Rails.version > '4.1' ? render(plain: 'ok') : render(text: 'ok')
+          render(plain: 'ok')
         end
       end
 

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -3,34 +3,19 @@ require_relative 'collection_serializer_test'
 
 module ActiveModel
   class Serializer
-    # Minitest.run_one_method isn't present in minitest 4
-    if $minitest_version > 4 # rubocop:disable Style/GlobalVars
-      class ArraySerializerTest < CollectionSerializerTest
-        extend Minitest::Assertions
-        def self.run_one_method(*)
-          _, stderr = capture_io do
-            super
-          end
-          if stderr !~ /NOTE: ActiveModel::Serializer::ArraySerializer.new is deprecated/
-            fail Minitest::Assertion, stderr
-          end
+    class ArraySerializerTest < CollectionSerializerTest
+      extend Minitest::Assertions
+      def self.run_one_method(*)
+        _, stderr = capture_io do
+          super
         end
-
-        def collection_serializer
-          ArraySerializer
+        if stderr !~ /NOTE: ActiveModel::Serializer::ArraySerializer.new is deprecated/
+          fail Minitest::Assertion, stderr
         end
       end
-    else
-      class ArraySerializerTest < ActiveSupport::TestCase
-        def test_json_key_with_root_warns_when_using_array_serializer
-          _, stderr = capture_io do
-            comment = Comment.new
-            post = Post.new
-            serializer = ArraySerializer.new([comment, post])
-            assert_equal 'comments', serializer.json_key
-          end
-          assert_match(/NOTE: ActiveModel::Serializer::ArraySerializer.new is deprecated/, stderr)
-        end
+
+      def collection_serializer
+        ArraySerializer
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,27 +20,9 @@ require 'fileutils'
 FileUtils.mkdir_p(File.expand_path('../../tmp/cache', __FILE__))
 
 gem 'minitest'
-begin
-  require 'minitest'
-rescue LoadError
-  # Minitest 4
-  require 'minitest/autorun'
-  $minitest_version = 4
-  # https://github.com/seattlerb/minitest/blob/644a52fd0/lib/minitest/autorun.rb
-  # https://github.com/seattlerb/minitest/blob/644a52fd0/lib/minitest/unit.rb#L768-L787
-  # Ensure backward compatibility with Minitest 4
-  Minitest = MiniTest unless defined?(Minitest)
-  Minitest::Test = MiniTest::Unit::TestCase
-else
-  # Minitest 5
-  require 'minitest/autorun'
-  $minitest_version = 5
-  # https://github.com/seattlerb/minitest/blob/e21fdda9d/lib/minitest/autorun.rb
-  # https://github.com/seattlerb/minitest/blob/e21fdda9d/lib/minitest.rb#L45-L59
-  # Filter out Minitest backtrace while allowing backtrace from other libraries
-  # to be shown.
-  Minitest.backtrace_filter = Minitest::BacktraceFilter.new
-end
+require 'minitest'
+require 'minitest/autorun'
+Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 require 'support/rails_app'
 


### PR DESCRIPTION
#### Purpose

Drop Ruby 2.0.0 support. Drop Rails 4.0 support.

https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/
http://guides.rubyonrails.org/maintenance_policy.html

#### Changes

- Remove 2.0.0 from travis
- Remove Rails 4.0 from travis
- Tidy code paths based on Rails versions
- Remove minitest 4/5 conditions.

#### Additional helpful information

- The arity tests seem to behave differently than the comments indicate.
- `render(plain: 'ok')` seems to work fine with Rails 4.1. The conditional said `>` when perhaps it meant `>=` or `> '4.0'`
