### PR TITLE
Exclude links without any data

### DIFF
--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -464,7 +464,8 @@ module ActiveModelSerializers
       #   }.reject! {|_,v| v.nil? }
       def links_for(serializer)
         serializer._links.each_with_object({}) do |(name, value), hash|
-          hash[name] = Link.new(serializer, value).as_json
+          result = Link.new(serializer, value).as_json
+          hash[name] = result if result
         end
       end
 

--- a/lib/active_model_serializers/adapter/json_api/link.rb
+++ b/lib/active_model_serializers/adapter/json_api/link.rb
@@ -71,6 +71,7 @@ module ActiveModelSerializers
           hash[:href] = @href if defined?(@href)
           hash[:meta] = @meta if defined?(@meta)
 
+          return nil if hash.empty?
           hash
         end
 

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -17,6 +17,7 @@ module ActiveModelSerializers
           link :yet_another do
             "http://example.com/resource/#{object.id}"
           end
+          link(:nil) { nil }
         end
 
         def setup


### PR DESCRIPTION
#### Purpose

I couldn't find a way to exclude a link conditionally. So I changed the serializer to exclude links without any data. A link without data is certainly wrong, so it's probably safe to exclude it.

#### Changes

A link without data is serialized as nil, and links serialized as nil are excluded from the output.

It's only implemented in the json-api adapter.

#### Caveats

It may not be the best solution to this problem nor the best implementation. Maybe conditionals would be better.

#### Related GitHub issues

None. Maybe the conditional attributes PR: #1403.