### PR TITLE
Issue warning when no serializer is found for an association.

### DIFF
--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -119,6 +119,7 @@ module ActiveModel
               serializer_options(subject, parent_serializer_options, reflection_options)
             )
           rescue ActiveModel::Serializer::CollectionSerializer::NoSerializerError
+            warn "No serializer found for #{association_value}."
             reflection_options[:virtual_value] = association_value.try(:as_json) || association_value
           end
         elsif !association_value.nil? && !association_value.instance_of?(Object)


### PR DESCRIPTION
Fix #1075.