### PR TITLE
Allow options on multiple attributes at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Features:
 - [#1687](https://github.com/rails-api/active_model_serializers/pull/1687) Only calculate `_cache_digest` (in `cache_key`) when `skip_digest` is false. (@bf4)
 - [#1647](https://github.com/rails-api/active_model_serializers/pull/1647) Restrict usage of `serializable_hash` options
   to the ActiveModel::Serialization and ActiveModel::Serializers::JSON interface. (@bf4)
+- [#1714](https://github.com/rails-api/active_model_serializers/pull/1714) Add options to multiple attributes at once. (@nicklandgrebe)
 
 Fixes:
 - [#1700](https://github.com/rails-api/active_model_serializers/pull/1700) Support pagination link for Kaminari when no data is returned. (@iamnader)

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -34,10 +34,11 @@ module ActiveModel
         #   class AdminAuthorSerializer < ActiveModel::Serializer
         #     attributes :id, :name, :recent_edits
         def attributes(*attrs)
+          options = attrs.pop if attrs.last.class == Hash
           attrs = attrs.first if attrs.first.class == Array
 
           attrs.each do |attr|
-            attribute(attr)
+            attribute(attr, options)
           end
         end
 

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -38,7 +38,7 @@ module ActiveModel
           attrs = attrs.first if attrs.first.class == Array
 
           attrs.each do |attr|
-            attribute(attr, options)
+            attribute(attr, options || {})
           end
         end
 

--- a/lib/active_model/serializer/attributes.rb
+++ b/lib/active_model/serializer/attributes.rb
@@ -34,11 +34,13 @@ module ActiveModel
         #   class AdminAuthorSerializer < ActiveModel::Serializer
         #     attributes :id, :name, :recent_edits
         def attributes(*attrs)
-          options = attrs.pop if attrs.last.class == Hash
+          options = attrs.last.class == Hash ? attrs.pop : {}
+          options = options.except(:key)
+
           attrs = attrs.first if attrs.first.class == Array
 
           attrs.each do |attr|
-            attribute(attr, options || {})
+            attribute(attr, options)
           end
         end
 

--- a/test/serializers/attributes_test.rb
+++ b/test/serializers/attributes_test.rb
@@ -48,6 +48,7 @@ module ActiveModel
         assert_equal([:id, :title, :body], serializer_class._attributes)
       end
 
+      # rubocop:disable Metrics/AbcSize
       def test_multiple_conditional_attributes
         model = ::Model.new(true: true, false: false)
 

--- a/test/serializers/attributes_test.rb
+++ b/test/serializers/attributes_test.rb
@@ -47,6 +47,16 @@ module ActiveModel
 
         assert_equal([:id, :title, :body], serializer_class._attributes)
       end
+
+      def test_attributes_options_assignment
+        model = ::Model.new(name: 'Name 1')
+
+        serializer = Class.new(ActiveModel::Serializer) do
+          attributes :name, key: :title
+        end
+
+        assert_equal({ title: 'Name 1' }, serializer.new(model).serializable_hash)
+      end
     end
   end
 end


### PR DESCRIPTION
#### Purpose

Add options to `Serializer.attributes` so we can apply conditions to multiple attributes at once.
#### Changes

Check if last item in `attrs` passed into `Serializer.attributes` has condition `class == Hash`, and if so, `pop` it off `attrs`, then pass it into `attribute(attr, options)` every time `attrs` is iterated over.

Before, only `attribute(attr)` would be called every time `attrs` is iterated over.
#### Caveats
#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/pull/1403#issuecomment-172044770
#### Additional helpful information
