### PR TITLE
Encourage pinning of pre-1.0.0 release [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ It is generally safe and recommended to use the master branch.
 Add this line to your application's Gemfile:
 
 ```
-gem 'active_model_serializers'
+gem 'active_model_serializers', '~> 0.10.0'
 ```
 
 And then execute:


### PR DESCRIPTION
#### Purpose

Encourage the pinning of pre-1.0.0 release of this gem.

0.10 introduced breaking changes (notably, no root node is included in the JSON). This broke our build. Since semver allows pre-1.0.0 to introduce breaking changes this is okay. However since the gem is 5 years old but has no 1.0 release maybe we should encourage the pinning of the gem in the README.

#### Changes

Documentation only.

#### Caveats


#### Related GitHub issues


#### Additional helpful information



