### PR TITLE
Fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ Fixes:
 
 Misc:
 
-### [v0.10.2 (2016-07-05)(unreleased)](https://github.com/rails-api/active_model_serializers/compare/v0.10.1...v0.10.2)
+### [v0.10.2 (2016-07-05)](https://github.com/rails-api/active_model_serializers/compare/v0.10.1...v0.10.2)
 
 Fixes:
-- [#1814] (https://github.com/rails-api/active_model_serializers/pull/1814) Ensuring read_multi works with fragment cache
+- [#1814](https://github.com/rails-api/active_model_serializers/pull/1814) Ensuring read_multi works with fragment cache
 
 Misc:
 - [#1808](https://github.com/rails-api/active_model_serializers/pull/1808) Adds documentation for `fields` option. (@luizkowalski)


### PR DESCRIPTION
v0.10.2 is totally released - https://rubygems.org/gems/active_model_serializers.