### PR TITLE
Fix CachingPostSerializer defining associations twice; add FragmentCaching benchmaking

### DIFF
--- a/test/benchmark/bm_caching.rb
+++ b/test/benchmark/bm_caching.rb
@@ -31,6 +31,10 @@ class ApiAssertion
     get("/caching/#{on_off}")
   end
 
+  def get_fragment_caching(on_off = 'on'.freeze)
+    get("/fragment_caching/#{on_off}")
+  end
+
   def get_non_caching(on_off = 'on'.freeze)
     get("/non_caching/#{on_off}")
   end
@@ -101,8 +105,10 @@ assertion.debug { assertion.get_status }
 time = 10
 {
   'caching on: caching serializers: gc off' => { disable_gc: true, send: [:get_caching, 'on'] },
+  'caching on: fragment caching serializers: gc off' => { disable_gc: true, send: [:get_fragment_caching, 'on'] },
   'caching on: non-caching serializers: gc off' => { disable_gc: true, send: [:get_non_caching, 'on'] },
   'caching off: caching serializers: gc off' => { disable_gc: true, send: [:get_caching, 'off'] },
+  'caching off: fragment caching serializers: gc off' => { disable_gc: true, send: [:get_fragment_caching, 'off'] },
   'caching off: non-caching serializers: gc off' => { disable_gc: true, send: [:get_non_caching, 'off'] }
 }.each do |label, options|
   assertion.clear

--- a/test/benchmark/controllers.rb
+++ b/test/benchmark/controllers.rb
@@ -1,12 +1,13 @@
 class PostController < ActionController::Base
   POST =
     begin
+      updated_at = Time.current
       if ENV['BENCH_STRESS']
         comments = (0..50).map do |i|
-          Comment.new(id: i, body: 'ZOMG A COMMENT')
+          Comment.new(id: i, body: 'ZOMG A COMMENT', updated_at: updated_at + i)
         end
       else
-        comments = [Comment.new(id: 1, body: 'ZOMG A COMMENT')]
+        comments = [Comment.new(id: 1, body: 'ZOMG A COMMENT', updated_at: updated_at)]
       end
       author = Author.new(id: 42, first_name: 'Joao', last_name: 'Moura')
       Post.new(id: 1337, title: 'New Post', blog: nil, body: 'Body', comments: comments, author: author)
@@ -15,6 +16,11 @@ class PostController < ActionController::Base
   def render_with_caching_serializer
     toggle_cache_status
     render json: POST, serializer: CachingPostSerializer, adapter: :json, meta: { caching: perform_caching }
+  end
+
+  def render_with_fragment_caching_serializer
+    toggle_cache_status
+    render json: POST, serializer: FragmentCachingPostSerializer, adapter: :json, meta: { caching: perform_caching }
   end
 
   def render_with_non_caching_serializer
@@ -73,5 +79,6 @@ Rails.application.routes.draw do
   get '/status(/:on)' => 'post#render_cache_status'
   get '/clear' => 'post#clear'
   get '/caching(/:on)' => 'post#render_with_caching_serializer'
+  get '/fragment_caching(/:on)' => 'post#render_with_fragment_caching_serializer'
   get '/non_caching(/:on)' => 'post#render_with_non_caching_serializer'
 end

--- a/test/benchmark/fixtures.rb
+++ b/test/benchmark/fixtures.rb
@@ -52,11 +52,28 @@ class CachingCommentSerializer < CommentSerializer
 end
 Rails.configuration.serializers << CachingCommentSerializer
 
-class CachingPostSerializer < PostSerializer
+# see https://github.com/rails-api/active_model_serializers/pull/1690/commits/68715b8f99bc29677e8a47bb3f305f23c077024b#r60344532
+class CachingPostSerializer < ActiveModel::Serializer
   cache key: 'post', expires_in: 0.1, skip_digest: true
+
+  attributes :id, :title, :body
+
+  has_many :comments, serializer: CommentSerializer
   belongs_to :blog, serializer: BlogSerializer
-  belongs_to :author, serializer: CachingAuthorSerializer
-  has_many :comments, serializer: CachingCommentSerializer
+  belongs_to :author, serializer: AuthorSerializer
+
+  link(:post_authors) { 'https://example.com/post_authors' }
+
+  meta do
+    {
+      rating: 5,
+      favorite_count: 10
+    }
+  end
+
+  def blog
+    Blog.new(id: 999, name: 'Custom blog')
+  end
 end
 Rails.configuration.serializers << CachingPostSerializer
 

--- a/test/benchmark/fixtures.rb
+++ b/test/benchmark/fixtures.rb
@@ -13,7 +13,7 @@ end
 Rails.configuration.serializers << BlogSerializer
 
 class CommentSerializer < ActiveModel::Serializer
-  attributes :id, :body
+  attributes :id, :body, :updated_at
 
   belongs_to :post
   belongs_to :author
@@ -43,7 +43,7 @@ end
 Rails.configuration.serializers << PostSerializer
 
 class CachingAuthorSerializer < AuthorSerializer
