### PR TITLE
Fix link to key transforms doc in post install message

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -60,7 +60,7 @@ Gem::Specification.new do |spec|
 
   spec.post_install_message = <<-EOF
 NOTE: The default key case for the JsonApi adapter has changed to dashed.
-See https://github.com/rails-api/active_model_serializers/blob/master/docs/general/key_transform.md
+See https://github.com/rails-api/active_model_serializers/blob/master/docs/general/key_transforms.md
 for more information on configuring this behavior.
 EOF
 end


### PR DESCRIPTION
Stumbled over this typo, old link (https://github.com/rails-api/active_model_serializers/blob/master/docs/general/key_transform.md) returns 404.