### PR TITLE
Pin rubocop to 0.39.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,6 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.36', require: false
+  gem 'rubocop', '~> 0.39.0', require: false
   gem 'yard', require: false
 end


### PR DESCRIPTION
#### Purpose

rubocop 0.40.0 causes some failures. Pin to 0.39.0 until they're resolved.

#### Related GitHub issues

#1722 

