### PR TITLE
Smarter association id lookup-- no db hit on belongs_to for id-only

### DIFF
--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -38,6 +38,10 @@ module ActiveModel
         reflection.options[:meta]
       end
 
+      def belongs_to?
+        reflection.foreign_key_on == :self
+      end
+
       def polymorphic?
         true == reflection_options[:polymorphic]
       end

--- a/lib/active_model/serializer/belongs_to_reflection.rb
+++ b/lib/active_model/serializer/belongs_to_reflection.rb
@@ -2,6 +2,10 @@ module ActiveModel
   class Serializer
     # @api private
     class BelongsToReflection < Reflection
+      # @api private
+      def foreign_key_on
+        :self
+      end
     end
   end
 end

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -47,11 +47,23 @@ module ActiveModel
     #
     # So you can inspect reflections in your Adapters.
     class Reflection < Field
+      attr_reader :foreign_key, :type
+
       def initialize(*)
         super
         options[:links] = {}
         options[:include_data_setting] = Serializer.config.include_data_default
         options[:meta] = nil
+        @type = options.fetch(:type) do
+          class_name = options.fetch(:class_name, name.to_s.camelize.singularize)
+          class_name.underscore.pluralize.to_sym
+        end
+        @foreign_key =
+          if collection?
+            "#{name.to_s.singularize}_ids".to_sym
+          else
+            "#{name}_id".to_sym
+          end
       end
 
       # @api public
@@ -148,6 +160,11 @@ module ActiveModel
         else
           serializer.read_attribute_for_serialization(name)
         end
+      end
+
+      # @api private
+      def foreign_key_on
+        :related
       end
 
       # Build association. This method is used internally to

--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -43,14 +43,21 @@ module ActiveModelSerializers
         end
 
         def data_for_one(association)
-          # TODO(BF): Process relationship without evaluating lazy_association
-          serializer = association.lazy_association.serializer
-          if (virtual_value = association.virtual_value)
-            virtual_value
-          elsif serializer && association.object
-            ResourceIdentifier.new(serializer, serializable_resource_options).as_json
+          if association.belongs_to? &&
+              parent_serializer.object.respond_to?(association.reflection.foreign_key)
+            id = parent_serializer.object.send(association.reflection.foreign_key)
+            type = association.reflection.type.to_s
+            ResourceIdentifier.for_type_with_id(type, id, serializable_resource_options)
           else
-            nil
+            # TODO(BF): Process relationship without evaluating lazy_association
+            serializer = association.lazy_association.serializer
+            if (virtual_value = association.virtual_value)
+              virtual_value
+            elsif serializer && association.object
+              ResourceIdentifier.new(serializer, serializable_resource_options).as_json
+            else
+              nil
+            end
           end
         end
 

--- a/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
@@ -22,6 +22,13 @@ module ActiveModelSerializers
           JsonApi.send(:transform_key_casing!, raw_type, transform_options)
         end
 
+        def self.for_type_with_id(type, id, options)
+          {
+            id: id.to_s,
+            type: type_for(:no_class_needed, type, options)
+          }
+        end
+
         # {http://jsonapi.org/format/#document-resource-identifier-objects Resource Identifier Objects}
         def initialize(serializer, options)
           @id   = id_for(serializer)


### PR DESCRIPTION
If the serializer has an association, 
- If adapter is not JSON API, serialize it. 
- else if it is JSON API and the related resource 
  - is not included, serialize just the ids
  - is included, serialize the all fields, or the requested fields

The thing where it doesn't actually call the association is a 
special case where AMS needs to know it can get the relationship id 
from the resource itself, so that userland code doesn't need to do any fancy association preloading.

The way this has been solved in [JSONAPI-Resources](https://github.com/cerebris/jsonapi-resources/blob/f4ab5683de49c2a506eea14096bd81a0ec85e94e/README.md#options)
is to have special rules for looking up association ids.
And see [JSONAPI::Relationship](https://github.com/cerebris/jsonapi-resources/blob/f4ab5683de49c2a506eea14096bd81a0ec85e94e/lib/jsonapi/relationship.rb)

In brief:

| association | foreign_key method | loads relation (i.e. when foreign key is on relation ) |
| --- | --- | --- |
| `has_many   :authors` | `:author_ids` | true |
| `has_one    :author` | `:author_id` | true |
| `belongs_to :author` | `:author_id` | false |

Caveat:

This will only work on active record objects

Includes:
- #1100

Follows:
- Closes #1552
- #1750
- #1797

Related:
- #1843
- #1555
