### PR TITLE
Support pagination link for Kaminari when no data is returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Features:
 - [#1340](https://github.com/rails-api/active_model_serializers/pull/1340) Add support for resource-level meta. (@beauby)
 
 Fixes:
+- [#1700](https://github.com/rails-api/active_model_serializers/pull/1700) Support pagination link for Kaminari when no data is returned
 - [#1657](https://github.com/rails-api/active_model_serializers/pull/1657) Add missing missing require "active_support/json". (@andreaseger)
 - [#1661](https://github.com/rails-api/active_model_serializers/pull/1661) Fixes `read_attribute_for_serialization` not
   seeing methods defined in serialization superclass (#1653, #1658, #1660), introduced in #1650. (@bf4)

--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -28,7 +28,7 @@ module ActiveModelSerializers
         private
 
         def pages_from
-          return {} if collection.total_pages == FIRST_PAGE
+          return {} if collection.total_pages <= FIRST_PAGE
 
           {}.tap do |pages|
             pages[:self] = collection.current_page

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -101,6 +101,13 @@ module ActiveModelSerializers
           end
         end
 
+        def expected_response_with_no_data_pagination_links
+          {}.tap do |hash|
+            hash[:data] = []
+            hash[:links] = {}
+          end
+        end
+
         def test_pagination_links_using_kaminari
           adapter = load_adapter(using_kaminari, mock_request)
 
@@ -118,6 +125,22 @@ module ActiveModelSerializers
 
           assert_equal expected_response_with_pagination_links_and_additional_params,
             adapter.serializable_hash
+        end
+
+        def test_pagination_links_when_zero_results_kaminari
+          @array = []
+
+          adapter = load_adapter(using_kaminari(1), mock_request)
+
+          assert_equal expected_response_with_no_data_pagination_links, adapter.serializable_hash
+        end
+
+        def test_pagination_links_when_zero_results_will_paginate
+          @array = []
+
+          adapter = load_adapter(using_will_paginate(1), mock_request)
+
+          assert_equal expected_response_with_no_data_pagination_links, adapter.serializable_hash
         end
 
         def test_last_page_pagination_links_using_kaminari


### PR DESCRIPTION
#### Purpose

This PR fixes a bug where the pagination links were showing up (with incorrect data) when a query returned no results and using kaminari.

The issue was in that case kaminari says total_pages is 0, whereas will_paginate says total_pages is 1.


#### Changes

This updated code supports both cases now and treats them as it had been working for will_paginate, namely no links show up.

#### Additional helpful information

I added tests for both kaminari and will_paginate.  The will_paginate test passed before my change, and the kaminari one failed.  Now they both pass.



