### PR TITLE
Namespace separator setting for json-api and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Breaking changes:
 
 Features:
+- [#1609](https://github.com/rails-api/active_model_serializers/pull/1609) Adds JSON API Attribute namespace separator setting. (@youroff)
 - [#1668](https://github.com/rails-api/active_model_serializers/pull/1668) Exclude nil and empty links. (@sigmike)
 - [#1426](https://github.com/rails-api/active_model_serializers/pull/1426) Add ActiveModelSerializers.config.default_includes (@empact)
 

--- a/docs/general/configuration_options.md
+++ b/docs/general/configuration_options.md
@@ -72,6 +72,21 @@ Possible values:
 - `:singular`
 - `:plural` (default)
 
+##### jsonapi_namespace_separator
+
+Sets separator string for namespaced models to render `type` attribute. Default value is `--`.
+
+##### jsonapi_type_transform
+
+Provides transform for `type` attribute. Class name `NicePost` gets converted into `nice_post`, `nice-post`, `NicePost` or `nicePost` depending on selected setting.
+
+Possible values:
+
+- `:underscore` (default)
+- `:dashed`
+- `:camel`
+- `:snake`
+
 ##### jsonapi_include_toplevel_object
 
 Include a [top level jsonapi member](http://jsonapi.org/format/#document-jsonapi-object)

--- a/lib/active_model/serializer/configuration.rb
+++ b/lib/active_model/serializer/configuration.rb
@@ -22,6 +22,8 @@ module ActiveModel
         config.default_includes = '*'
         config.adapter = :attributes
         config.jsonapi_resource_type = :plural
+        config.jsonapi_namespace_separator = '--'.freeze
+        config.jsonapi_type_transform = :underscore
         config.jsonapi_version = '1.0'
         config.jsonapi_toplevel_meta = {}
         # Make JSON API top-level jsonapi member opt-in

--- a/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
@@ -21,11 +21,13 @@ module ActiveModelSerializers
 
         def type_for(serializer)
           return serializer._type if serializer._type
-          if ActiveModelSerializers.config.jsonapi_resource_type == :singular
-            serializer.object.class.model_name.singular
-          else
-            serializer.object.class.model_name.plural
+          type = serializer.object.class.to_s.split('::')
+          type.map! { |t| KeyTransform.transform(t, ActiveModelSerializers.config.jsonapi_type_transform) }
+          type = type.join ActiveModelSerializers.config.jsonapi_namespace_separator
+          if ActiveModelSerializers.config.jsonapi_resource_type == :plural
+            type = type.pluralize
           end
+          type
         end
 
         def id_for(serializer)

--- a/lib/active_model_serializers/key_transform.rb
+++ b/lib/active_model_serializers/key_transform.rb
@@ -66,5 +66,26 @@ module ActiveModelSerializers
     def unaltered(value)
       value
     end
+
+    # Transforms string to selected case
+    # Accepts string in any case: 'camel', 'undescore', 'dashed'.
+    #
+    # @example:
+    #   transform('SomeClass', :underscore) => 'some_class'
+    #   transform('some_class', :snake) => 'someClass'
+    #   etc...
+    def transform(string, type)
+      string = string.underscore
+      case type.to_sym
+      when :dashed
+        string.dasherize
+      when :camel
+        string.camelize
+      when :snake
+        string.camelize(:lower)
+      else
+        string
+      end
+    end
   end
 end

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -216,8 +216,8 @@ module ActiveModelSerializers
           expected = {
             related: {
               data: [{
-                type: 'spam-unrelated-links',
-                id: '456'
+                id: '456',
+                type: 'spam--unrelated-links'
               }]
             }
           }

--- a/test/adapter/json_api/resource_identifier_test.rb
+++ b/test/adapter/json_api/resource_identifier_test.rb
@@ -28,61 +28,59 @@ module ActiveModelSerializers
         end
 
         def test_defined_type
-          test_type(WithDefinedTypeSerializer, 'with-defined-type')
+          assert_identifier(WithDefinedTypeSerializer.new(@model), type: 'with-defined-type')
         end
 
         def test_singular_type
-          test_type_inflection(AuthorSerializer, 'author', :singular)
+          assert_with_confing(AuthorSerializer.new(@model), type: 'author', inflection: :singular)
         end
 
         def test_plural_type
-          test_type_inflection(AuthorSerializer, 'authors', :plural)
+          assert_with_confing(AuthorSerializer.new(@model), type: 'authors', inflection: :plural)
+        end
+
+        def test_type_with_namespace
+          spam = Spam::UnrelatedLink.new
+          assert_identifier(Spam::UnrelatedLinkSerializer.new(spam), type: 'spam--unrelated-links')
+        end
+
+        def test_type_with_custom_namespace
+          spam = Spam::UnrelatedLink.new
+          assert_with_confing(Spam::UnrelatedLinkSerializer.new(spam), type: 'spam/unrelated-links', namespace_separator: '/')
         end
 
         def test_id_defined_on_object
-          test_id(AuthorSerializer, @model.id.to_s)
+          assert_identifier(AuthorSerializer.new(@model), id: @model.id.to_s)
         end
 
         def test_id_defined_on_serializer
-          test_id(WithDefinedIdSerializer, 'special_id')
+          assert_identifier(WithDefinedIdSerializer.new(@model), id: 'special_id')
         end
 
         def test_id_defined_on_fragmented
-          test_id(FragmentedSerializer, 'special_id')
+          assert_identifier(WithDefinedIdSerializer.new(@model), id: 'special_id')
         end
 
         private
 
-        def test_type_inflection(serializer_class, expected_type, inflection)
-          original_inflection = ActiveModelSerializers.config.jsonapi_resource_type
-          ActiveModelSerializers.config.jsonapi_resource_type = inflection
-          test_type(serializer_class, expected_type)
-        ensure
-          ActiveModelSerializers.config.jsonapi_resource_type = original_inflection
-        end
-
-        def test_type(serializer_class, expected_type)
-          serializer = serializer_class.new(@model)
-          resource_identifier = ResourceIdentifier.new(serializer, nil)
-          expected = {
-            id: @model.id.to_s,
-            type: expected_type
-          }
-
-          assert_equal(expected, resource_identifier.as_json)
-        end
-
-        def test_id(serializer_class, id)
-          serializer = serializer_class.new(@model)
-          resource_identifier = ResourceIdentifier.new(serializer, nil)
+        def assert_with_confing(serializer, opts = {})
           inflection = ActiveModelSerializers.config.jsonapi_resource_type
-          type = @model.class.model_name.send(inflection)
-          expected = {
-            id: id,
-            type: type
-          }
+          namespace_separator = ActiveModelSerializers.config.jsonapi_namespace_separator
+          ActiveModelSerializers.config.jsonapi_resource_type = opts.fetch(:inflection, inflection)
+          ActiveModelSerializers.config.jsonapi_namespace_separator = opts.fetch(:namespace_separator, namespace_separator)
+          assert_identifier(serializer, opts)
+        ensure
+          ActiveModelSerializers.config.jsonapi_resource_type = inflection
+          ActiveModelSerializers.config.jsonapi_namespace_separator = namespace_separator
+        end
 
-          assert_equal(expected, resource_identifier.as_json)
+        def assert_identifier(serializer, opts = {})
+          identifier = ResourceIdentifier.new(serializer, opts)
+          expected = {
+            id: opts.fetch(:id, identifier.as_json[:id]),
+            type: opts.fetch(:type, identifier.as_json[:type])
+          }
+          assert_equal(expected, identifier.as_json)
         end
       end
     end


### PR DESCRIPTION
- Documentation
- Type transform setting and transformer, name fixed in tests

I resolved https://github.com/rails-api/active_model_serializers/pull/1609, 
merged into master, and would like @remear and @youroff to review for any
changes, since I'm merging this after changes in the KeyTransform code were made.