### PR TITLE
adds polymorphic option to association definition which includes asso…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Features:
 
 Fixes:
 - [#1700](https://github.com/rails-api/active_model_serializers/pull/1700) Support pagination link for Kaminari when no data is returned. (@iamnader)
+- [#1726](https://github.com/rails-api/active_model_serializers/pull/1726) Adds polymorphic option to association definition which includes association type/nesting in serializer (@cgmckeever)
 
 Misc:
 - [#1673](https://github.com/rails-api/active_model_serializers/pull/1673) Adds "How to" guide on using AMS with POROs (@DrSayre)

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -52,6 +52,7 @@ Where:
   - `if:`
   - `unless:`
   - `virtual_value:`
+  - `polymorphic:` defines if polymorphic relation type should be nested in serialized association.
 - optional: `&block` is a context that returns the association's attributes.
   - prevents `association_name` method from being called.
   - return value of block is used as the association value.

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -45,7 +45,14 @@ module ActiveModelSerializers
         return unless association.serializer && association.serializer.object
 
         opts = instance_options.merge(include: @include_tree[association.key])
-        Attributes.new(association.serializer, opts).serializable_hash(options)
+        relationship_value = Attributes.new(association.serializer, opts).serializable_hash(options)
+
+        if association.options[:polymorphic] && relationship_value
+          polymorphic_type = association.serializer.object.class.name.underscore
+          relationship_value = { type: polymorphic_type, polymorphic_type.to_sym => relationship_value }
+        end
+
+        relationship_value
       end
 
       # Set @cached_attributes

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -24,6 +24,16 @@ ActiveRecord::Schema.define do
     t.string :email
     t.timestamp null: false
   end
+  create_table :object_tags, force: true do |t|
+    t.string :poly_tag_id
+    t.string :taggable_type
+    t.string :taggable_id
+    t.timestamp null: false
+  end
+  create_table :poly_tags, force: true do |t|
+    t.string :phrase
+    t.timestamp null: false
+  end
   create_table :pictures, force: true do |t|
     t.string :title
     t.string :imageable_type

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -70,10 +70,21 @@ end
 
 class Employee < ActiveRecord::Base
   has_many :pictures, as: :imageable
+  has_many :object_tags, as: :taggable
+end
+
+class ObjectTag < ActiveRecord::Base
+  belongs_to :poly_tag
+  belongs_to :taggable, polymorphic: true
 end
 
 class Picture < ActiveRecord::Base
   belongs_to :imageable, polymorphic: true
+  has_many :object_tags, as: :taggable
+end
+
+class PolyTag < ActiveRecord::Base
+  has_many :object_tags
 end
 
 module Spam; end
@@ -245,7 +256,23 @@ end
 PolymorphicBelongsToSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id, :title
 
-  has_one :imageable, serializer: PolymorphicHasManySerializer
+  has_one :imageable, serializer: PolymorphicHasManySerializer, polymorphic: true
+end
+
+PolymorphicSimpleSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id
+end
+
+PolymorphicObjectTagSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id
+
+  has_many :taggable, serializer: PolymorphicSimpleSerializer, polymorphic: true
+end
+
+PolymorphicTagSerializer = Class.new(ActiveModel::Serializer) do
+  attributes :id, :phrase
+
+  has_many :object_tags, serializer: PolymorphicObjectTagSerializer
 end
 
 Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do


### PR DESCRIPTION
#### Purpose

Current polymorphic association adds the association serialization directly under the polymorphic name (ie imageable).  This does not allow the client provider a straightforward knowledge of what the polymorphic association is, and thus can not easily determine how to handle the data.

This PR allows for the polymorphic: option flag on the association to nest the attributes under the association type - henceforth allowing the client to know what the polymorphic association is, and handle accordingly.

#### Changes

adds polymorphic: option to the serializer association definition which then determines if serialized association should be nested under association type

#### Caveats

Affected serialization adapters: **attributes** && **json**
**Does not affect json_api **

#### Related GitHub issues

my earlier question/inquiry:
https://github.com/rails-api/active_model_serializers/issues/1717

Earlier Polymorphic testing PR which touched up the serialization package diversion from 0.8x
https://github.com/rails-api/active_model_serializers/pull/1420#issuecomment-170284925

#### Additional helpful information

adds polymorphic option to association definition which includes association type in serializer
regen gemlock