### PR TITLE
Upgrade to rubocop ~> 0.40.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,6 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.39.0', require: false
+  gem 'rubocop', '~> 0.40.0', require: false
   gem 'yard', require: false
 end

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -431,7 +431,8 @@ module ActiveModelSerializers
       def relationships_for(serializer, requested_associations)
         include_directive = JSONAPI::IncludeDirective.new(
           requested_associations,
-          allow_wildcard: true)
+          allow_wildcard: true
+        )
         serializer.associations(include_directive).each_with_object({}) do |association, hash|
           hash[association.key] = Relationship.new(
             serializer,


### PR DESCRIPTION
#### Purpose

Upgrade to rubocop ~> 0.40.0.

#### Changes

Updates version pin to ~> 0.40.0. Fixes a lingering offense introduced after #1722.

#### Related GitHub issues

#1722

#### Additional helpful information

#1722 fixed most offenses introduced by rubocop 0.40.0.