### PR TITLE
Ensuring read_multi works with fragment cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 Features:
 
 Fixes:
+- [#1814] (https://github.com/rails-api/active_model_serializers/pull/1814) Ensuring read_multi works with fragment cache
 
 Misc:
 

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -227,23 +227,19 @@ module ActiveModel
         end
       end
 
-      def non_cached_attributes(adapter_instance, fields)
-        non_cached_fields = fields[:non_cached].dup
-        non_cached_hash = attributes(non_cached_fields, true)
-        include_directive = JSONAPI::IncludeDirective.new(non_cached_fields - non_cached_hash.keys)
-        non_cached_hash.merge! resource_relationships({}, { include_directive: include_directive }, adapter_instance)
-        non_cached_hash
-      end
-
       # 1. Determine cached fields from serializer class options
       # 2. Get non_cached_fields and fetch cache_fields
       # 3. Merge the two hashes using adapter_instance#fragment_cache
+      # rubocop:disable Metrics/AbcSize
       def fetch_attributes_fragment(adapter_instance, cached_attributes = {})
         serializer_class._cache_options ||= {}
         serializer_class._cache_options[:key] = serializer_class._cache_key if serializer_class._cache_key
         fields = serializer_class.fragmented_attributes
 
-        non_cached_hash = non_cached_attributes(adapter_instance, fields)
+        non_cached_fields = fields[:non_cached].dup
+        non_cached_hash = attributes(non_cached_fields, true)
+        include_directive = JSONAPI::IncludeDirective.new(non_cached_fields - non_cached_hash.keys)
+        non_cached_hash.merge! resource_relationships({}, { include_directive: include_directive }, adapter_instance)
 
         cached_fields = fields[:cached].dup
         key = cache_key(adapter_instance)
@@ -258,6 +254,7 @@ module ActiveModel
         # Merge both results
         adapter_instance.fragment_cache(cached_hash, non_cached_hash)
       end
+      # rubocop:enable Metrics/AbcSize
 
       def cache_key(adapter_instance)
         return @cache_key if defined?(@cache_key)

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -197,7 +197,7 @@ module ActiveModel
         def object_cache_key(serializer, adapter_instance)
           return unless serializer.present? && serializer.object.present?
 
-          serializer.class.cache_enabled? ? serializer.cache_key(adapter_instance) : nil
+          (serializer.class.cache_enabled? || serializer.class.fragment_cache_enabled?) ? serializer.cache_key(adapter_instance) : nil
         end
       end
 
@@ -211,7 +211,7 @@ module ActiveModel
             end
           end
         elsif serializer_class.fragment_cache_enabled?
-          fetch_attributes_fragment(adapter_instance)
+          fetch_attributes_fragment(adapter_instance, cached_attributes)
         else
           attributes(fields, true)
         end
@@ -230,7 +230,7 @@ module ActiveModel
       # 1. Determine cached fields from serializer class options
       # 2. Get non_cached_fields and fetch cache_fields
       # 3. Merge the two hashes using adapter_instance#fragment_cache
-      def fetch_attributes_fragment(adapter_instance)
+      def fetch_attributes_fragment(adapter_instance, cached_attributes={})
         serializer_class._cache_options ||= {}
         serializer_class._cache_options[:key] = serializer_class._cache_key if serializer_class._cache_key
         fields = serializer_class.fragmented_attributes
@@ -243,12 +243,13 @@ module ActiveModel
         cached_fields = fields[:cached].dup
         key = cache_key(adapter_instance)
         cached_hash =
-          serializer_class.cache_store.fetch(key, serializer_class._cache_options) do
-            hash = attributes(cached_fields, true)
-            include_directive = JSONAPI::IncludeDirective.new(cached_fields - hash.keys)
-            hash.merge! resource_relationships({}, { include_directive: include_directive }, adapter_instance)
+          cached_attributes.fetch(key) do
+            serializer_class.cache_store.fetch(key, serializer_class._cache_options) do
+              hash = attributes(cached_fields, true)
+              include_directive = JSONAPI::IncludeDirective.new(cached_fields - hash.keys)
+              hash.merge! resource_relationships({}, { include_directive: include_directive }, adapter_instance)
+            end
           end
-
         # Merge both results
         adapter_instance.fragment_cache(cached_hash, non_cached_hash)
       end

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -227,18 +227,23 @@ module ActiveModel
         end
       end
 
-      # 1. Determine cached fields from serializer class options
-      # 2. Get non_cached_fields and fetch cache_fields
-      # 3. Merge the two hashes using adapter_instance#fragment_cache
-      def fetch_attributes_fragment(adapter_instance, cached_attributes={})
-        serializer_class._cache_options ||= {}
-        serializer_class._cache_options[:key] = serializer_class._cache_key if serializer_class._cache_key
-        fields = serializer_class.fragmented_attributes
-
+      def non_cached_attributes(adapter_instance, fields)
         non_cached_fields = fields[:non_cached].dup
         non_cached_hash = attributes(non_cached_fields, true)
         include_directive = JSONAPI::IncludeDirective.new(non_cached_fields - non_cached_hash.keys)
         non_cached_hash.merge! resource_relationships({}, { include_directive: include_directive }, adapter_instance)
+        non_cached_hash
+      end
+
+      # 1. Determine cached fields from serializer class options
+      # 2. Get non_cached_fields and fetch cache_fields
+      # 3. Merge the two hashes using adapter_instance#fragment_cache
+      def fetch_attributes_fragment(adapter_instance, cached_attributes = {})
+        serializer_class._cache_options ||= {}
+        serializer_class._cache_options[:key] = serializer_class._cache_key if serializer_class._cache_key
+        fields = serializer_class.fragmented_attributes
+
+        non_cached_hash = non_cached_attributes(adapter_instance, fields)
 
         cached_fields = fields[:cached].dup
         key = cache_key(adapter_instance)

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -326,7 +326,7 @@ module ActiveModelSerializers
         cache except: [:body]
       end
 
-      serializers = ActiveModel::Serializer::CollectionSerializer.new([@post, @post], {serializer: post_serializer})
+      serializers = ActiveModel::Serializer::CollectionSerializer.new([@post, @post], serializer: post_serializer)
 
       Timecop.freeze(Time.current) do
         # Warming up.

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -336,9 +336,7 @@ module ActiveModelSerializers
         serializers.serializable_hash(adapter_options, options, adapter_instance)
 
         # Should find something with read_multi now
-        options = {}
         adapter_options = {}
-        adapter_instance = ActiveModelSerializers::Adapter::Attributes.new(serializers, adapter_options)
         serializers.serializable_hash(adapter_options, options, adapter_instance)
         cached_attributes = adapter_options.fetch(:cached_attributes)
 


### PR DESCRIPTION
#### Purpose
AMS was not reading multiple values from the cache at once when the serializer was using fragment cache.

#### Changes
Changed the flow slightly to find the keys for fragment_cache_enabled? serializers. Then ensured the cached attributes were forwarded to the appropriate method.

#### Caveats
Hopefully the reviewers would be able to enlighten me. 

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/827

#### Additional helpful information
All tests did pass and I've created one that fails in 0.10.1 (not reading multiple values on a fragment cache enabled serializer) and is now passing. I also did try this code in my dev environment and was able to confirm AMS was using mget in the collection being serialized an all its has_one relationships.
AMS should consider using mset as well.
