### PR TITLE
adds mac files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,13 @@ tmp
 .ruby-gemset
 vendor/bundle
 tags
+
+# silly macs
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
#### Purpose

Macs like to leave breadcrumb files which get picked up by GIT.  This excludes them via .gitignore

#### Changes

update to .gitignore





