### PR TITLE
Assert Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 - [#1662](https://github.com/rails-api/active_model_serializers/pull/1662) Drop support for Rails 4.0 and Ruby 2.0.0. (@remear)
 
 Features:
+- [#1677](https://github.com/rails-api/active_model_serializers/pull/1677) Add `assert_schema`, `assert_request_schema`, `assert_request_response_schema`. (@bf4)
 - [#1697](https://github.com/rails-api/active_model_serializers/pull/1697) Include actual exception message with custom exceptions;
   `Test::Schema` exceptions are now `Minitest::Assertion`s. (@bf4)
 - [#1699](https://github.com/rails-api/active_model_serializers/pull/1699) String/Lambda support for conditional attributes/associations (@mtsmfm)

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -131,7 +131,7 @@ module ActiveModelSerializers
           hash[:links].update(pagination_links_for(serializer))
         end
 
-        hash[:meta] = instance_options[:meta] if instance_options[:meta].is_a?(Hash)
+        hash[:meta] = instance_options[:meta] unless instance_options[:meta].blank?
 
         hash
       end

--- a/lib/active_model_serializers/test/schema.rb
+++ b/lib/active_model_serializers/test/schema.rb
@@ -19,6 +19,7 @@ module ActiveModelSerializers
         assert(matcher.call, matcher.message)
       end
 
+      # May be renamed
       def assert_request_response_schema(schema_path = nil, message = nil)
         assert_request_schema(schema_path, message)
         assert_response_schema(schema_path, message)
@@ -35,6 +36,7 @@ module ActiveModelSerializers
       class AssertSchema
         attr_reader :schema_path, :request, :response, :message, :payload
 
+        # Interface may change.
         def initialize(schema_path, request, response, message, payload = nil)
           require_json_schema!
           @request = request

--- a/lib/active_model_serializers/test/schema.rb
+++ b/lib/active_model_serializers/test/schema.rb
@@ -10,19 +10,36 @@ module ActiveModelSerializers
       #   get :index
       #   assert_response_schema
       def assert_response_schema(schema_path = nil, message = nil)
-        matcher = AssertResponseSchema.new(schema_path, response, message)
+        matcher = AssertResponseSchema.new(schema_path, request, response, message)
+        assert(matcher.call, matcher.message)
+      end
+
+      def assert_request_schema(schema_path = nil, message = nil)
+        matcher = AssertRequestSchema.new(schema_path, request, response, message)
+        assert(matcher.call, matcher.message)
+      end
+
+      def assert_request_response_schema(schema_path = nil, message = nil)
+        assert_request_schema(schema_path, message)
+        assert_response_schema(schema_path, message)
+      end
+
+      def assert_schema(payload, schema_path = nil, message = nil)
+        matcher = AssertSchema.new(schema_path, request, response, message, payload)
         assert(matcher.call, matcher.message)
       end
 
       MissingSchema = Class.new(Minitest::Assertion)
       InvalidSchemaError = Class.new(Minitest::Assertion)
 
-      class AssertResponseSchema
-        attr_reader :schema_path, :response, :message
+      class AssertSchema
+        attr_reader :schema_path, :request, :response, :message, :payload
 
-        def initialize(schema_path, response, message)
+        def initialize(schema_path, request, response, message, payload = nil)
           require_json_schema!
+          @request = request
           @response = response
+          @payload = payload
           @schema_path = schema_path || schema_path_default
           @message = message
           @document_store = JsonSchema::DocumentStore.new
@@ -41,11 +58,11 @@ module ActiveModelSerializers
         attr_reader :document_store
 
         def controller_path
-          response.request.filtered_parameters[:controller]
+          request.filtered_parameters[:controller]
         end
 
         def action
-          response.request.filtered_parameters[:action]
+          request.filtered_parameters[:action]
         end
 
         def schema_directory
@@ -66,6 +83,10 @@ module ActiveModelSerializers
 
         def response_body
           load_json(response.body)
+        end
+
+        def request_params
+          request.env['action_dispatch.request.request_parameters']
         end
 
         def json_schema
@@ -96,6 +117,18 @@ module ActiveModelSerializers
           require 'json_schema'
         rescue LoadError
           raise LoadError, "You don't have json_schema installed in your application. Please add it to your Gemfile and run bundle install"
+        end
+      end
+      class AssertResponseSchema < AssertSchema
+        def initialize(*)
+          super
+          @payload = response_body
+        end
+      end
+      class AssertRequestSchema < AssertSchema
+        def initialize(*)
+          super
+          @payload = request_params
         end
       end
     end

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -110,7 +110,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_key_is_present_when_empty_hash_with_json_api
+      def test_meta_key_is_not_present_when_empty_hash_with_json_api
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
@@ -122,8 +122,7 @@ module ActiveModel
             id: '1',
             type: 'blogs',
             attributes: { title: 'AMS Hints' }
-          },
-          meta: {}
+          }
         }
         assert_equal(expected, actual)
       end


### PR DESCRIPTION
This works, but I'd like some discussionon the interface change, and then I'll
add some tests.

- [x] `assert_request_schema`
  - [ ] Handle missing `type` in create params ([an exception allowed in the spec](http://jsonapi.org/format/#document-resource-objects))
- [x] `assert_schema_schema`
- [ ] validate when no `data` is present, [but just `meta`](http://jsonapi.org/format/#document-top-level)