### PR TITLE
Add note about will_paginate previous_page method

### DIFF
--- a/docs/howto/add_pagination_links.md
+++ b/docs/howto/add_pagination_links.md
@@ -81,13 +81,12 @@ def pagination_dict(object)
   {
     current_page: object.current_page,
     next_page: object.next_page,
-    prev_page: object.prev_page,
+    prev_page: object.prev_page, # use object.previous_page when using will_paginate
     total_pages: object.total_pages,
     total_count: object.total_count
   }
 end
 ```
-**[NOTE] will_paginate uses `previous_page` method**
 
 Then, use it on your render method.
 
@@ -127,13 +126,12 @@ def meta_attributes(resource, extra_meta = {})
   {
     current_page: resource.current_page,
     next_page: resource.next_page,
-    prev_page: resource.prev_page,
+    prev_page: resource.prev_page, # use resource.previous_page when using will_paginate
     total_pages: resource.total_pages,
     total_count: resource.total_count
   }.merge(extra_meta)
 end
 ```
-**[NOTE] will_paginate uses `previous_page` method**
 
 ### Attributes adapter
 

--- a/docs/howto/add_pagination_links.md
+++ b/docs/howto/add_pagination_links.md
@@ -87,6 +87,7 @@ def pagination_dict(object)
   }
 end
 ```
+**[NOTE] will_paginate uses `previous_page` method**
 
 Then, use it on your render method.
 
@@ -132,7 +133,7 @@ def meta_attributes(resource, extra_meta = {})
   }.merge(extra_meta)
 end
 ```
-
+**[NOTE] will_paginate uses `previous_page` method**
 
 ### Attributes adapter
 


### PR DESCRIPTION
#### Purpose
Make the Add Pagination Links HowTo clearer in using kaminari or will_paginate for pagination links

#### Changes
Add documentation in docs/howto/add_pagination_links.md

#### Additional helpful information
`pagination_dict` method in JSON adapter section refers only to kaminari `prev_page.` Newer version of will_paginate uses `previous_page` method.

Preferred to add a note(just one line) rather than copy/pasting the method definition and change the regarding method.