### PR TITLE
String/Lambda support for conditional attributes/associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 - [#1662](https://github.com/rails-api/active_model_serializers/pull/1662) Drop support for Rails 4.0 and Ruby 2.0.0. (@remear)
 
 Features:
+- [#1699](https://github.com/rails-api/active_model_serializers/pull/1699) String/Lambda support for conditional attributes/associations (@mtsmfm)
 - [#1687](https://github.com/rails-api/active_model_serializers/pull/1687) Only calculate `_cache_digest` (in `cache_key`) when `skip_digest` is false. (@bf4)
 - [#1647](https://github.com/rails-api/active_model_serializers/pull/1647) Restrict usage of `serializable_hash` options
   to the ActiveModel::Serialization and ActiveModel::Serializers::JSON interface. (@bf4)

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -80,6 +80,10 @@ end
 
 ```ruby
 has_one :blog, if: :show_blog?
+# you can also use a string or lambda
+# has_one :blog, if: 'scope.admin?'
+# has_one :blog, if: -> (serializer) { serializer.scope.admin? }
+# has_one :blog, if: -> { scope.admin? }
 
 def show_blog?
   scope.admin?

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -239,27 +239,55 @@ module ActiveModel
           end
         end
 
+        # rubocop:disable Metrics/AbcSize
         def test_conditional_associations
-          serializer = Class.new(ActiveModel::Serializer) do
-            belongs_to :if_assoc_included, if: :true
-            belongs_to :if_assoc_excluded, if: :false
-            belongs_to :unless_assoc_included, unless: :false
-            belongs_to :unless_assoc_excluded, unless: :true
+          model = ::Model.new(true: true, false: false)
 
-            def true
-              true
+          scenarios = [
+            { options: { if:     :true  }, included: true  },
+            { options: { if:     :false }, included: false },
+            { options: { unless: :false }, included: true  },
+            { options: { unless: :true  }, included: false },
+            { options: { if:     'object.true'  }, included: true  },
+            { options: { if:     'object.false' }, included: false },
+            { options: { unless: 'object.false' }, included: true  },
+            { options: { unless: 'object.true'  }, included: false },
+            { options: { if:     -> { object.true }  }, included: true  },
+            { options: { if:     -> { object.false } }, included: false },
+            { options: { unless: -> { object.false } }, included: true  },
+            { options: { unless: -> { object.true }  }, included: false },
+            { options: { if:     -> (s) { s.object.true }  }, included: true  },
+            { options: { if:     -> (s) { s.object.false } }, included: false },
+            { options: { unless: -> (s) { s.object.false } }, included: true  },
+            { options: { unless: -> (s) { s.object.true }  }, included: false }
+          ]
+
+          scenarios.each do |s|
+            serializer = Class.new(ActiveModel::Serializer) do
+              belongs_to :association, s[:options]
+
+              def true
+                true
+              end
+
+              def false
+                false
+              end
             end
 
-            def false
-              false
+            hash = serializable(model, serializer: serializer).serializable_hash
+            assert_equal(s[:included], hash.key?(:association), "Error with #{s[:options]}")
+          end
+        end
+
+        def test_illegal_conditional_associations
+          exception = assert_raises(TypeError) do
+            Class.new(ActiveModel::Serializer) do
+              belongs_to :x, if: nil
             end
           end
 
-          model = ::Model.new
-          hash = serializable(model, serializer: serializer).serializable_hash
-          expected = { if_assoc_included: nil, unless_assoc_included: nil }
-
-          assert_equal(expected, hash)
+          assert_match(/:if should be a Symbol, String or Proc/, exception.message)
         end
       end
     end


### PR DESCRIPTION
#### Purpose

I want to exclude attribute if its association/attribute is nil.

`:if` option accepts only symbol at this time so we must write condition like following:

```ruby
class UserSerializer < ApplicationSerializer
  has_one :game, if: :game_exists?

  def game_exists?
    object.game
  end
end
```

But it is not bad to support String like [rails](http://guides.rubyonrails.org/active_record_validations.html#conditional-validation):

```ruby
class UserSerializer < ApplicationSerializer
  has_one :game, if: 'object.game'
end
```

I don't have any use case for lambda(proc) at this time but many developers who experienced rails will guess that it accepts lambda.

#### Related GitHub issues

#1403

