### PR TITLE
Adding documentation on conditional attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
 Fixes:
 
 Misc:
+- [#1734](https://github.com/rails-api/active_model_serializers/pull/1734) Adds documentation for conditional attribute (@lambda2)
 
 ### [v0.10.0 (2016-05-17)](https://github.com/rails-api/active_model_serializers/compare/4a2d9853ba7...v0.10.0)
 

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -34,7 +34,18 @@ Serialization of the resource `title`
 | `attribute :title { 'A Different Title'}` | `{ title: 'A Different Title' } `
 | `attribute :title`<br>`def title 'A Different Title' end` | `{ title: 'A Different Title' }`
 
-[PR please for conditional attributes:)](https://github.com/rails-api/active_model_serializers/pull/1403)
+An `if` or `unless` option can make an attribute conditional. It takes a symbol of a method name on the serializer, or a lambda literal.
+
+e.g.
+
+```ruby
+attribute :private_data, if: :is_current_user?
+attribute :another_private_data, if: -> { scope.admin? }
+
+def is_current_user?
+  object.id == current_user.id
+end
+```
 
 ### Associations
 


### PR DESCRIPTION
#### Purpose
Adding documentation on conditional attributes for the `attribute` method.

#### Changes
Adding documentation and short example ([from this pull request](https://github.com/rails-api/active_model_serializers/pull/1403)) on conditional attributes for the `attribute` method.
#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/pull/1403