### PR TITLE
Remove nil relationships links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Features:
 
 Fixes:
 
+- [#1833](https://github.com/rails-api/active_model_serializers/pull/1833) Remove relationship links if they are null (@groyoh)
+
 Misc:
 
 ### [v0.10.2 (2016-07-05)](https://github.com/rails-api/active_model_serializers/compare/v0.10.1...v0.10.2)

--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -13,7 +13,8 @@ module ActiveModelSerializers
           @serializable_resource_options = serializable_resource_options
           @data = data_for(serializer)
           @links = args.fetch(:links, {}).each_with_object({}) do |(key, value), hash|
-            hash[key] = ActiveModelSerializers::Adapter::JsonApi::Link.new(parent_serializer, value).as_json
+            result = Link.new(parent_serializer, value).as_json
+            hash[key] = result if result
           end
           meta = args.fetch(:meta, nil)
           @meta = meta.respond_to?(:call) ? parent_serializer.instance_eval(&meta) : meta

--- a/test/adapter/json_api/relationships_test.rb
+++ b/test/adapter/json_api/relationships_test.rb
@@ -13,8 +13,9 @@ module ActiveModel
             end
 
             has_one :profile do
+              id = object.profile.id
               link :related do
-                "//example.com/profiles/#{object.profile.id}"
+                "//example.com/profiles/#{id}" if id != 123
               end
             end
 
@@ -109,6 +110,14 @@ module ActiveModel
             expected = {
               data: { id: '1337', type: 'profiles' },
               links: { related: '//example.com/profiles/1337' }
+            }
+            assert_relationship(:profile, expected)
+          end
+
+          def test_relationship_nil_link
+            @author.profile.id = 123
+            expected = {
+              data: { id: '123', type: 'profiles' }
             }
             assert_relationship(:profile, expected)
           end


### PR DESCRIPTION
#### Purpose

Given this serializer:

```ruby
class PostSerializer < ActiveModel::Serializer
  has_one :author do
    link :related do
      "www.example.com/author/#{object.id}" if false # the conditional is set to false to demonstrate the issue
    end
  end
end
```

*Expected behavior*

```json
{
  "data": {
    "type": "post",
    "id": "1",
    "relationships": {
      "author": {
        "data": { "id": 1, "type": "author" }
      }
    }
  }
}
```

*Actual behavior*

```json
{
  "data": {
    "type": "post",
    "id": "1",
    "relationships": {
      "author": {
        "data": { "id": 1, "type": "author" },
        "links": {
          "related": null
        }
      }
    }
  }
}
```

#### Changes

The `nil` links are now removed. This is similar as to how resource links are handled right now.