### PR TITLE
Include ControllerSupport on ActiveSupport on_load action_controller

### DIFF
--- a/lib/active_model_serializers/register_jsonapi_renderer.rb
+++ b/lib/active_model_serializers/register_jsonapi_renderer.rb
@@ -60,4 +60,6 @@ ActionController::Renderers.add :jsonapi do |json, options|
   self.response_body = json
 end
 
-ActionController::Base.send :include, ActiveModelSerializers::Jsonapi::ControllerSupport
+ActiveSupport.on_load(:action_controller) do
+  include ActiveModelSerializers::Jsonapi::ControllerSupport
+end


### PR DESCRIPTION
#### Purpose

Include `ActiveModelSerializers::Jsonapi::ControllerSupport` when ActionController is loaded.

Rails API controllers inherit from `ActionController::API` and not `ActionController::Base`. Therefore, `ControllerSupport` was never included in such controllers.

#### Additional helpful information

This change was originally proposed by @bf4.