### PR TITLE
Fix docs for deserialization relationships

### DIFF
--- a/docs/general/deserialization.md
+++ b/docs/general/deserialization.md
@@ -42,7 +42,7 @@ document = {
       'title' => 'Title 1',
       'date' => '2015-12-20'
     },
-    'associations' => {
+    'relationships' => {
       'author' => {
         'data' => {
           'type' => 'user',


### PR DESCRIPTION
#### Purpose

I found in the tests that deserialization expects relationships to be under a `relationships` key.
https://github.com/rails-api/active_model_serializers/blob/master/test/action_controller/json_api/deserialization_test.rb#L68

#### Changes

One key in the example document to be deserialized, from `associations` to `relationships`.

#### Caveats


#### Related GitHub issues


#### Additional helpful information


