### PR TITLE
Fix tests to comply with the JSON API spec.

### DIFF
--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -131,8 +131,9 @@ module ActiveModelSerializers
               id: '1',
               type: 'virtual-values',
               relationships: {
-                maker: { data: { id: 1 } },
-                reviews: { data: [{ id: 1 }, { id: 2 }] }
+                maker: { data: { type: 'makers', id: '1' } },
+                reviews: { data: [{ type: 'reviews', id: '1' },
+                                  { type: 'reviews', id: '2' }] }
               }
             }
           }, adapter.serializable_hash)

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -65,8 +65,9 @@ module ActiveModelSerializers
               id: '1',
               type: 'virtual-values',
               relationships: {
-                maker: { data: { id: 1 } },
-                reviews: { data: [{ id: 1 }, { id: 2 }] }
+                maker: { data: { type: 'makers', id: '1' } },
+                reviews: { data: [{ type: 'reviews', id: '1' },
+                                  { type: 'reviews', id: '2' }] }
               }
             }
           }

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -227,8 +227,9 @@ end
 VirtualValueSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
 
-  has_many :reviews, virtual_value: [{ id: 1 }, { id: 2 }]
-  has_one :maker, virtual_value: { id: 1 }
+  has_many :reviews, virtual_value: [{ type: 'reviews', id: '1' },
+                                     { type: 'reviews', id: '2' }]
+  has_one :maker, virtual_value: { type: 'makers', id: '1' }
 
   def reviews
   end


### PR DESCRIPTION
#### Purpose
Some old tests for associations with virtual values were generating non-JSON API compliant payloads.

#### Related GitHub issues
Fixes #1112.