### PR TITLE
[WIP] fix belongs_to causing unnecessary db hits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :bench do
 end
 
 group :test do
+  gem 'pry-byebug'
   gem 'sqlite3',                          platform: (@windows_platforms + [:ruby])
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'codeclimate-test-reporter', require: false

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -87,10 +87,14 @@ module ActiveModel
         return unless object
 
         Enumerator.new do |y|
+          # _reflections is an AMS::BelongsToReflection or
+          # an AMS::HasManyReflection
           self.class._reflections.each do |reflection|
             next if reflection.excluded?(self)
             key = reflection.options.fetch(:key, reflection.name)
             next unless include_tree.key?(key)
+            # until this is called, the reflection / association
+            # is _not_ evaluated
             y.yield reflection.build_association(self, instance_options)
           end
         end

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -56,6 +56,11 @@ module ActiveModel
         :nil
       end
 
+      # This gets the value of the reflection.
+      # this needs to be avoided if we have a belongs_to relationship
+      # because we only care about the id and type, and not about the object.
+      # This causes n+1 queries unnecessarily
+      #
       # @param serializer [ActiveModel::Serializer]
       # @yield [ActiveModel::Serializer]
       # @return [:nil, associated resource or resource collection]
@@ -70,6 +75,9 @@ module ActiveModel
       #     end
       #   end
       def value(serializer)
+        require 'pry-byebug'
+        binding.pry
+
         @object = serializer.object
         @scope = serializer.scope
 
@@ -78,9 +86,15 @@ module ActiveModel
           if block_value != :nil
             block_value
           elsif @_include_data
+            # this is what needs to be avoided in the case of belongs_to.
+            # should an id and type hash just be returned?
+            # maybe how associations work in general needs to be re-looked at
             serializer.read_attribute_for_serialization(name)
           end
         else
+          # this is what needs to be avoided in the case of belongs_to.
+          # should an id and type hash just be returned?
+          # maybe how associations work in general needs to be re-looked at
           serializer.read_attribute_for_serialization(name)
         end
       end

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -430,7 +430,10 @@ module ActiveModelSerializers
       #   }.reject! {|_,v| v.nil? }
       def relationships_for(serializer, requested_associations)
         include_tree = ActiveModel::Serializer::IncludeTree.from_include_args(requested_associations)
-        serializer.associations(include_tree).each_with_object({}) do |association, hash|
+        # the association object evaluates the relationship, which we
+        # don't want it to do
+        included_associations = serializer.associations(include_tree)
+        included_associations.each_with_object({}) do |association, hash|
           hash[association.key] = Relationship.new(
             serializer,
             association.serializer,

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -126,6 +126,21 @@ module ActiveModel
         assert expected_association_keys.include? :site
       end
 
+      class BelongsToTestPostSerializer < ActiveModel::Serializer
+        belongs_to :blog
+      end
+
+      test 'belongs_to should not load record' do
+        post = Post.new
+        post.blog_id = 'blog'
+        post.blog = 'should not touch this'
+
+        actual = serializable(post, adapter: :json_api, serializer: BelongsToTestPostSerializer).as_json
+        expected = { data: { id: 'post', type: 'posts', relationships: { blog: { data: { id: 'blog', type: 'blogs' } } } } }
+
+        assert_equal expected, actual
+      end
+
       class InlineAssociationTestPostSerializer < ActiveModel::Serializer
         has_many :comments
         has_many :comments, key: :last_comments do


### PR DESCRIPTION
#### Purpose

we only need id and type for belongs to relationships, and we can optimize render time by not touching objects at the other end of the belongs_to
#### Changes

Just notes for now. So others can see where the problem is. We're going to have to tweak how we build the relationship reflection objects, or maybe make all calls to the reflection lazy. idk.

I feel like in order to do this properly, we are going to need to more directly tie in to ActiveRecord.
as @beauby said in #1100: 

>  What happens if we have belongs_to :author in the serializer, and belongs_to :author, class_name: "User" in the model? Then I fear AMS wouldn't know how to set the type property of the Resource Identifier.

So.. not sure if the team wants to have that much coupling with AR. I think its needed in order to properly address this issue though. 
#### Related GitHub issues
#762
#1100 (failing test by @ssendev)
#### TODO before merging
- [ ] Remove binding.pry
- [ ] Actually fix the issue
