### PR TITLE
skip using serializer if no serializer key provide

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -44,8 +44,14 @@ module ActionController
       true
     end
 
+    def use_serializer?(options)
+      options.key?(:serializer) || options.key?(:each_serializer)
+    end
+
     [:_render_option_json, :_render_with_renderer_json].each do |renderer_method|
       define_method renderer_method do |resource, options|
+        return super(resource, options) unless use_serializer?(options)
+
         options.fetch(:serialization_context) do
           options[:serialization_context] = ActiveModelSerializers::SerializationContext.new(request, options)
         end


### PR DESCRIPTION
#### Purpose
Skip using `SerializableResource` unless the `serializer` or `each_serializer` provided.

Sometimes  i don't have to use `serializers` because i just want to render a given json. 

For example:
```ruby
  render(status: 401, json: { message: message || "unauthorized" })
```


