### PR TITLE
remove dynamic class creation where not needed

### DIFF
--- a/test/action_controller/json_api/transform_test.rb
+++ b/test/action_controller/json_api/transform_test.rb
@@ -5,7 +5,9 @@ module ActionController
     class JsonApi
       class KeyTransformTest < ActionController::TestCase
         class KeyTransformTestController < ActionController::Base
-          Post = Class.new(::Model)
+          class Post < ::Model; end
+          class Author < ::Model; end
+          class TopComment < ::Model; end
           class PostSerializer < ActiveModel::Serializer
             type 'posts'
             attributes :title, :body, :publish_at
@@ -22,13 +24,11 @@ module ActionController
             end
           end
 
-          Author = Class.new(::Model)
           class AuthorSerializer < ActiveModel::Serializer
             type 'authors'
             attributes :first_name, :last_name
           end
 
-          TopComment = Class.new(::Model)
           class TopCommentSerializer < ActiveModel::Serializer
             type 'top_comments'
             attributes :body

--- a/test/adapter/json/transform_test.rb
+++ b/test/adapter/json/transform_test.rb
@@ -15,7 +15,7 @@ module ActiveModelSerializers
           @adapter = ActiveModelSerializers::Adapter::Json.new(serializer, options)
         end
 
-        Post = Class.new(::Model)
+        class Post < ::Model; end
         class PostSerializer < ActiveModel::Serializer
           attributes :id, :title, :body, :publish_at
         end

--- a/test/adapter/json_api/fields_test.rb
+++ b/test/adapter/json_api/fields_test.rb
@@ -4,7 +4,10 @@ module ActiveModelSerializers
   module Adapter
     class JsonApi
       class FieldsTest < ActiveSupport::TestCase
-        Post = Class.new(::Model)
+        class Post < ::Model; end
+        class Author < ::Model; end
+        class Comment < ::Model; end
+
         class PostSerializer < ActiveModel::Serializer
           type 'posts'
           attributes :title, :body
@@ -12,13 +15,11 @@ module ActiveModelSerializers
           has_many :comments
         end
 
-        Author = Class.new(::Model)
         class AuthorSerializer < ActiveModel::Serializer
           type 'authors'
           attributes :name, :birthday
         end
 
-        Comment = Class.new(::Model)
         class CommentSerializer < ActiveModel::Serializer
           type 'comments'
           attributes :body

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -1,10 +1,9 @@
 require 'test_helper'
 
-NestedPost = Class.new(Model)
+class NestedPost < ::Model; end
 class NestedPostSerializer < ActiveModel::Serializer
   has_many :nested_posts
 end
-
 module ActiveModelSerializers
   module Adapter
     class JsonApi
@@ -283,8 +282,8 @@ module ActiveModelSerializers
       end
 
       class NoDuplicatesTest < ActiveSupport::TestCase
-        Post = Class.new(::Model)
-        Author = Class.new(::Model)
+        class Post < ::Model; end
+        class Author < ::Model; end
 
         class PostSerializer < ActiveModel::Serializer
           type 'posts'
@@ -303,8 +302,8 @@ module ActiveModelSerializers
           @author.posts << @post1
           @author.posts << @post2
 
-          @nestedpost1 = ::NestedPost.new(id: 1, nested_posts: [])
-          @nestedpost2 = ::NestedPost.new(id: 2, nested_posts: [])
+          @nestedpost1 = NestedPost.new(id: 1, nested_posts: [])
+          @nestedpost2 = NestedPost.new(id: 2, nested_posts: [])
           @nestedpost1.nested_posts << @nestedpost1
           @nestedpost1.nested_posts << @nestedpost2
           @nestedpost2.nested_posts << @nestedpost1

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -4,7 +4,7 @@ module ActiveModelSerializers
   module Adapter
     class JsonApi
       class LinksTest < ActiveSupport::TestCase
