### PR TITLE
Fix RuboCop 0.40 linter errors

### DIFF
--- a/lib/active_model/serializer/include_tree.rb
+++ b/lib/active_model/serializer/include_tree.rb
@@ -95,12 +95,11 @@ module ActiveModel
 
       def [](key)
         # TODO(beauby): Adopt a lazy caching strategy for generating subtrees.
-        case
-        when @hash.key?(key)
+        if @hash.key?(key)
           self.class.new(@hash[key])
-        when @hash.key?(:*)
+        elsif @hash.key?(:*)
           self.class.new(@hash[:*])
-        when @hash.key?(:**)
+        elsif @hash.key?(:**)
           self.class.new(:** => {})
         else
           nil

--- a/lib/active_model_serializers/deprecate.rb
+++ b/lib/active_model_serializers/deprecate.rb
@@ -36,8 +36,7 @@ module ActiveModelSerializers
           target = is_a?(Module) ? "#{self}." : "#{self.class}#"
           msg = ["NOTE: #{target}#{name} is deprecated",
                  replacement == :none ? ' with no replacement' : "; use #{replacement} instead",
-                 "\n#{target}#{name} called from #{ActiveModelSerializers.location_of_caller.join(":")}"
-                ]
+                 "\n#{target}#{name} called from #{ActiveModelSerializers.location_of_caller.join(":")}"]
           warn "#{msg.join}."
           send old, *args, &block
         end

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -100,7 +100,8 @@ module ActionController
         get :render_array_using_explicit_serializer_and_custom_serializers
 
         expected = [
-          { 'title' => 'New Post',
+          {
+            'title' => 'New Post',
             'body' => 'Body',
             'id' => assigns(:post).id,
             'comments' => [{ 'id' => 1 }, { 'id' => 2 }],

--- a/test/action_controller/json_api/errors_test.rb
+++ b/test/action_controller/json_api/errors_test.rb
@@ -7,8 +7,8 @@ module ActionController
         def test_active_model_with_multiple_errors
           get :render_resource_with_errors
 
-          expected_errors_object =
-            { :errors =>
+          expected_errors_object = {
+            :errors =>
               [
                 { :source => { :pointer => '/data/attributes/name' }, :detail => 'cannot be nil' },
                 { :source => { :pointer => '/data/attributes/name' }, :detail => 'must be longer' },

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -294,7 +294,8 @@ module ActionController
           comments: [
             {
               id: 1,
-              body: 'ZOMG A COMMENT' }
+              body: 'ZOMG A COMMENT'
+            }
           ],
           blog: {
             id: 999,
@@ -333,7 +334,8 @@ module ActionController
           comments: [
             {
               id: 1,
-              body: 'ZOMG A COMMENT' }
+              body: 'ZOMG A COMMENT'
+            }
           ],
           blog: {
             id: 999,
@@ -407,7 +409,8 @@ module ActionController
           comments: [
             {
               id: 1,
-              body: 'ZOMG A COMMENT' }
+              body: 'ZOMG A COMMENT'
+            }
           ],
           blog: {
             id: 999,

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -58,9 +58,10 @@ module ActiveModelSerializers
 
         def test_limiting_fields
           actual = ActiveModelSerializers::SerializableResource.new(
-            [@first_post, @second_post], adapter: :json_api,
-                                         fields: { posts: %w(title comments blog author) })
-                                                               .serializable_hash
+            [@first_post, @second_post],
+            adapter: :json_api,
+            fields: { posts: %w(title comments blog author) }
+          ).serializable_hash
           expected = [
             {
               id: '1',

--- a/test/adapter/json_api/errors_test.rb
+++ b/test/adapter/json_api/errors_test.rb
@@ -22,14 +22,13 @@ module ActiveModelSerializers
           assert_equal serializable_resource.serializer_instance.attributes, {}
           assert_equal serializable_resource.serializer_instance.object, @resource
 
-          expected_errors_object =
-            { :errors =>
-              [
-                {
-                  source: { pointer: '/data/attributes/name' },
-                  detail: 'cannot be nil'
-                }
-              ]
+          expected_errors_object = {
+            :errors => [
+              {
+                source: { pointer: '/data/attributes/name' },
+                detail: 'cannot be nil'
+              }
+            ]
           }
           assert_equal serializable_resource.as_json, expected_errors_object
         end
@@ -48,13 +47,12 @@ module ActiveModelSerializers
           assert_equal serializable_resource.serializer_instance.attributes, {}
           assert_equal serializable_resource.serializer_instance.object, @resource
 
-          expected_errors_object =
-            { :errors =>
-              [
-                { :source => { :pointer => '/data/attributes/name' }, :detail => 'cannot be nil' },
-                { :source => { :pointer => '/data/attributes/name' }, :detail => 'must be longer' },
-                { :source => { :pointer => '/data/attributes/id' }, :detail => 'must be a uuid' }
-              ]
+          expected_errors_object = {
+            :errors => [
+              { :source => { :pointer => '/data/attributes/name' }, :detail => 'cannot be nil' },
+              { :source => { :pointer => '/data/attributes/name' }, :detail => 'must be longer' },
+              { :source => { :pointer => '/data/attributes/id' }, :detail => 'must be a uuid' }
+            ]
           }
           assert_equal serializable_resource.as_json, expected_errors_object
         end

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -341,9 +341,10 @@ module ActiveModelSerializers
 
         def test_no_duplicates_collection
           hash = ActiveModelSerializers::SerializableResource.new(
-            [@post1, @post2], adapter: :json_api,
-                              include: '*.*')
-                                                             .serializable_hash
+            [@post1, @post2],
+            adapter: :json_api,
+            include: '*.*'
+          ).serializable_hash
           expected = [
             {
               type: 'authors', id: '1',
@@ -364,7 +365,8 @@ module ActiveModelSerializers
           hash = ActiveModelSerializers::SerializableResource.new(
             @nestedpost1,
             adapter: :json_api,
-            include: '*').serializable_hash
+            include: '*'
+          ).serializable_hash
           expected = [
             type: 'nested-posts', id: '2',
             relationships: {
@@ -383,7 +385,8 @@ module ActiveModelSerializers
           hash = ActiveModelSerializers::SerializableResource.new(
             [@nestedpost1, @nestedpost2],
             adapter: :json_api,
-            include: '*').serializable_hash
+            include: '*'
+          ).serializable_hash
           assert_nil(hash[:included])
         end
       end

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -40,7 +40,8 @@ module ActiveModelSerializers
                   stuff: 'value'
                 }
               }
-            }).serializable_hash
+            }
+          ).serializable_hash
           expected = {
             self: {
               href: 'http://example.com/posts',

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -43,7 +43,8 @@ module ActiveModelSerializers
         end
 
         def data
-          { data: [
+          {
+            data: [
               { id: '1', type: 'profiles', attributes: { name: 'Name 1', description: 'Description 1' } },
               { id: '2', type: 'profiles', attributes: { name: 'Name 2', description: 'Description 2' } },
               { id: '3', type: 'profiles', attributes: { name: 'Name 3', description: 'Description 3' } },

--- a/test/adapter/json_api/transform_test.rb
+++ b/test/adapter/json_api/transform_test.rb
@@ -86,7 +86,8 @@ module ActiveModelSerializers
                   data: [
                     { id: '7', type: 'comments' },
                     { id: '12', type: 'comments' }
-                ] }
+                  ]
+                }
               },
               links: {
                 self: 'http://example.com/posts/1337',
@@ -122,7 +123,8 @@ module ActiveModelSerializers
                   data: [
                     { id: '7', type: 'comments' },
                     { id: '12', type: 'comments' }
-                ] }
+                  ]
+                }
               },
               links: {
                 self: 'http://example.com/posts/1337',
@@ -158,7 +160,8 @@ module ActiveModelSerializers
                   Data: [
                     { Id: '7', Type: 'Comments' },
                     { Id: '12', Type: 'Comments' }
-                ] }
+                  ]
+                }
               },
               Links: {
                 Self: 'http://example.com/posts/1337',
@@ -192,7 +195,8 @@ module ActiveModelSerializers
                   data: [
                     { id: '7', type: 'comments' },
                     { id: '12', type: 'comments' }
-                ] }
+                  ]
+                }
               },
               links: {
                 self: 'http://example.com/posts/1337',
@@ -226,7 +230,8 @@ module ActiveModelSerializers
                   data: [
                     { id: '7', type: 'comments' },
                     { id: '12', type: 'comments' }
-                ] }
+                  ]
+                }
               },
               links: {
                 self: 'http://example.com/posts/1337',
@@ -270,7 +275,8 @@ module ActiveModelSerializers
                   Data: [
                     { Id: '7', Type: 'Comments' },
                     { Id: '12', Type: 'Comments' }
-                ] }
+                  ]
+                }
               },
               Links: {
                 Self: 'http://example.com/posts/1337',
@@ -304,7 +310,8 @@ module ActiveModelSerializers
                   data: [
                     { id: '7', type: 'comments' },
                     { id: '12', type: 'comments' }
-                ] }
+                  ]
+                }
               },
               links: {
                 self: 'http://example.com/posts/1337',
@@ -324,18 +331,18 @@ module ActiveModelSerializers
           serializer = ActiveModel::Serializer::ErrorSerializer.new(resource)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
           result = adapter.serializable_hash
-          expected_errors_object =
-            { :errors =>
-              [
-                {
-                  :source => { :pointer => '/data/attributes/published-at' },
-                  :detail => 'must be in the future' },
-                {
-                  :source => { :pointer => '/data/attributes/title' },
-                  :detail => 'must be longer'
-                }
-              ]
-            }
+          expected_errors_object = {
+            :errors => [
+              {
+                :source => { :pointer => '/data/attributes/published-at' },
+                :detail => 'must be in the future'
+              },
+              {
+                :source => { :pointer => '/data/attributes/title' },
+                :detail => 'must be longer'
+              }
+            ]
+          }
           assert_equal expected_errors_object, result
         end
 
@@ -349,19 +356,18 @@ module ActiveModelSerializers
             adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
             adapter.serializable_hash
           end
-          expected_errors_object =
-            { :Errors =>
-              [
-                {
-                  :Source => { :Pointer => '/data/attributes/PublishedAt' },
-                  :Detail => 'must be in the future'
-                },
-                {
-                  :Source => { :Pointer => '/data/attributes/Title' },
-                  :Detail => 'must be longer'
-                }
-              ]
-            }
+          expected_errors_object = {
+            :Errors => [
+              {
+                :Source => { :Pointer => '/data/attributes/PublishedAt' },
+                :Detail => 'must be in the future'
+              },
+              {
+                :Source => { :Pointer => '/data/attributes/Title' },
+                :Detail => 'must be longer'
+              }
+            ]
+          }
           assert_equal expected_errors_object, result
         end
 
@@ -375,19 +381,18 @@ module ActiveModelSerializers
             adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
             adapter.serializable_hash
           end
-          expected_errors_object =
-            { :Errors =>
-              [
-                {
-                  :Source => { :Pointer => '/data/attributes/PublishedAt' },
-                  :Detail => 'must be in the future'
-                },
-                {
-                  :Source => { :Pointer => '/data/attributes/Title' },
-                  :Detail => 'must be longer'
-                }
-              ]
-            }
+          expected_errors_object = {
+            :Errors => [
+              {
+                :Source => { :Pointer => '/data/attributes/PublishedAt' },
+                :Detail => 'must be in the future'
+              },
+              {
+                :Source => { :Pointer => '/data/attributes/Title' },
+                :Detail => 'must be longer'
+              }
+            ]
+          }
           assert_equal expected_errors_object, result
         end
 
@@ -402,18 +407,17 @@ module ActiveModelSerializers
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
           result = adapter.serializable_hash
 
-          expected_errors_object =
-            { :errors =>
-              [
-                {
-                  :source => { :pointer => '/data/attributes/published-at' },
-                  :detail => 'must be in the future'
-                },
-                {
-                  :source => { :pointer => '/data/attributes/title' },
-                  :detail => 'must be longer'
-                }
-              ]
+          expected_errors_object = {
+            :errors => [
+              {
+                :source => { :pointer => '/data/attributes/published-at' },
+                :detail => 'must be in the future'
+              },
+              {
+                :source => { :pointer => '/data/attributes/title' },
+                :detail => 'must be longer'
+              }
+            ]
           }
           assert_equal expected_errors_object, result
         end
@@ -429,12 +433,11 @@ module ActiveModelSerializers
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
           result = adapter.serializable_hash
 
-          expected_errors_object =
-            { :errors =>
-              [
-                { :source => { :pointer => '/data/attributes/published_at' }, :detail => 'must be in the future' },
-                { :source => { :pointer => '/data/attributes/title' }, :detail => 'must be longer' }
-              ]
+          expected_errors_object = {
+            :errors => [
+              { :source => { :pointer => '/data/attributes/published_at' }, :detail => 'must be in the future' },
+              { :source => { :pointer => '/data/attributes/title' }, :detail => 'must be longer' }
+            ]
           }
           assert_equal expected_errors_object, result
         end
@@ -466,12 +469,11 @@ module ActiveModelSerializers
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
           result = adapter.serializable_hash
 
-          expected_errors_object =
-            { :Errors =>
-              [
-                { :Source => { :Pointer => '/data/attributes/PublishedAt' }, :Detail => 'must be in the future' },
-                { :Source => { :Pointer => '/data/attributes/Title' }, :Detail => 'must be longer' }
-              ]
+          expected_errors_object = {
+            :Errors => [
+              { :Source => { :Pointer => '/data/attributes/PublishedAt' }, :Detail => 'must be in the future' },
+              { :Source => { :Pointer => '/data/attributes/Title' }, :Detail => 'must be longer' }
+            ]
           }
           assert_equal expected_errors_object, result
         end
@@ -487,12 +489,11 @@ module ActiveModelSerializers
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
           result = adapter.serializable_hash
 
-          expected_errors_object =
-            { :errors =>
-              [
-                { :source => { :pointer => '/data/attributes/publishedAt' }, :detail => 'must be in the future' },
-                { :source => { :pointer => '/data/attributes/title' }, :detail => 'must be longer' }
-              ]
+          expected_errors_object = {
+            :errors => [
+              { :source => { :pointer => '/data/attributes/publishedAt' }, :detail => 'must be in the future' },
+              { :source => { :pointer => '/data/attributes/title' }, :detail => 'must be longer' }
+            ]
           }
           assert_equal expected_errors_object, result
         end

--- a/test/adapter/json_test.rb
+++ b/test/adapter/json_test.rb
@@ -33,9 +33,10 @@ module ActiveModelSerializers
 
         assert_equal({
           id: 1,
-          reviews: [{ id: 1, body: 'ZOMG A COMMENT' },
-                    { id: 2, body: 'ZOMG ANOTHER COMMENT' }
-                  ],
+          reviews: [
+            { id: 1, body: 'ZOMG A COMMENT' },
+            { id: 2, body: 'ZOMG ANOTHER COMMENT' }
+          ],
           writer: { id: 1, name: 'Steve K.' },
           site: { id: 1, name: 'My Blog!!' }
           }, adapter.serializable_hash[:post])

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -48,12 +48,12 @@ module ActiveModelSerializers
           resource, {
             serializer: ActiveModel::Serializer::ErrorSerializer,
             adapter: :json_api
-          })
-        expected_response_document =
-          { :errors =>
-            [
-              { :source => { :pointer => '/data/attributes/name' }, :detail => 'must be awesome' }
-            ]
+          }
+        )
+        expected_response_document = {
+          :errors => [
+            { :source => { :pointer => '/data/attributes/name' }, :detail => 'must be awesome' }
+          ]
         }
         assert_equal serializable_resource.as_json(options), expected_response_document
       end
@@ -69,12 +69,12 @@ module ActiveModelSerializers
             serializer: ActiveModel::Serializer::ErrorsSerializer,
             each_serializer: ActiveModel::Serializer::ErrorSerializer,
             adapter: :json_api
-          })
-        expected_response_document =
-          { :errors =>
-            [
-              { :source => { :pointer => '/data/attributes/title' }, :detail => 'must be amazing' }
-            ]
+          }
+        )
+        expected_response_document = {
+          :errors => [
+            { :source => { :pointer => '/data/attributes/title' }, :detail => 'must be amazing' }
+          ]
         }
         assert_equal serializable_resource.as_json(options), expected_response_document
       end

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -15,7 +15,8 @@ module ActiveModel
           @blog,
           adapter: :json,
           serializer: AlternateBlogSerializer,
