### PR TITLE
Support conditional setting of serialization_scope in controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 - [#1662](https://github.com/rails-api/active_model_serializers/pull/1662) Drop support for Rails 4.0 and Ruby 2.0.0. (@remear)
 
 Features:
+- [#1711](https://github.com/rails-api/active_model_serializers/pull/1711) Set `serialization_scope` conditionally for specif actions in controller. (@yogeshjain999)
 - [#1699](https://github.com/rails-api/active_model_serializers/pull/1699) String/Lambda support for conditional attributes/associations (@mtsmfm)
 - [#1687](https://github.com/rails-api/active_model_serializers/pull/1687) Only calculate `_cache_digest` (in `cache_key`) when `skip_digest` is false. (@bf4)
 - [#1647](https://github.com/rails-api/active_model_serializers/pull/1647) Restrict usage of `serializable_hash` options

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -302,6 +302,34 @@ So that when we render the `#edit` action, we'll get
 
 Where `can_edit` is `view_context.current_user.admin?` (true).
 
+You can optionally tell what to set as `serialization_scope` for specific actions,
+similar to `before_action` method in controllers.
+
+```diff
+class PostsController < ActionController::Base
+  serialization_scope :admin_user, only: :edit
+
+  def show
+    render json: @post, serializer: PostSerializer
+  end
+
+  def edit
+    @post.save
+    render json: @post, serializer: Admin::PostSerializer
+  end
+
+  private
+
+  def admin_user
+    User.new(id: 2, name: 'Bob', admin: true)
+  end
+
+  def current_user
+    User.new(id: 2, name: 'Bob', admin: false)
+  end
+end
+```
+
 #### #read_attribute_for_serialization(key)
 
 The serialized value for a given key. e.g. `read_attribute_for_serialization(:title) #=> 'Hello World'`

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -8,8 +8,10 @@ module ActionController
     include ActionController::Renderers
 
     module ClassMethods
-      def serialization_scope(scope)
-        self._serialization_scope = scope
+      def serialization_scope(scope, opts = {})
+        before_action(opts.slice(:only, :except, :if, :unless)) do
+          self._serialization_scope = scope
+        end
       end
     end
 


### PR DESCRIPTION
#### Purpose
I want to set `serialization_scope` as different object rather than `current_user`, for only specific actions in given controller.

#### Changes
Adds support for setting `serialization_scope` conditionally in controllers, same as calling `before_action` with options.