### PR TITLE
[WIP] Make Serializers serializable, Step 2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Metrics/ClassLength:
   Exclude:
     - test/**/*.rb
 
+Metrics/ModuleLength:
+  Max: 103 # TODO: Lower to 100
+
 Metrics/CyclomaticComplexity:
   Max: 7 # TODO: Lower to 6
 

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -206,6 +206,20 @@ module ActiveModel
         end
       end
 
+      def cached_attributes(options, cached_attributes, adapter_instance)
+        if self.class.cache_enabled?
+          cached_attributes.fetch(cache_key(adapter_instance)) do
+            cache_check(adapter_instance) do
+              attributes(options[:fields])
+            end
+          end
+        else
+          cache_check(adapter_instance) do
+            attributes(options[:fields])
+          end
+        end
+      end
+
       def cache_check(adapter_instance)
         if self.class.cache_enabled?
           self.class.cache_store.fetch(cache_key(adapter_instance), self.class._cache_options) do

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -214,8 +214,12 @@ module ActiveModel
 
       def cache_check(adapter_instance)
         if self.class.cache_enabled?
-          self.class.cache_store.fetch(cache_key(adapter_instance), self.class._cache_options) do
-            yield
+          cached_attributes = instance_options[:cached_attributes] || {}
+          key = cache_key(adapter_instance)
+          cached_attributes.fetch(key) do
+            self.class.cache_store.fetch(key, self.class._cache_options) do
+              yield
+            end
           end
         elsif self.class.fragment_cache_enabled?
           fetch_fragment_cache(adapter_instance)

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -206,17 +206,9 @@ module ActiveModel
         end
       end
 
-      def cached_attributes(options, cached_attributes, adapter_instance)
-        if self.class.cache_enabled?
-          cached_attributes.fetch(cache_key(adapter_instance)) do
-            cache_check(adapter_instance) do
-              attributes(options[:fields])
-            end
-          end
-        else
-          cache_check(adapter_instance) do
-            attributes(options[:fields])
-          end
+      def cached_attributes(fields, adapter_instance)
+        cache_check(adapter_instance) do
+          attributes(fields)
         end
       end
 

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -206,15 +206,6 @@ module ActiveModel
         end
       end
 
-      # Get attributes from @cached_attributes
-      # @return [Hash] cached attributes
-      # def cached_attributes(fields, adapter_instance)
-      def cached_fields(fields, adapter_instance)
-        cache_check(adapter_instance) do
-          attributes(fields)
-        end
-      end
-
       def cache_check(adapter_instance)
         if self.class.cache_enabled?
           self.class.cache_store.fetch(cache_key(adapter_instance), self.class._cache_options) do

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -20,8 +20,6 @@ module ActiveModelSerializers
       private
 
       def serializable_hash_for_collection(options)
-        cache_attributes
-
         serializer.map { |s| Attributes.new(s, instance_options).serializable_hash(options) }
       end
 
@@ -48,15 +46,9 @@ module ActiveModelSerializers
         Attributes.new(association.serializer, opts).serializable_hash(options)
       end
 
-      # Set @cached_attributes
-      def cache_attributes
-        return if @cached_attributes.present?
-
-        @cached_attributes = ActiveModel::Serializer.cache_read_multi(serializer, self, @include_tree)
-      end
-
       def resource_object_for(options)
         if serializer.class.cache_enabled?
+          @cached_attributes ||= ActiveModel::Serializer.cache_read_multi(serializer, self, @include_tree)
           @cached_attributes.fetch(serializer.cache_key(self)) do
             serializer.cached_fields(options[:fields], self)
           end

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -23,7 +23,7 @@ module ActiveModelSerializers
       end
 
       def serializable_hash_for_single_resource(options)
-        resource = serializer.cached_attributes(options, {}, self)
+        resource = serializer.cached_attributes(options[:fields], self)
         relationships = resource_relationships(options)
         resource.merge(relationships)
       end

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -28,10 +28,14 @@ module ActiveModelSerializers
           if serializer.class.cache_enabled?
             @cached_attributes ||= ActiveModel::Serializer.cache_read_multi(serializer, self, @include_tree)
             @cached_attributes.fetch(serializer.cache_key(self)) do
