### PR TITLE
AMS 0.8: Fix memory leak with :scope_name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,3 +31,8 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: (@windows_platforms + [:jruby])
+
+# JRuby versions before 9.x report their version as "1.9.x" or lower, so lock these to an older version of mime-types
+if defined?(JRUBY_VERSION) and Gem::ruby_version < Gem::Version.new("2.0.0")
+  gem 'mime-types', '< 3'
+end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -294,9 +294,7 @@ module ActiveModel
 
       scope_name = @options[:scope_name]
       if scope_name && !respond_to?(scope_name)
-        self.class.class_eval do
-          define_method scope_name, lambda { scope }
-        end
+        self.singleton_class.send :alias_method, scope_name, :scope
       end
     end
 


### PR DESCRIPTION
#### Purpose
Fix a memory leak when :scope_name is used.

#### Changes
Make `ActiveModel::Serializer#initialize` define a method on the serializer's singleton class, not the serializer class. 

#### Caveats
`singleton_class` is not available before Ruby 1.8, I think.

#### Related GitHub issues


#### Additional helpful information
Supplying :scope_name causes `ActiveModel::Serializer#initialize` to
define a method on the class, which retains a reference to the
Serializer instance and any options passed (such as the scope object).

Given the following test script:
```ruby
require 'json'
require 'active_model_serializers'
require 'objspace'

class Canary
  def initialize
    @created_at = Time.now
    @contents = "0123456789" * 1_000_000
  end

  def inspect
    "Canary"
  end
end

class FooSerializer < ActiveModel::Serializer; end

def serialize_something
  ser = FooSerializer.new({id: 99}, scope_name: :current_canary, scope: Canary.new)
  ser.as_json
end

serialize_something
GC.start
sleep 1

puts "Method defined on class: ", FooSerializer.method_defined?(:current_canary)
if p = ObjectSpace.reachable_objects_from(FooSerializer).find{ |pp| Proc === pp }
  puts "Options captured: ", p.binding.local_variable_get(:options)
end
```

Output before applying this patch:
```
Method defined on class: 
true
Options captured: 
{:scope_name=>:current_canary, :scope=>Canary, :hash=>{:foo=>{}}, :unique_values=>{}}
```
Note that the Proc object captures its environment, which includes the `options` hash.

After:
```
Method defined on class: 
false
```