### PR TITLE
Setting the content_type sets the response Content-Type

### DIFF
--- a/lib/active_model_serializers/register_jsonapi_renderer.rb
+++ b/lib/active_model_serializers/register_jsonapi_renderer.rb
@@ -57,7 +57,6 @@ end
 ActionController::Renderers.add :jsonapi do |json, options|
   json = serialize_jsonapi(json, options).to_json(options) unless json.is_a?(String)
   self.content_type ||= media_type
-  headers.merge! ActiveModelSerializers::Jsonapi::HEADERS[:response]
   self.response_body = json
 end
 


### PR DESCRIPTION
Otherwise we have two headers, 'Content-Type' and 'CONTENT_TYPE'.
I don't know when Rails decides to use one or the other.