### PR TITLE
Add documentation on upgrading from `0.8` to `0.10` safely

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ This is the documentation of ActiveModelSerializers, it's focused on the **0.10.
 - [Testing ActiveModelSerializers](howto/test.md)
 - [Passing Arbitrary Options](howto/passing_arbitrary_options.md)
 - [How to serialize a Plain-Old Ruby Object (PORO)](howto/serialize_poro.md)
+- [How to upgrade from `0.8` to `0.10` safely](howto/upgrade_from_0_8_to_0_10.md)
 
 ## Integrations
 

--- a/docs/howto/upgrade_from_0_8_to_0_10.md
+++ b/docs/howto/upgrade_from_0_8_to_0_10.md
@@ -21,7 +21,7 @@ functionality as you had with `AMS 0.8`. Then, you can continue to develop in yo
 new serializers that don't use these backwards compatible versions and slowly migrate
 existing serializers to the `0.10` versions as needed.
 
-### Basic list `0.10` breaking changes
+### `0.10` breaking changes
 - Passing a serializer to `render json:` is no longer supported
     - Ex. `render json: CustomerSerializer.new(customer)`
 - Passing a nil resource to serializer now fails

--- a/docs/howto/upgrade_from_0_8_to_0_10.md
+++ b/docs/howto/upgrade_from_0_8_to_0_10.md
@@ -21,6 +21,27 @@ functionality as you had with `AMS 0.8`. Then, you can continue to develop in yo
 new serializers that don't use these backwards compatible versions and slowly migrate
 existing serializers to the `0.10` versions as needed.
 
+### Basic list `0.10` breaking changes
+- Passing a serializer to `render json:` is no longer supported
+    - Ex. `render json: CustomerSerializer.new(customer)`
+- Passing a nil resource to serializer now fails
+    - Ex. `CustomerSerializer.new(nil)`
+- Attribute methods are no longer accessible from other serializer methods
+    - Ex. 
+    ```ruby
+    class MySerializer
+      attributes :foo, :bar
+      
+      def foo
+        bar + 1
+      end
+    end
+    ```
+ - `root` option to collection serializer behaves differently
+    - Ex. `ActiveModel::ArraySerializer.new(resources, root: "resources")`
+- No default serializer when serializer doesn't exist
+- `@options` changed to `instance_options`
+
 ## Steps to migrate
 
 ### 1. Upgrade the `active_model_serializer` gem in you `Gemfile`
@@ -46,10 +67,10 @@ module ActiveModel
     # Since attributes could be read from the `object` via `method_missing`,
     # the `try` method did not behave as before. This patches `try` with the
     # original implementation plus the addition of
-    # ` || object.respond_to?(a.first)` to check if the object responded to
+    # ` || object.respond_to?(a.first, true)` to check if the object responded to
     # the given method.
     def try(*a, &b)
-      if a.empty? || respond_to?(a.first) || object.respond_to?(a.first)
+      if a.empty? || respond_to?(a.first, true) || object.respond_to?(a.first, true)
         try!(*a, &b)
       end
     end


### PR DESCRIPTION
#### Purpose
Provide guidance on how to upgrade from `0.8` to `0.10` safely, based on my experience recently upgrading my `0.8.3` app to `0.10.2` successfully.

#### Changes
Adds `docs/howto/upgrade_from_0_8_to_0_10.md`

#### Caveats
The upgrade doc may not contain all edge cases and possible issues during migration. It is purely a documentation of the process that worked for my app.

It maybe be that this is more useful as a gem or some other way with proper testing. Unfortunately, I don't think I'll have time to do this myself, but I wanted to get this out so that someone else could move forward with their migration and contribute a gem that encapsulates the code snippets I provide with proper testing. I hope this document is still useful without this.

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/1694
https://github.com/rails-api/active_model_serializers/issues/1005



