### PR TITLE
Handle situations when serializer is initialized with a nil object.

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -180,7 +180,7 @@ module ActiveModel
         send(attr)
       elsif self.class._fragmented
         self.class._fragmented.read_attribute_for_serialization(attr)
-      else
+      elsif object
         object.read_attribute_for_serialization(attr)
       end
     end

--- a/test/serializers/read_attribute_for_serialization_test.rb
+++ b/test/serializers/read_attribute_for_serialization_test.rb
@@ -7,9 +7,11 @@ module ActiveModel
       class Parent < ActiveModelSerializers::Model
         attr_accessor :id
       end
+
       class Child < Parent
         attr_accessor :name
       end
+
       class ParentSerializer < ActiveModel::Serializer
         attributes :$id
 
@@ -17,8 +19,14 @@ module ActiveModel
           object.id
         end
       end
+
       class ChildSerializer < ParentSerializer
         attributes :name
+      end
+
+      def test_for_serializer_initialized_with_nil_object
+        child = ChildSerializer.new(nil)
+        assert_equal nil, child.read_attribute_for_serialization(:name)
       end
 
       def test_child_serializer_calls_dynamic_method_in_parent_serializer
@@ -32,6 +40,7 @@ module ActiveModel
       class ErrorResponse < ActiveModelSerializers::Model
         attr_accessor :error
       end
+
       class ApplicationSerializer < ActiveModel::Serializer
         attributes :status
 
@@ -39,9 +48,11 @@ module ActiveModel
           object.try(:errors).blank? && object.try(:error).blank?
         end
       end
+
       class ErrorResponseSerializer < ApplicationSerializer
         attributes :error
       end
+
       class ErrorResponseWithSuperSerializer < ApplicationSerializer
         attributes :error
 


### PR DESCRIPTION
#### Purpose

Gracefully handle situations when serializer is accidentally/unknowingly
initialized with a nil object.

#### Changes

1. A simple IF that checks if object exists before calling a method on it.
2. Line breaks for code readability

#### Caveats


#### Related GitHub issues


#### Additional helpful information


This case may come up when using with the airblade/paper_trail gem.

For example:

employee = Employee.first.version_at(date) # version may or may not exist on that date.
EmployeeSerializer.new(employee).attributes

fails with undefined method ```read_attribute_for_serialization``` for Nil class.