-        LinkAuthor = Class.new(::Model)
+        class LinkAuthor < ::Model; end
         class LinkAuthorSerializer < ActiveModel::Serializer
           link :self do
             href "http://example.com/link_author/#{object.id}"

--- a/test/adapter/json_api/transform_test.rb
+++ b/test/adapter/json_api/transform_test.rb
@@ -4,7 +4,10 @@ module ActiveModelSerializers
   module Adapter
     class JsonApi
       class KeyCaseTest < ActiveSupport::TestCase
-        Post = Class.new(::Model)
+        class Post < ::Model; end
+        class Author < ::Model; end
+        class Comment < ::Model; end
+
         class PostSerializer < ActiveModel::Serializer
           type 'posts'
           attributes :title, :body, :publish_at
@@ -23,13 +26,11 @@ module ActiveModelSerializers
           end
         end
 
-        Author = Class.new(::Model)
         class AuthorSerializer < ActiveModel::Serializer
           type 'authors'
           attributes :first_name, :last_name
         end
 
-        Comment = Class.new(::Model)
         class CommentSerializer < ActiveModel::Serializer
           type 'comments'
           attributes :body

--- a/test/benchmark/bm_caching.rb
+++ b/test/benchmark/bm_caching.rb
@@ -4,7 +4,7 @@ require_relative './app'
 # https://github.com/ruby-bench/ruby-bench-suite/blob/8ad567f7e43a044ae48c36833218423bb1e2bd9d/rails/benchmarks/actionpack_router.rb
 class ApiAssertion
   include Benchmark::ActiveModelSerializers::TestMethods
-  BadRevisionError = Class.new(StandardError)
+  class BadRevisionError < StandardError; end
 
   def valid?
     caching = get_caching

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -4,22 +4,22 @@ require 'tempfile'
 
 module ActiveModelSerializers
   class CacheTest < ActiveSupport::TestCase
-    UncachedAuthor = Class.new(Author) do
+    class UncachedAuthor < Author
       # To confirm cache_key is set using updated_at and cache_key option passed to cache
       undef_method :cache_key
     end
 
-    Article = Class.new(::Model) do
+    class Article < ::Model
       # To confirm error is raised when cache_key is not set and cache_key option not passed to cache
       undef_method :cache_key
     end
 
-    ArticleSerializer = Class.new(ActiveModel::Serializer) do
+    class ArticleSerializer < ActiveModel::Serializer
       cache only: [:place], skip_digest: true
       attributes :title
     end
 
-    InheritedRoleSerializer = Class.new(RoleSerializer) do
+    class InheritedRoleSerializer < RoleSerializer
       cache key: 'inherited_role', only: [:name, :special_attribute]
       attribute :special_attribute
     end

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class CollectionSerializerTest < ActiveSupport::TestCase
-      MessagesSerializer = Class.new(ActiveModel::Serializer) do
+      class MessagesSerializer < ActiveModel::Serializer
         type 'messages'
       end
 

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -50,18 +50,18 @@ class ProfilePreviewSerializer < ActiveModel::Serializer
   attributes :name
 end
 
-Post     = Class.new(Model)
-Like     = Class.new(Model)
-Author   = Class.new(Model)
-Bio      = Class.new(Model)
-Blog     = Class.new(Model)
-Role     = Class.new(Model)
-User     = Class.new(Model)
-Location = Class.new(Model)
-Place    = Class.new(Model)
-Tag      = Class.new(Model)
-VirtualValue = Class.new(Model)
-Comment = Class.new(Model) do
+class Post < Model; end
+class Like < Model; end
+class Author < Model; end
+class Bio < Model; end
+class Blog < Model; end
+class Role < Model; end
+class User < Model; end
+class Location < Model; end
+class Place < Model; end
+class Tag < Model; end
+class VirtualValue < Model; end
+class Comment < Model
   # Uses a custom non-time-based cache key
   def cache_key
     "#{self.class.name.downcase}/#{id}"
@@ -88,9 +88,9 @@ class PolyTag < ActiveRecord::Base
 end
 
 module Spam; end
