### PR TITLE
Remove unnecessary Serializer#cached_fields; Extracted cached_attributes

### DIFF
--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -208,17 +208,17 @@ module ActiveModel
         end
       end
 
-      def cached_attributes(options, cached_attributes, adapter_instance)
+      def cached_attributes(fields, cached_attributes, adapter_instance)
         if self.class.cache_enabled?
           key = cache_key(adapter_instance)
           cached_attributes.fetch(key) do
             cache_check(adapter_instance) do
-              attributes(options[:fields])
+              attributes(fields)
             end
           end
         else
           cache_check(adapter_instance) do
-            attributes(options[:fields])
+            attributes(fields)
           end
         end
       end

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -206,15 +206,6 @@ module ActiveModel
         end
       end
 
-      # Get attributes from @cached_attributes
-      # @return [Hash] cached attributes
-      # def cached_attributes(fields, adapter_instance)
-      def cached_fields(fields, adapter_instance)
-        cache_check(adapter_instance) do
-          attributes(fields)
-        end
-      end
-
       def cache_check(adapter_instance)
         if self.class.cache_enabled?
           self.class.cache_store.fetch(cache_key(adapter_instance), self.class._cache_options) do

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -1,3 +1,5 @@
+# TODO(BF): refactor file to be smaller
+# rubocop:disable Metrics/ModuleLength
 module ActiveModel
   class Serializer
     UndefinedCacheKey = Class.new(StandardError)
@@ -206,6 +208,21 @@ module ActiveModel
         end
       end
 
+      def cached_attributes(options, cached_attributes, adapter_instance)
+        if self.class.cache_enabled?
+          key = cache_key(adapter_instance)
+          cached_attributes.fetch(key) do
+            cache_check(adapter_instance) do
+              attributes(options[:fields])
+            end
+          end
+        else
+          cache_check(adapter_instance) do
+            attributes(options[:fields])
+          end
+        end
+      end
+
       def cache_check(adapter_instance)
         if self.class.cache_enabled?
           self.class.cache_store.fetch(cache_key(adapter_instance), self.class._cache_options) do
@@ -322,3 +339,4 @@ module ActiveModel
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -33,7 +33,7 @@ module ActiveModelSerializers
 
       def serializable_hash_for_single_resource(options)
         cached_attributes = instance_options[:cached_attributes] || {}
-        resource = serializer.cached_attributes(options, cached_attributes, self)
+        resource = serializer.cached_attributes(options[:fields], cached_attributes, self)
         relationships = resource_relationships(options)
         resource.merge(relationships)
       end

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -32,7 +32,16 @@ module ActiveModelSerializers
       end
 
       def serializable_hash_for_single_resource(options)
-        resource = resource_object_for(options)
+        resource =
+          if serializer.class.cache_enabled?
+            cached_attributes = instance_options[:cached_attributes] || {}
+            key = serializer.cache_key(self)
+            cached_attributes.fetch(key) do
+              serializer.cached_fields(options[:fields], self)
+            end
+          else
+            serializer.cached_fields(options[:fields], self)
+          end
         relationships = resource_relationships(options)
         resource.merge(relationships)
       end
@@ -59,18 +68,6 @@ module ActiveModelSerializers
         end
 
         relationship_value
-      end
-
-      def resource_object_for(options)
-        if serializer.class.cache_enabled?
-          cached_attributes = instance_options[:cached_attributes] || {}
-          key = serializer.cache_key(self)
-          cached_attributes.fetch(key) do
-            serializer.cached_fields(options[:fields], self)
-          end
-        else
-          serializer.cached_fields(options[:fields], self)
-        end
       end
     end
   end

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -32,20 +32,8 @@ module ActiveModelSerializers
       end
 
       def serializable_hash_for_single_resource(options)
-        resource =
-          if serializer.class.cache_enabled?
-            cached_attributes = instance_options[:cached_attributes] || {}
-            key = serializer.cache_key(self)
-            cached_attributes.fetch(key) do
-              serializer.cache_check(self) do
-                serializer.attributes(options[:fields])
-              end
-            end
-          else
-            serializer.cache_check(self) do
-              serializer.attributes(options[:fields])
-            end
-          end
+        cached_attributes = instance_options[:cached_attributes] || {}
+        resource = serializer.cached_attributes(options, cached_attributes, self)
         relationships = resource_relationships(options)
         resource.merge(relationships)
       end

--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -37,10 +37,14 @@ module ActiveModelSerializers
             cached_attributes = instance_options[:cached_attributes] || {}
             key = serializer.cache_key(self)
             cached_attributes.fetch(key) do
-              serializer.cached_fields(options[:fields], self)
+              serializer.cache_check(self) do
+                serializer.attributes(options[:fields])
+              end
             end
           else
-            serializer.cached_fields(options[:fields], self)
+            serializer.cache_check(self) do
+              serializer.attributes(options[:fields])
+            end
           end
         relationships = resource_relationships(options)
         resource.merge(relationships)


### PR DESCRIPTION
- Remove unnecessary Adapter::Base#resource_object_for
- Remove unnecessary Serializer#cached_fields
- Complete extracting to Serializer#cached_attributes; put cached_attributes in right spot
- Simplify Serializer#cached_attributes to take a fields argument

Extracted from #1684