### PR TITLE
Add support for Deserialization's `:only` parameter for undercased symbols to be consistent with strong_parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 0.10.x
 
+Features:
+- [#1674](https://github.com/rails-api/active_model_serializers/pull/1674) Make Deserialization support underscored symbols (@NullVoxPopuli)
+
+Fixes:
+
+Misc:
+- [#1673](https://github.com/rails-api/active_model_serializers/pull/1673) Adds "How to" guide on using AMS with POROs (@DrSayre)
+
 ### [v0.10.0.rc5 (2016-04-04)](https://github.com/rails-api/active_model_serializers/compare/v0.10.0.rc4...v0.10.0.rc5)
 
 Breaking changes:
@@ -64,7 +72,6 @@ Fixes:
 - [#1488](https://github.com/rails-api/active_model_serializers/pull/1488) Require ActiveSupport's string inflections (@nate00)
 
 Misc:
-- [#1673](https://github.com/rails-api/active_model_serializers/pull/1673) Adds "How to" guide on using AMS with POROs (@DrSayre)
 - [#1608](https://github.com/rails-api/active_model_serializers/pull/1608) Move SerializableResource to ActiveModelSerializers (@groyoh)
 - [#1602](https://github.com/rails-api/active_model_serializers/pull/1602) Add output examples to Adapters docs (@remear)
 - [#1557](https://github.com/rails-api/active_model_serializers/pull/1557) Update docs regarding overriding the root key (@Jwan622)

--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -93,8 +93,11 @@ module ActiveModelSerializers
           attributes['id'] = primary_data['id'] if primary_data['id']
           relationships = primary_data['relationships'] || {}
 
-          filter_fields(attributes, options)
-          filter_fields(relationships, options)
+          attributes = transform_keys(attributes, options)
+          relationships = transform_keys(relationships, options)
+
+          attributes = filter_fields(attributes, options)
+          relationships = filter_fields(relationships, options)
 
           hash = {}
           hash.merge!(parse_attributes(attributes, options))
@@ -142,9 +145,13 @@ module ActiveModelSerializers
         # @api private
         def filter_fields(fields, options)
           if (only = options[:only])
-            fields.slice!(*Array(only).map(&:to_s))
+            only = Array(only).map { |o| o.to_s.underscore }
+            fields.select { |k, _v| only.include?(k) }
           elsif (except = options[:except])
-            fields.except!(*Array(except).map(&:to_s))
+            except = Array(except).map { |o| o.to_s.underscore }
+            fields.reject { |k, _v| except.include?(k) }
+          else
+            fields
           end
         end
 

--- a/test/action_controller/json_api/deserialization_test.rb
+++ b/test/action_controller/json_api/deserialization_test.rb
@@ -17,11 +17,19 @@ module ActionController
             )
             render json: parsed_hash
           end
+
+          def render_payload_with_only_filter
+            parsed_hash = ActiveModelSerializers::Deserialization.jsonapi_parse(
+              params,
+              only: [:image_height, :image_width]
+            )
+            render json: parsed_hash
+          end
         end
 
         tests DeserializationTestController
 
-        def test_deserialization_of_relationship_only_object
+        test 'deserialization of relationship only object' do
           hash = {
             'data' => {
               'type' => 'restraints',
@@ -53,7 +61,33 @@ module ActionController
           assert_equal(expected, response)
         end
 
-        def test_deserialization
+        test 'deserialization with the only filter' do
+          hash = {
+            'data' => {
+              'type' => 'photos',
+              'id' => 'zorglub',
+              'attributes' => {
+                'title' => 'Ember Hamster',
+                'src' => 'http://example.com/images/productivity.png',
+                'image-width' => '200',
+                'imageHeight' => '200',
+                'ImageSize' => '1024'
+              }
+            }
+          }
+
+          post :render_payload_with_only_filter, params: hash
+
+          response = JSON.parse(@response.body)
+          expected = {
+            'image_width' => '200',
+            'image_height' => '200'
+          }
+
+          assert_equal(expected, response)
+        end
+
+        test 'JSON API document is flattened' do
           hash = {
             'data' => {
               'type' => 'photos',


### PR DESCRIPTION
#### Purpose

Currently, you need to provide hyphenated strings for the only list, per the JSON API standard:
```
  result = ActiveModelSerializers::Deserialization
      .jsonapi_parse(params,
        only: [
          'name', 'short-description', 'domain',
          'starts-at', 'ends-at',
          'mail-payments-end-at', 'electronic-payments-end-at',
          'location', 'show-on-public-calendar',
          'registration-email-disclaimer'
      ])
```

This is inconsistent with rails' parameter keys, which are `:underscored_symbols`

#### Changes

Adds a test for various key formats to the `only` parameter, and supports `:underscored_symbols`
