### PR TITLE
Meta no longer handled in Base adapter.

### DIFF
--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -48,11 +48,6 @@ module ActiveModelSerializers
         Attributes.new(association.serializer, opts).serializable_hash(options)
       end
 
-      # no-op: Attributes adapter does not include meta data, because it does not support root.
-      def include_meta(json)
-        json
-      end
-
       # Set @cached_attributes
       def cache_attributes
         return if @cached_attributes.present?

--- a/lib/active_model_serializers/adapter/base.rb
+++ b/lib/active_model_serializers/adapter/base.rb
@@ -26,9 +26,7 @@ module ActiveModelSerializers
       end
 
       def as_json(options = nil)
-        hash = serializable_hash(options)
-        include_meta(hash)
-        hash
+        serializable_hash(options)
       end
 
       def fragment_cache(cached_hash, non_cached_hash)
@@ -49,21 +47,8 @@ module ActiveModelSerializers
         options ||= {} # rubocop:disable Lint/UselessAssignment
       end
 
-      def meta
-        instance_options.fetch(:meta, nil)
-      end
-
-      def meta_key
-        instance_options.fetch(:meta_key, 'meta'.freeze)
-      end
-
       def root
         serializer.json_key.to_sym if serializer.json_key
-      end
-
-      def include_meta(json)
-        json[meta_key] = meta unless meta.blank?
-        json
       end
 
       class << self

--- a/lib/active_model_serializers/adapter/json.rb
+++ b/lib/active_model_serializers/adapter/json.rb
@@ -4,7 +4,17 @@ module ActiveModelSerializers
       def serializable_hash(options = nil)
         options = serialization_options(options)
         serialized_hash = { root => Attributes.new(serializer, instance_options).serializable_hash(options) }
+        serialized_hash[meta_key] = meta unless meta.blank?
+
         self.class.transform_key_casing!(serialized_hash, instance_options)
+      end
+
+      def meta
+        instance_options.fetch(:meta, nil)
+      end
+
+      def meta_key
+        instance_options.fetch(:meta_key, 'meta'.freeze)
       end
     end
   end

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -67,6 +67,7 @@ module ActiveModelSerializers
       #    links: toplevel_links,
       #    jsonapi: toplevel_jsonapi
       #  }.reject! {|_,v| v.nil? }
+      # rubocop:disable Metrics/CyclomaticComplexity
       def success_document
         is_collection = serializer.respond_to?(:each)
         serializers = is_collection ? serializer : [serializer]
@@ -130,8 +131,11 @@ module ActiveModelSerializers
           hash[:links].update(pagination_links_for(serializer))
         end
 
+        hash[:meta] = instance_options[:meta] if instance_options[:meta].is_a?(Hash)
+
         hash
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       # {http://jsonapi.org/format/#errors JSON API Errors}
       # TODO: look into caching

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -92,7 +92,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_key_is_used_with_json_api
+      def test_meta_key_is_not_used_with_json_api
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
@@ -105,25 +105,25 @@ module ActiveModel
             type: 'blogs',
             attributes: { title: 'AMS Hints' }
           },
-          'haha_meta' => { total: 10 }
+          meta: { total: 10 }
         }
         assert_equal(expected, actual)
       end
 
-      def test_meta_key_is_not_present_when_blank_object_with_json_api
+      def test_meta_key_is_present_when_empty_hash_with_json_api
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
           serializer: AlternateBlogSerializer,
-          meta: {},
-          meta_key: 'haha_meta'
+          meta: {}
         ).as_json
         expected = {
           data: {
             id: '1',
             type: 'blogs',
             attributes: { title: 'AMS Hints' }
-          }
+          },
+          meta: {}
         }
         assert_equal(expected, actual)
       end
@@ -133,8 +133,7 @@ module ActiveModel
           @blog,
           adapter: :json_api,
           serializer: AlternateBlogSerializer,
-          meta: '',
-          meta_key: 'haha_meta'
+          meta: ''
         ).as_json
         expected = {
           data: {


### PR DESCRIPTION
Make each relevant adapter (i.e. `Json` and `JsonApi`) handle top level `meta`.