### PR TITLE
Memoize resource relationships

### DIFF
--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -34,7 +34,7 @@ module ActiveModelSerializers
       def resource_relationships(options)
         relationships = {}
         serializer.associations(@include_tree).each do |association|
-          relationships[association.key] = relationship_value_for(association, options)
+          relationships[association.key] ||= relationship_value_for(association, options)
         end
 
         relationships


### PR DESCRIPTION
## Purpose: improve performance

related: https://github.com/rails-api/active_model_serializers/issues/1586

### Changes: memoize serialized associations

### Results: caching serializers are now at least as performant as non-caching

With caching on, serializer performance is now


| before | after|
| ----- | ----- |
| 571 ips / 822 ips, 1803 objects / 1257 objects| 783 ips / 798 ips, 1355 objects / 1257 objects

### Caveats: should porbably be fixed at the association-yielding level

Nicer debug; compare caching by serializer, grouped by caching on/off

 ```plain
 bundle exec bin/bench_regression a5eaf6cd7a7fed42d9e64777753a1762e187eadc 1033b711c7d7c231bb5b832e7dfe7f99389f22c4 --pattern bm_caching

  "version": "0.10.0.rc5",
  "rails_version": "4.2.6",
  "benchmark_run[environment]": "2.2.2p95",

HEAD is now at a5eaf6c... Nicer debug; compare caching by serializer, grouped by caching on/off

 caching on: caching serializers: gc off 783.6956866669746/ips; 1355 objects
 caching on: non-caching serializers: gc off 798.8629770532652/ips; 1257
 objects caching off: caching serializers: gc off 682.3661326140281/ips; 1355 objects
caching off: non-caching serializers: gc off 721.2175067555897/ips; 1257 objects

HEAD is now at 1033b71... Merge pull request #1638 from bf4/caching_redux

 caching on: caching serializers: gc off 570.6905948477781/ips; 1803 objects
 caching on: non-caching serializers: gc off 822.8418206976623/ips; 1257 objects
 caching off: caching serializers: gc off 523.4174806572001/ips; 1803 objects
 caching off: non-caching serializers: gc off 747.6026493097758/ips; 1257 objects
```