-              serializer.cached_fields(options[:fields], self)
+              serializer.cache_check(self) do
+                serializer.attributes(options[:fields])
+              end
             end
           else
-            serializer.cached_fields(options[:fields], self)
+            serializer.cache_check(self) do
+              serializer.attributes(options[:fields])
+            end
           end
         relationships = resource_relationships(options)
         resource.merge(relationships)

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -4,7 +4,6 @@ module ActiveModelSerializers
       def initialize(serializer, options = {})
         super
         @include_tree = ActiveModel::Serializer::IncludeTree.from_include_args(options[:include] || '*')
-        @cached_attributes = options[:cache_attributes] || {}
       end
 
       def serializable_hash(options = nil)
@@ -20,14 +19,11 @@ module ActiveModelSerializers
       private
 
       def serializable_hash_for_collection(options)
-        @cached_attributes.present? ||
-          (@cached_attributes = ActiveModel::Serializer.cache_read_multi(serializer, self, @include_tree))
-
         serializer.map { |s| Attributes.new(s, instance_options).serializable_hash(options) }
       end
 
       def serializable_hash_for_single_resource(options)
-        resource = serializer.cached_attributes(options, @cached_attributes, self)
+        resource = serializer.cached_attributes(options, {}, self)
         relationships = resource_relationships(options)
         resource.merge(relationships)
       end

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -19,6 +19,7 @@ module ActiveModelSerializers
       private
 
       def serializable_hash_for_collection(options)
+        instance_options[:cached_attributes] ||= ActiveModel::Serializer.cache_read_multi(serializer, self, @include_tree)
         serializer.map { |s| Attributes.new(s, instance_options).serializable_hash(options) }
       end
 

--- a/lib/active_model_serializers/adapter/base.rb
+++ b/lib/active_model_serializers/adapter/base.rb
@@ -33,12 +33,6 @@ module ActiveModelSerializers
         non_cached_hash.merge cached_hash
       end
 
-      def cache_check(serializer)
-        serializer.cache_check(self) do
-          yield
-        end
-      end
-
       private
 
       # see https://github.com/rails-api/active_model_serializers/pull/965

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -290,7 +290,7 @@ module ActiveModelSerializers
 
       # {http://jsonapi.org/format/#document-resource-objects Document Resource Objects}
       def resource_object_for(serializer)
-        resource_object = cache_check(serializer) do
+        resource_object = serializer.cache_check(self) do
           resource_object = ResourceIdentifier.new(serializer, instance_options).as_json
 
           requested_fields = fieldset && fieldset.fields_for(resource_object[:type])

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -303,8 +303,8 @@ module ActiveModelSerializers
         render_object_with_cache(@comment)
 
         attributes = Adapter::Attributes.new(serializer)
-        attributes.send(:cache_attributes)
-        cached_attributes = attributes.instance_variable_get(:@cached_attributes)
+        include_tree = ActiveModel::Serializer::IncludeTree.from_include_args('*')
+        cached_attributes = ActiveModel::Serializer.cache_read_multi(serializer, attributes, include_tree)
 
         assert_equal cached_attributes["#{@comment.cache_key}/#{attributes.cached_name}"], Comment.new(id: 1, body: 'ZOMG A COMMENT').attributes
         assert_equal cached_attributes["#{@comment.post.cache_key}/#{attributes.cached_name}"], Post.new(id: 'post', title: 'New Post', body: 'Body').attributes


### PR DESCRIPTION
**Purpose**

As part of fixing the caching issues, this PR continues to moving the responsibility
of serializing attributes and associations from the adapter to the serializer.

This change allows the adapter to focus on its job: adapting the resource serialization
to the (output) API format.

**Changes**

TBD

**Caveats**

TBD

**Related GitHub issues**

Continues from https://github.com/rails-api/active_model_serializers/pull/1638

- https://github.com/rails-api/active_model_serializers/pull/1494
- https://github.com/rails-api/active_model_serializers/pull/1471

**Additional helpful information**