-Spam::UnrelatedLink = Class.new(Model)
+class Spam::UnrelatedLink < Model; end
 
-PostSerializer = Class.new(ActiveModel::Serializer) do
+class PostSerializer < ActiveModel::Serializer
   cache key: 'post', expires_in: 0.1, skip_digest: true
   attributes :id, :title, :body
 
@@ -108,12 +108,12 @@ PostSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-SpammyPostSerializer = Class.new(ActiveModel::Serializer) do
+class SpammyPostSerializer < ActiveModel::Serializer
   attributes :id
   has_many :related
 end
 
-CommentSerializer = Class.new(ActiveModel::Serializer) do
+class CommentSerializer < ActiveModel::Serializer
   cache expires_in: 1.day, skip_digest: true
   attributes :id, :body
 
@@ -125,7 +125,7 @@ CommentSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-AuthorSerializer = Class.new(ActiveModel::Serializer) do
+class AuthorSerializer < ActiveModel::Serializer
   cache key: 'writer', skip_digest: true
   attribute :id
   attribute :name
@@ -135,7 +135,7 @@ AuthorSerializer = Class.new(ActiveModel::Serializer) do
   has_one :bio
 end
 
-RoleSerializer = Class.new(ActiveModel::Serializer) do
+class RoleSerializer < ActiveModel::Serializer
   cache only: [:name, :slug], skip_digest: true
   attributes :id, :name, :description
   attribute :friendly_id, key: :slug
@@ -147,13 +147,13 @@ RoleSerializer = Class.new(ActiveModel::Serializer) do
   belongs_to :author
 end
 
-LikeSerializer = Class.new(ActiveModel::Serializer) do
+class LikeSerializer < ActiveModel::Serializer
   attributes :id, :time
 
   belongs_to :likeable
 end
 
-LocationSerializer = Class.new(ActiveModel::Serializer) do
+class LocationSerializer < ActiveModel::Serializer
   cache only: [:address], skip_digest: true
   attributes :id, :lat, :lng
 
@@ -164,20 +164,20 @@ LocationSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-PlaceSerializer = Class.new(ActiveModel::Serializer) do
+class PlaceSerializer < ActiveModel::Serializer
   attributes :id, :name
 
   has_many :locations
 end
 
-BioSerializer = Class.new(ActiveModel::Serializer) do
+class BioSerializer < ActiveModel::Serializer
   cache except: [:content], skip_digest: true
   attributes :id, :content, :rating
 
   belongs_to :author
 end
 
-BlogSerializer = Class.new(ActiveModel::Serializer) do
+class BlogSerializer < ActiveModel::Serializer
   cache key: 'blog'
   attributes :id, :name
 
@@ -185,50 +185,50 @@ BlogSerializer = Class.new(ActiveModel::Serializer) do
   has_many :articles
 end
 
-PaginatedSerializer = Class.new(ActiveModel::Serializer::CollectionSerializer) do
+class PaginatedSerializer < ActiveModel::Serializer::CollectionSerializer
   def json_key
     'paginated'
   end
 end
 
-AlternateBlogSerializer = Class.new(ActiveModel::Serializer) do
+class AlternateBlogSerializer < ActiveModel::Serializer
   attribute :id
   attribute :name, key: :title
 end
 
-CustomBlogSerializer = Class.new(ActiveModel::Serializer) do
+class CustomBlogSerializer < ActiveModel::Serializer
   attribute :id
   attribute :special_attribute
 
   has_many :articles
 end
 
-CommentPreviewSerializer = Class.new(ActiveModel::Serializer) do
+class CommentPreviewSerializer < ActiveModel::Serializer
   attributes :id
 
   belongs_to :post
 end
 
-AuthorPreviewSerializer = Class.new(ActiveModel::Serializer) do
+class AuthorPreviewSerializer < ActiveModel::Serializer
   attributes :id
 
   has_many :posts
 end
 
-PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
+class PostPreviewSerializer < ActiveModel::Serializer
   attributes :title, :body, :id
 
   has_many :comments, serializer: CommentPreviewSerializer
   belongs_to :author, serializer: AuthorPreviewSerializer
 end
 
-PostWithTagsSerializer = Class.new(ActiveModel::Serializer) do
+class PostWithTagsSerializer < ActiveModel::Serializer
   attributes :id
 
   has_many :tags
 end
 
-PostWithCustomKeysSerializer = Class.new(ActiveModel::Serializer) do
+class PostWithCustomKeysSerializer < ActiveModel::Serializer
   attributes :id
 
   has_many :comments, key: :reviews
@@ -236,7 +236,7 @@ PostWithCustomKeysSerializer = Class.new(ActiveModel::Serializer) do
   has_one :blog, key: :site
 end
 
-VirtualValueSerializer = Class.new(ActiveModel::Serializer) do
+class VirtualValueSerializer < ActiveModel::Serializer
   attributes :id
 
   has_many :reviews, virtual_value: [{ type: 'reviews', id: '1' },
@@ -250,33 +250,33 @@ VirtualValueSerializer = Class.new(ActiveModel::Serializer) do
   end
 end
 
-PolymorphicHasManySerializer = Class.new(ActiveModel::Serializer) do
+class PolymorphicHasManySerializer < ActiveModel::Serializer
   attributes :id, :name
 end
 
-PolymorphicBelongsToSerializer = Class.new(ActiveModel::Serializer) do
+class PolymorphicBelongsToSerializer < ActiveModel::Serializer
   attributes :id, :title
 
   has_one :imageable, serializer: PolymorphicHasManySerializer, polymorphic: true
 end
 
-PolymorphicSimpleSerializer = Class.new(ActiveModel::Serializer) do
+class PolymorphicSimpleSerializer < ActiveModel::Serializer
   attributes :id
 end
 
-PolymorphicObjectTagSerializer = Class.new(ActiveModel::Serializer) do
+class PolymorphicObjectTagSerializer < ActiveModel::Serializer
   attributes :id
 
   has_many :taggable, serializer: PolymorphicSimpleSerializer, polymorphic: true
 end
 
-PolymorphicTagSerializer = Class.new(ActiveModel::Serializer) do
+class PolymorphicTagSerializer < ActiveModel::Serializer
   attributes :id, :phrase
 
   has_many :object_tags, serializer: PolymorphicObjectTagSerializer
 end
 
-Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do
+class Spam::UnrelatedLinkSerializer < ActiveModel::Serializer
   cache only: [:id]
   attributes :id
 end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -87,8 +87,9 @@ class PolyTag < ActiveRecord::Base
   has_many :object_tags
 end
 
-module Spam; end
-class Spam::UnrelatedLink < Model; end
+module Spam
+  class UnrelatedLink < Model; end
+end
 
 class PostSerializer < ActiveModel::Serializer
   cache key: 'post', expires_in: 0.1, skip_digest: true
@@ -276,8 +277,10 @@ class PolymorphicTagSerializer < ActiveModel::Serializer
   has_many :object_tags, serializer: PolymorphicObjectTagSerializer
 end
 
-class Spam::UnrelatedLinkSerializer < ActiveModel::Serializer
-  cache only: [:id]
-  attributes :id
+module Spam
+  class UnrelatedLinkSerializer < ActiveModel::Serializer
+    cache only: [:id]
+    attributes :id
+  end
 end
 $VERBOSE = verbose

--- a/test/serializers/association_macros_test.rb
+++ b/test/serializers/association_macros_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class AssociationMacrosTest < ActiveSupport::TestCase
-      AuthorSummarySerializer = Class.new
+      class AuthorSummarySerializer < ActiveModel::Serializer; end
+
       class AssociationsTestSerializer < Serializer
         belongs_to :author, serializer: AuthorSummarySerializer
         has_many :comments

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -159,18 +159,18 @@ module ActiveModel
 
       class NamespacedResourcesTest < ActiveSupport::TestCase
         class ResourceNamespace
-          Post    = Class.new(::Model)
-          Comment = Class.new(::Model)
-          Author  = Class.new(::Model)
-          Description = Class.new(::Model)
+          class Post    < ::Model; end
+          class Comment < ::Model; end
+          class Author  < ::Model; end
+          class Description < ::Model; end
           class PostSerializer < ActiveModel::Serializer
             has_many :comments
             belongs_to :author
             has_one :description
           end
-          CommentSerializer     = Class.new(ActiveModel::Serializer)
-          AuthorSerializer      = Class.new(ActiveModel::Serializer)
-          DescriptionSerializer = Class.new(ActiveModel::Serializer)
+          class CommentSerializer     < ActiveModel::Serializer; end
+          class AuthorSerializer      < ActiveModel::Serializer; end
+          class DescriptionSerializer < ActiveModel::Serializer; end
         end
 
         def setup
@@ -200,17 +200,17 @@ module ActiveModel
       end
 
       class NestedSerializersTest < ActiveSupport::TestCase
-        Post    = Class.new(::Model)
-        Comment = Class.new(::Model)
-        Author  = Class.new(::Model)
-        Description = Class.new(::Model)
+        class Post    < ::Model; end
+        class Comment < ::Model; end
+        class Author  < ::Model; end
+        class Description < ::Model; end
         class PostSerializer < ActiveModel::Serializer
           has_many :comments
-          CommentSerializer = Class.new(ActiveModel::Serializer)
+          class CommentSerializer < ActiveModel::Serializer; end
           belongs_to :author
-          AuthorSerializer = Class.new(ActiveModel::Serializer)
+          class AuthorSerializer < ActiveModel::Serializer; end
           has_one :description
-          DescriptionSerializer = Class.new(ActiveModel::Serializer)
+          class DescriptionSerializer < ActiveModel::Serializer; end
         end
 
         def setup
@@ -291,12 +291,12 @@ module ActiveModel
       end
 
       class InheritedSerializerTest < ActiveSupport::TestCase
-        InheritedPostSerializer = Class.new(PostSerializer) do
+        class InheritedPostSerializer < PostSerializer
           belongs_to :author, polymorphic: true
           has_many :comments, key: :reviews
         end
 
-        InheritedAuthorSerializer = Class.new(AuthorSerializer) do
+        class InheritedAuthorSerializer < AuthorSerializer
           has_many :roles, polymorphic: true
           has_one :bio, polymorphic: true
         end

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -81,7 +81,7 @@ module ActiveModel
         assert_equal('custom', hash[:blog][:id])
       end
 
-      PostWithVirtualAttribute = Class.new(::Model)
+      class PostWithVirtualAttribute < ::Model; end
       class PostWithVirtualAttributeSerializer < ActiveModel::Serializer
         attribute :name do
           "#{object.first_name} #{object.last_name}"

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -28,8 +28,8 @@ module ActiveModel
 
       class SerializerTest < ActiveSupport::TestCase
         module ResourceNamespace
-          Post    = Class.new(::Model)
-          Comment = Class.new(::Model)
+          class Post    < ::Model; end
+          class Comment < ::Model; end
 
           class PostSerializer < ActiveModel::Serializer
             class CommentSerializer < ActiveModel::Serializer
@@ -46,7 +46,7 @@ module ActiveModel
           end
         end
 
-        Tweet = Class.new(::Model)
+        class Tweet < ::Model; end
         TweetSerializer = Class.new
 
         def setup


### PR DESCRIPTION
#### Purpose

Part n+1 in a long-running series of test improvements. This particular episode is to discourage people from (or at least not show them how to) dynamically creating classes for testing when they don't need to be dynamically created.

#### Changes

any class-level `SubClass = Class.new(SuperClass)` was converted to `class SubClass < SuperClass; end`

#### Caveats

None

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/pull/1848#discussion_r71128386

#### Additional helpful information

Step next will be renaming tests from 

`def test_method_whatever` to `test 'this is what is being tested' do`

