### PR TITLE
Added ability for type to take a proc or a block

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -188,9 +188,7 @@ module ActiveModel
 
     # Used by adapter as resource root.
     def json_key
-      root ||
-        (_type && _type.is_a?(Proc) ? _type.call(object) : _type) ||
-        object.class.model_name.to_s.underscore
+      root || _type || object.class.model_name.to_s.underscore
     end
 
     def read_attribute_for_serialization(attr)

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -188,7 +188,9 @@ module ActiveModel
 
     # Used by adapter as resource root.
     def json_key
-      root || _type || object.class.model_name.to_s.underscore
+      root ||
+        (_type && _type.is_a?(Proc) ? _type.call(object) : _type) ||
+        object.class.model_name.to_s.underscore
     end
 
     def read_attribute_for_serialization(attr)

--- a/lib/active_model/serializer/type.rb
+++ b/lib/active_model/serializer/type.rb
@@ -26,14 +26,7 @@ module ActiveModel
         #     type proc { |object| object.class.name }
         #
         def type(type = nil, &block)
-          type = block if block_given?
-          return unless type
-
-          self._type = if type.respond_to?(:call) && type.arity == 1
-                         type
-                       else
-                         type.to_s
-                       end
+          self._type = block || type
         end
       end
     end

--- a/lib/active_model/serializer/type.rb
+++ b/lib/active_model/serializer/type.rb
@@ -16,8 +16,13 @@ module ActiveModel
         # @example
         #   class AdminAuthorSerializer < ActiveModel::Serializer
         #     type 'authors'
+        #
+        # @example
+        # TODO: actually do block, not Proc
+        #   class AdminAuthorSerializer < ActiveModel::Serializer
+        #     type { |object| object.class.name }
         def type(type)
-          self._type = type && type.to_s
+          self._type = type.is_a?(Proc) ? type : type.to_s if type
         end
       end
     end

--- a/lib/active_model/serializer/type.rb
+++ b/lib/active_model/serializer/type.rb
@@ -21,8 +21,15 @@ module ActiveModel
         # TODO: actually do block, not Proc
         #   class AdminAuthorSerializer < ActiveModel::Serializer
         #     type { |object| object.class.name }
-        def type(type)
-          self._type = type.is_a?(Proc) ? type : type.to_s if type
+        def type(type = nil, &block)
+          type = block if block_given?
+          return unless type
+
+          self._type = if type.respond_to?(:call) && type.arity == 1
+                         type
+                       else
+                         type.to_s
+                       end
         end
       end
     end

--- a/lib/active_model/serializer/type.rb
+++ b/lib/active_model/serializer/type.rb
@@ -18,9 +18,13 @@ module ActiveModel
         #     type 'authors'
         #
         # @example
-        # TODO: actually do block, not Proc
         #   class AdminAuthorSerializer < ActiveModel::Serializer
         #     type { |object| object.class.name }
+        #
+        # @example
+        #   class AdminAuthorSerializer < ActiveModel::Serializer
+        #     type proc { |object| object.class.name }
+        #
         def type(type = nil, &block)
           type = block if block_given?
           return unless type

--- a/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
@@ -20,8 +20,8 @@ module ActiveModelSerializers
         private
 
         def type_for(serializer)
-          return serializer._type.call(serializer.object) if serializer._type.is_a?(Proc)
-          return serializer._type if serializer._type
+          return serializer._type.call(serializer.object) if serializer._type.respond_to?(:call)
+          return serializer._type.to_s if serializer._type
           if ActiveModelSerializers.config.jsonapi_resource_type == :singular
             serializer.object.class.model_name.singular
           else

--- a/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
@@ -20,6 +20,7 @@ module ActiveModelSerializers
         private
 
         def type_for(serializer)
+          return serializer._type.call(serializer.object) if serializer._type.is_a?(Proc)
           return serializer._type if serializer._type
           if ActiveModelSerializers.config.jsonapi_resource_type == :singular
             serializer.object.class.model_name.singular

--- a/test/adapter/json_api/type_test.rb
+++ b/test/adapter/json_api/type_test.rb
@@ -28,9 +28,7 @@ module ActiveModel
           end
 
           class LambdaTypeSerializer < ActiveModel::Serializer
-            type do |object|
-              "lambda-#{object.class.model_name}"
-            end
+            type ->(object) { "lambda-#{object.class.model_name}" }
           end
 
           setup do

--- a/test/adapter/json_api/type_test.rb
+++ b/test/adapter/json_api/type_test.rb
@@ -15,8 +15,18 @@ module ActiveModel
             type :profile
           end
 
+          class BlockTypeSerializer < ActiveModel::Serializer
+            type proc { |object|
+              "block-#{object.class.model_name}"
+            }
+          end
+
           setup do
             @author = Author.new(id: 1, name: 'Steve K.')
+          end
+
+          test 'the type can take a block' do
+            assert_type(@author, 'block-author', serializer: BlockTypeSerializer)
           end
 
           def test_config_plural

--- a/test/adapter/json_api/type_test.rb
+++ b/test/adapter/json_api/type_test.rb
@@ -15,14 +15,24 @@ module ActiveModel
             type :profile
           end
 
-          class BlockTypeSerializer < ActiveModel::Serializer
+          class ProcTypeSerializer < ActiveModel::Serializer
             type proc { |object|
-              "block-#{object.class.model_name}"
+              "proc-#{object.class.model_name}"
             }
+          end
+
+          class BlockTypeSerializer < ActiveModel::Serializer
+            type do |object|
+              "block-#{object.class.model_name}"
+            end
           end
 
           setup do
             @author = Author.new(id: 1, name: 'Steve K.')
+          end
+
+          test 'the type can take a proc' do
+            assert_type(@author, 'proc-author', serializer: ProcTypeSerializer)
           end
 
           test 'the type can take a block' do

--- a/test/adapter/json_api/type_test.rb
+++ b/test/adapter/json_api/type_test.rb
@@ -27,6 +27,12 @@ module ActiveModel
             end
           end
 
+          class LambdaTypeSerializer < ActiveModel::Serializer
+            type do |object|
+              "lambda-#{object.class.model_name}"
+            end
+          end
+
           setup do
             @author = Author.new(id: 1, name: 'Steve K.')
           end
@@ -37,6 +43,10 @@ module ActiveModel
 
           test 'the type can take a block' do
             assert_type(@author, 'block-author', serializer: BlockTypeSerializer)
+          end
+
+          test 'the type can take a lambda' do
+            assert_type(@author, 'lambda-author', serializer: LambdaTypeSerializer)
           end
 
           def test_config_plural


### PR DESCRIPTION
#### Purpose

I want to be able to dynamically set the type, especially for polymorphic associations.

``` ruby
class BlockTypeSerializer < ActiveModel::Serializer
   type proc { |object|
     "block-#{object.class.model_name}"
  }
end
```
#### Caveats

So for, only a proc -- we should unify all our apis with block options, though, yeah?
