### PR TITLE
Fix spelling

### DIFF
--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -266,7 +266,7 @@ In the controller, the scope/scope_name options are equal to
 the [`serialization_scope`method](https://github.com/rails-api/active_model_serializers/blob/d02cd30fe55a3ea85e1d351b6e039620903c1871/lib/action_controller/serialization.rb#L13-L20),
 which is `:current_user`, by default.
 
-Specfically, the `scope_name` is defaulted to `:current_user`, and may be set as
+Specifically, the `scope_name` is defaulted to `:current_user`, and may be set as
 `serialization_scope :view_context`.  The `scope` is set to `send(scope_name)` when `scope_name` is
 present and the controller responds to `scope_name`.
 

--- a/test/benchmark/app.rb
+++ b/test/benchmark/app.rb
@@ -43,7 +43,7 @@ class BenchmarkApp < Rails::Application
   config.secret_key_base = 'abc123'
   config.consider_all_requests_local = false
 
-  # otherwise deadlock occured
+  # otherwise deadlock occurred
   config.middleware.delete 'Rack::Lock'
 
   # to disable log files


### PR DESCRIPTION
Here's the pre-push hook I use :)

```
cat <<  'EOF' > .git/hooks/pre-push

bundle exec rake rubocop

if command -v misspell >/dev/null; then
  misspell  -w -error -source=text {app,config,lib,spec,test,docs,bin}/**/* 2>/dev/null
fi

EOF
chmod +x .git/hooks/pre-push
```