### PR TITLE
Bugfix/redefine associations on inherited serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Misc:
 
 Fixes:
 - [#1814](https://github.com/rails-api/active_model_serializers/pull/1814) Ensuring read_multi works with fragment cache
-- [#1848](https://github.com/rails-api/active_model_serializers/pull/1848) Redefine associations on inherited serializers
+- [#1848](https://github.com/rails-api/active_model_serializers/pull/1848) Redefine associations on inherited serializers. (@EhsanYousefi)
 
 Misc:
 - [#1808](https://github.com/rails-api/active_model_serializers/pull/1808) Adds documentation for `fields` option. (@luizkowalski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Misc:
 
 Fixes:
 - [#1814](https://github.com/rails-api/active_model_serializers/pull/1814) Ensuring read_multi works with fragment cache
+- [#1848](https://github.com/rails-api/active_model_serializers/pull/1848) Redefine associations on inherited serializers
 
 Misc:
 - [#1808](https://github.com/rails-api/active_model_serializers/pull/1808) Adds documentation for `fields` option. (@luizkowalski)

--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -13,7 +13,7 @@ module ActiveModel
       included do
         with_options instance_writer: false, instance_reader: true do |serializer|
           serializer.class_attribute :_reflections
-          self._reflections ||= []
+          self._reflections ||= {}
         end
 
         extend ActiveSupport::Autoload
@@ -74,7 +74,8 @@ module ActiveModel
         # @api private
         #
         def associate(reflection)
-          self._reflections << reflection
+          key = reflection.options[:key]
+          key ? self._reflections[key] = reflection : self._reflections[reflection.name] = reflection
         end
       end
 
@@ -86,7 +87,7 @@ module ActiveModel
         return unless object
 
         Enumerator.new do |y|
-          self.class._reflections.each do |reflection|
+          self.class._reflections.values.each do |reflection|
             next if reflection.excluded?(self)
             key = reflection.options.fetch(:key, reflection.name)
             next unless include_directive.key?(key)

--- a/test/serializers/association_macros_test.rb
+++ b/test/serializers/association_macros_test.rb
@@ -11,7 +11,7 @@ module ActiveModel
       end
 
       def before_setup
-        @reflections = AssociationsTestSerializer._reflections
+        @reflections = AssociationsTestSerializer._reflections.values
       end
 
       def test_has_one_defines_reflection

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -291,7 +291,6 @@ module ActiveModel
       end
 
       class InheritedSerializerTest < ActiveSupport::TestCase
-
         InheritedPostSerializer = Class.new(PostSerializer) do
           belongs_to :author, custom_option: true
           has_many :comments, custom_option: true, key: :reviews
@@ -305,7 +304,7 @@ module ActiveModel
 
         def setup
           @author = Author.new(name: 'Steve K.')
-          @author.bio = Bio.new(id:1, content: 'AMS Contributor')
+          @author.bio = Bio.new(id: 1, content: 'AMS Contributor')
           @blog = Blog.new(name: 'AMS Blog')
           @post = Post.new(title: 'New Post', body: 'Body')
           @post.blog = @blog
@@ -318,49 +317,46 @@ module ActiveModel
         end
 
         def test_redefined_has_many_and_has_one
-
-          without_redefine = lambda {
+          without_redefine = lambda do
             associations = {}
             @author_serializer.associations.each do |ass|
               associations[ass.name] = ass.options[:custom_option]
             end
 
             expected_associations = {
-                posts: nil,
-                roles: nil,
-                bio: nil
+              posts: nil,
+              roles: nil,
+              bio: nil
             }
 
             assert_equal(associations, expected_associations)
             assert_equal(@author_serializer.associations.count, 3)
-          }
+          end
 
           without_redefine.call
 
-          with_redefine = lambda {
+          with_redefine = lambda do
             associations = {}
             @inherited_author_serializer.associations.each do |ass|
               associations[ass.name] = ass.options[:custom_option]
             end
 
             expected_associations = {
-                posts: true,
-                roles: true,
-                bio: true
+              posts: true,
+              roles: true,
+              bio: true
             }
 
             assert_equal(associations, expected_associations)
             # it should not replace association with a different key
             assert_equal(@inherited_author_serializer.associations.count, 4)
-          }
+          end
 
           with_redefine.call
-
         end
 
         def test_redefined_belongs_to
-
-          without_redefine = lambda {
+          without_redefine = lambda do
             associations = {}
             @post_serializer.associations.each do |ass|
               associations[ass.name] = ass.options[:custom_option]
@@ -374,11 +370,11 @@ module ActiveModel
 
             assert_equal(associations, expected_associations)
             assert_equal(@author_serializer.associations.count, 3)
-          }
+          end
 
           without_redefine.call
 
-          with_redefine = lambda {
+          with_redefine = lambda do
             associations = {}
             @inherited_post_serializer.associations.each do |ass|
               associations[ass.name] = ass.options[:custom_option]
@@ -393,14 +389,11 @@ module ActiveModel
             assert_equal(associations, expected_associations)
             # it should not replace association with a different key
             assert_equal(@inherited_author_serializer.associations.count, 4)
-          }
+          end
 
           with_redefine.call
-
         end
-
       end
-
     end
   end
 end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'pry'
 module ActiveModel
   class Serializer
     class AssociationsTest < ActiveSupport::TestCase

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -305,9 +305,9 @@ module ActiveModel
         def setup
           @author = Author.new(name: 'Steve K.')
           @post = Post.new(title: 'New Post', body: 'Body')
-          @post_serializer = PostSerializer.new(@post, custom_options: true)
+          @post_serializer = PostSerializer.new(@post)
           @author_serializer = AuthorSerializer.new(@author)
-          @inherited_post_serializer = InheritedPostSerializer.new(@post, custom_options: true)
+          @inherited_post_serializer = InheritedPostSerializer.new(@post)
           @inherited_author_serializer = InheritedAuthorSerializer.new(@author)
         end
 


### PR DESCRIPTION
#### Purpose
Allow for associations redefinition on inherited serializers
#### Related GitHub issues
[1696](https://github.com/rails-api/active_model_serializers/issues/1696)

