### PR TITLE
Fix the order of pagination links for the json_api adapter

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -31,12 +31,12 @@ module ActiveModelSerializers
           return {} if collection.total_pages == FIRST_PAGE
 
           {}.tap do |pages|
-            pages[:self] = collection.current_page
-
             unless collection.current_page == FIRST_PAGE
               pages[:first] = FIRST_PAGE
               pages[:prev]  = collection.current_page - FIRST_PAGE
             end
+
+            pages[:self] = collection.current_page
 
             unless collection.current_page == collection.total_pages
               pages[:next] = collection.current_page + FIRST_PAGE


### PR DESCRIPTION
#### Purpose
Fix the order of pagination links for the json_api adapter

#### Changes
in lib/active_model_serializers/adapter/json_api/pagination_links.rb

#### Caveats


#### Related GitHub issues


#### Additional helpful information



In all the pagination links generated by this adapter the self link comes before first and prev, ideally it should come after them.