### PR TITLE
Update README to write how to configure adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Thanks!
 
 ## High-level behavior
 
+Choose an adapter from [adapters](lib/active_model_serializers/adapter):
+
+``` ruby
+ActiveModelSerializers.config.adapter = :json_api # Default: `:attributes`
+```
+
 Given a [serializable model](lib/active_model/serializer/lint.rb):
 
 ```ruby


### PR DESCRIPTION
For the new user, how to customize adapter is an important concern.
Additionally, README says:
> Check how to change the adapter in the sections below.

However how to change adapter was not documented anywhere.