-  cache key: 'writer', only: [:first_name, :last_name], skip_digest: true
+  cache key: 'writer', skip_digest: true
 end
 Rails.configuration.serializers << CachingAuthorSerializer
 
@@ -58,9 +58,9 @@ class CachingPostSerializer < ActiveModel::Serializer
 
   attributes :id, :title, :body
 
-  has_many :comments, serializer: CommentSerializer
   belongs_to :blog, serializer: BlogSerializer
-  belongs_to :author, serializer: AuthorSerializer
+  belongs_to :author, serializer: CachingAuthorSerializer
+  has_many :comments, serializer: CachingCommentSerializer
 
   link(:post_authors) { 'https://example.com/post_authors' }
 
@@ -76,6 +76,41 @@ class CachingPostSerializer < ActiveModel::Serializer
   end
 end
 Rails.configuration.serializers << CachingPostSerializer
+
+class FragmentCachingAuthorSerializer < AuthorSerializer
+  cache key: 'writer', only: [:first_name, :last_name], skip_digest: true
+end
+Rails.configuration.serializers << FragmentCachingAuthorSerializer
+
+class FragmentCachingCommentSerializer < CommentSerializer
+  cache expires_in: 1.day, except: [:updated_at], skip_digest: true
+end
+Rails.configuration.serializers << CachingCommentSerializer
+
+# see https://github.com/rails-api/active_model_serializers/pull/1690/commits/68715b8f99bc29677e8a47bb3f305f23c077024b#r60344532
+class FragmentCachingPostSerializer < ActiveModel::Serializer
+  cache key: 'post', expires_in: 0.1, skip_digest: true
+
+  attributes :id, :title, :body
+
+  belongs_to :blog, serializer: BlogSerializer
+  belongs_to :author, serializer: FragmentCachingAuthorSerializer
+  has_many :comments, serializer: FragmentCachingCommentSerializer
+
+  link(:post_authors) { 'https://example.com/post_authors' }
+
+  meta do
+    {
+      rating: 5,
+      favorite_count: 10
+    }
+  end
+
+  def blog
+    Blog.new(id: 999, name: 'Custom blog')
+  end
+end
+Rails.configuration.serializers << FragmentCachingPostSerializer
 
 if ENV['ENABLE_ACTIVE_RECORD'] == 'true'
   require 'active_record'
@@ -167,7 +202,7 @@ else
   end
 
   class Comment < BenchmarkModel
-    attr_accessor :id, :body
+    attr_accessor :id, :body, :updated_at
   end
 
   class Author < BenchmarkModel


### PR DESCRIPTION
## Summary

You can see that with caching on the caching serializer is slightly slower than the non-caching, and the fragment caching serializer is much slower

| serializer_type | ips | objects |
|-------------------|----------------------|-------------------|
| caching | 190.252 | 8259
| non-caching | 211.199 | 7295
| fragment | 53.773 | 22761

with caching off (i.e. disabled in the controller) the serializer behavior is more similar

| serializer_type | ips | objects |
|-------------------|----------------------|-------------------|
| caching |163.787 | 8290
| non-caching | 163.678 | 7295
| fragment | 45.753 |  22761


(these are run on my mbp while it's mostly idle, so compare the ips rather than look at absolutes, and then with a little fuzziness. I should include sterr in the future)

Also note that the objects being serialized are all in-memory. There are no queries being made.

## Related

- #1586 
- #1690
  - #1686
  - #1688 

## Source

Running

`SUMMARIZE=true bin/bench_regression 7485c84 335869e --repeat-count=5 --env='BENCH_STRESS=true'  --pattern='bm_caching'`

## Details

```js
var this-pr = {
  "commit_hash": "335869e",
  "version": "0.10.0.rc5",
  "rails_version": "4.2.6",
  "benchmark_run[environment]": "2.2.2p95",
  "runs": [
    {
      "benchmark_type[category]": "caching on: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 190.252,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 8259
    },
    {
      "benchmark_type[category]": "caching on: fragment caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 53.773,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 22761
    },
    {
      "benchmark_type[category]": "caching on: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 211.199,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 7295
    },
    {
      "benchmark_type[category]": "caching off: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 163.787,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 8290
    },
    {
      "benchmark_type[category]": "caching off: fragment caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 45.753,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 22761
    },
    {
      "benchmark_type[category]": "caching off: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 163.678,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 7295
    }
  ]
}
```

```js
var master = {
  "commit_hash": "7485c84",
  "version": "0.10.0.rc5",
  "rails_version": "4.2.6",
  "benchmark_run[environment]": "2.2.2p95",
  "runs": [
    {
      "benchmark_type[category]": "caching on: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 274.5,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 6005
    },
    {
      "benchmark_type[category]": "caching on: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 294.831,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 5357
    },
    {
      "benchmark_type[category]": "caching off: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 233.751,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 6005
    },
    {
      "benchmark_type[category]": "caching off: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 251.077,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 5357
    }
  ]
}
```