-          meta: { total: 10 }).as_json
+          meta: { total: 10 }
+        ).as_json
         expected = {
           blog: {
             id: 1,
@@ -65,7 +66,8 @@ module ActiveModel
           @blog,
           adapter: :attributes,
           serializer: AlternateBlogSerializer,
-          meta: { total: 10 }).as_json
+          meta: { total: 10 }
+        ).as_json
         expected = {
           id: 1,
           title: 'AMS Hints'
@@ -79,7 +81,8 @@ module ActiveModel
           adapter: :json,
           serializer: AlternateBlogSerializer,
           meta: { total: 10 },
-          meta_key: 'haha_meta').as_json
+          meta_key: 'haha_meta'
+        ).as_json
         expected = {
           blog: {
             id: 1,
@@ -98,7 +101,8 @@ module ActiveModel
           adapter: :json_api,
           serializer: AlternateBlogSerializer,
           meta: { total: 10 },
-          meta_key: 'haha_meta').as_json
+          meta_key: 'haha_meta'
+        ).as_json
         expected = {
           data: {
             id: '1',
@@ -149,7 +153,8 @@ module ActiveModel
         actual = ActiveModelSerializers::SerializableResource.new(
           [@blog],
           adapter: :attributes,
-          meta: { total: 10 }).as_json
+          meta: { total: 10 }
+        ).as_json
         expected = [{
           id: 1,
           name: 'AMS Hints',
@@ -171,7 +176,8 @@ module ActiveModel
           [@blog],
           adapter: :json,
           meta: { total: 10 },
-          meta_key: 'haha_meta').as_json
+          meta_key: 'haha_meta'
+        ).as_json
         expected = {
           blogs: [{
             id: 1,


### PR DESCRIPTION
#### Purpose
Fixing the Travis-CI build, which seems to use [RuboCop 0.40](https://github.com/bbatsov/rubocop/releases/tag/v0.40.0) despite the Gemfile.lock pinning rubocop to 0.38.

#### Changes
- Mostly whitespace changes to satisfy the linters introduced in https://github.com/bbatsov/rubocop/issues/2857.
- One substitution of if/elsif/else for case/when/else.

New lints that I am updating the code style to reflect:

- Style/EmptyCaseCondition: Do not use empty case condition, instead use
  an if expression.

- Style/MultilineArrayBraceLayout: Closing array brace must be on the
  same line as the last array element when opening brace is on the same
  line as the first array element.

- Style/MultilineHashBraceLayout: Closing hash brace must be on the same
  line as the last hash element when opening brace is on the same line
  as the first hash element.

- Style/MultilineMethodCallBraceLayout: Closing method call brace must
  be on the line after the last argument when opening brace is on a
  separate line from the first argument.

#### Caveats

#### Related GitHub issues

- Blocking #1426

#### Additional helpful information
