### PR TITLE
Prevent loading association when include_data is set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Breaking changes:
 Features:
 
 Fixes:
+- [#1710](https://github.com/rails-api/active_model_serializers/pull/1710) Prevent association loading when `include_data` option
+  is set to `false`. (@groyoh)
 
 Misc:
 - [#1734](https://github.com/rails-api/active_model_serializers/pull/1734) Adds documentation for conditional attribute (@lambda2)

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -75,10 +75,10 @@ module ActiveModel
 
         if block
           block_value = instance_exec(serializer, &block)
-          if block_value == :nil
-            serializer.read_attribute_for_serialization(name)
-          else
+          if block_value != :nil
             block_value
+          elsif @_include_data
+            serializer.read_attribute_for_serialization(name)
           end
         else
           serializer.read_attribute_for_serialization(name)


### PR DESCRIPTION
#### Purpose
Fixes #1707. 

#### Changes
Do not call `read_attribute_for_serialization` when `include_data` is set to `false`.