### PR TITLE
[WIP] Test Updates: Part 2 of 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :bench do
 end
 
 group :test do
+  gem 'minitest'
   gem 'sqlite3',                          platform: (@windows_platforms + [:ruby])
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'codeclimate-test-reporter', require: false

--- a/test/action_controller/adapter_selector_test.rb
+++ b/test/action_controller/adapter_selector_test.rb
@@ -22,12 +22,12 @@ module ActionController
 
       tests AdapterSelectorTestController
 
-      def test_render_using_default_adapter
+      test 'render_using_default_adapter' do
         get :render_using_default_adapter
         assert_equal '{"name":"Name 1","description":"Description 1"}', response.body
       end
 
-      def test_render_using_adapter_override
+      test 'render_using_adapter_override' do
         get :render_using_adapter_override
 
         expected = {
@@ -44,7 +44,7 @@ module ActionController
         assert_equal expected.to_json, response.body
       end
 
-      def test_render_skipping_adapter
+      test 'render_skipping_adapter' do
         get :render_skipping_adapter
         assert_equal '{"name":"Name 1","description":"Description 1","comments":"Comments 1"}', response.body
       end

--- a/test/action_controller/explicit_serializer_test.rb
+++ b/test/action_controller/explicit_serializer_test.rb
@@ -66,14 +66,14 @@ module ActionController
 
       tests ExplicitSerializerTestController
 
-      def test_render_using_explicit_serializer
+      test 'render_using_explicit_serializer' do
         get :render_using_explicit_serializer
 
         assert_equal 'application/json', @response.content_type
         assert_equal '{"name":"Name 1"}', @response.body
       end
 
-      def test_render_array_using_explicit_serializer
+      test 'render_array_using_explicit_serializer' do
         get :render_array_using_explicit_serializer
         assert_equal 'application/json', @response.content_type
 
@@ -85,7 +85,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_array_using_implicit_serializer
+      test 'render_array_using_implicit_serializer' do
         get :render_array_using_implicit_serializer
         assert_equal 'application/json', @response.content_type
 
@@ -96,7 +96,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_array_using_explicit_serializer_and_custom_serializers
+      test 'render_array_using_explicit_serializer_and_custom_serializers' do
         get :render_array_using_explicit_serializer_and_custom_serializers
 
         expected = [
@@ -112,7 +112,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_using_explicit_each_serializer
+      test 'render_using_explicit_each_serializer' do
         get :render_using_explicit_each_serializer
 
         expected = {

--- a/test/action_controller/json/include_test.rb
+++ b/test/action_controller/json/include_test.rb
@@ -69,7 +69,7 @@ module ActionController
 
         tests IncludeTestController
 
-        def test_render_without_include
+        test 'render_without_include' do
           get :render_without_include
           response = JSON.parse(@response.body)
           expected = {
@@ -89,14 +89,14 @@ module ActionController
           assert_equal(expected, response)
         end
 
-        def test_render_resource_with_include_hash
+        test 'render_resource_with_include_hash' do
           get :render_resource_with_include_hash
           response = JSON.parse(@response.body)
 
           assert_equal(expected_include_response, response)
         end
 
-        def test_render_resource_with_include_string
+        test 'render_resource_with_include_string' do
           get :render_resource_with_include_string
 
           response = JSON.parse(@response.body)
@@ -104,7 +104,7 @@ module ActionController
           assert_equal(expected_include_response, response)
         end
 
-        def test_render_resource_with_deep_include
+        test 'render_resource_with_deep_include' do
           get :render_resource_with_deep_include
 
           response = JSON.parse(@response.body)
@@ -112,7 +112,7 @@ module ActionController
           assert_equal(expected_deep_include_response, response)
         end
 
-        def test_render_with_empty_default_includes
+        test 'render_with_empty_default_includes' do
           with_default_includes '' do
             get :render_without_include
             response = JSON.parse(@response.body)
@@ -126,7 +126,7 @@ module ActionController
           end
         end
 
-        def test_render_with_recursive_default_includes
+        test 'render_with_recursive_default_includes' do
           with_default_includes '**' do
             get :render_without_recursive_relationships
             response = JSON.parse(@response.body)
@@ -163,7 +163,7 @@ module ActionController
           end
         end
 
-        def test_render_with_includes_overrides_default_includes
+        test 'render_with_includes_overrides_default_includes' do
           with_default_includes '' do
             get :render_resource_with_include_hash
             response = JSON.parse(@response.body)

--- a/test/action_controller/json_api/deserialization_test.rb
+++ b/test/action_controller/json_api/deserialization_test.rb
@@ -21,7 +21,7 @@ module ActionController
 
         tests DeserializationTestController
 
-        def test_deserialization_of_relationship_only_object
+        test 'deserialization_of_relationship_only_object' do
           hash = {
             'data' => {
               'type' => 'restraints',
@@ -53,7 +53,7 @@ module ActionController
           assert_equal(expected, response)
         end
 
-        def test_deserialization
+        test 'deserialization' do
           hash = {
             'data' => {
               'type' => 'photos',

--- a/test/action_controller/json_api/errors_test.rb
+++ b/test/action_controller/json_api/errors_test.rb
@@ -4,7 +4,7 @@ module ActionController
   module Serialization
     class JsonApi
       class ErrorsTest < ActionController::TestCase
-        def test_active_model_with_multiple_errors
+        test 'active_model_with_multiple_errors' do
           get :render_resource_with_errors
 
           expected_errors_object = {

--- a/test/action_controller/json_api/linked_test.rb
+++ b/test/action_controller/json_api/linked_test.rb
@@ -92,13 +92,13 @@ module ActionController
           end
         end
 
-        def test_render_resource_without_include
+        test 'render_resource_without_include' do
           get '/render_resource_without_include'
           response = JSON.parse(@response.body)
           refute response.key? 'included'
         end
 
-        def test_render_resource_with_include
+        test 'render_resource_with_include' do
           get '/render_resource_with_include'
           response = JSON.parse(@response.body)
           assert response.key? 'included'
@@ -106,7 +106,7 @@ module ActionController
           assert_equal 'Steve K.', response['included'].first['attributes']['name']
         end
 
-        def test_render_resource_with_nested_has_many_include
+        test 'render_resource_with_nested_has_many_include' do
           get '/render_resource_with_nested_has_many_include_wildcard'
           response = JSON.parse(@response.body)
           expected_linked = [
@@ -148,7 +148,7 @@ module ActionController
           assert_equal expected_linked, response['included']
         end
 
-        def test_render_resource_with_include_of_custom_key_by_original
+        test 'render_resource_with_include_of_custom_key_by_original' do
           get '/render_resource_with_include_of_custom_key_by_original'
           response = JSON.parse(@response.body)
           assert response.key? 'included'
@@ -160,33 +160,33 @@ module ActionController
           assert_includes relationships, 'site'
         end
 
-        def test_render_resource_with_nested_include
+        test 'render_resource_with_nested_include' do
           get '/render_resource_with_nested_include'
           response = JSON.parse(@response.body)
           assert response.key? 'included'
           assert_equal 3, response['included'].size
         end
 
-        def test_render_collection_without_include
+        test 'render_collection_without_include' do
           get '/render_collection_without_include'
           response = JSON.parse(@response.body)
           refute response.key? 'included'
         end
 
-        def test_render_collection_with_include
+        test 'render_collection_with_include' do
           get '/render_collection_with_include'
           response = JSON.parse(@response.body)
           assert response.key? 'included'
         end
 
-        def test_render_resource_with_nested_attributes_even_when_missing_associations
+        test 'render_resource_with_nested_attributes_even_when_missing_associations' do
           get '/render_resource_with_missing_nested_has_many_include'
           response = JSON.parse(@response.body)
           assert response.key? 'included'
           refute include_type?(response['included'], 'roles')
         end
 
-        def test_render_collection_with_missing_nested_has_many_include
+        test 'render_collection_with_missing_nested_has_many_include' do
           get '/render_collection_with_missing_nested_has_many_include'
           response = JSON.parse(@response.body)
           assert response.key? 'included'

--- a/test/action_controller/json_api/pagination_test.rb
+++ b/test/action_controller/json_api/pagination_test.rb
@@ -46,7 +46,7 @@ module ActionController
 
         tests PaginationTestController
 
-        def test_render_pagination_links_with_will_paginate
+        test 'render_pagination_links_with_will_paginate' do
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1",
                              'first' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1",
                              'prev' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1",
@@ -58,7 +58,7 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_render_only_last_and_next_pagination_links
+        test 'render_only_last_and_next_pagination_links' do
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
                              'next' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2",
                              'last' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2" }
@@ -67,7 +67,7 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_render_pagination_links_with_kaminari
+        test 'render_pagination_links_with_kaminari' do
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1",
                              'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1",
@@ -78,7 +78,7 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_render_only_prev_and_first_pagination_links
+        test 'render_only_prev_and_first_pagination_links' do
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1",
                              'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1" }
@@ -87,7 +87,7 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_render_only_last_and_next_pagination_links_with_additional_params
+        test 'render_only_last_and_next_pagination_links_with_additional_params' do
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2&teste=additional",
                              'next' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2&teste=additional",
                              'last' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2&teste=additional" }
@@ -96,7 +96,7 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_render_only_prev_and_first_pagination_links_with_additional_params
+        test 'render_only_prev_and_first_pagination_links_with_additional_params' do
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1&teste=additional",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1&teste=additional",
                              'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1&teste=additional" }
@@ -105,7 +105,7 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_array_without_pagination_links
+        test 'array_without_pagination_links' do
           get :render_array_without_pagination_links, params: { page: { number: 2, size: 1 } }
           response = JSON.parse(@response.body)
           refute response.key? 'links'

--- a/test/action_controller/json_api/transform_test.rb
+++ b/test/action_controller/json_api/transform_test.rb
@@ -71,7 +71,7 @@ module ActionController
 
         tests KeyTransformTestController
 
-        def test_render_resource_with_transform
+        test 'render_resource_with_transform' do
           get :render_resource_with_transform
           response = JSON.parse(@response.body)
           expected = {
@@ -106,7 +106,7 @@ module ActionController
           assert_equal expected, response
         end
 
-        def test_render_resource_with_transform_nil
+        test 'render_resource_with_transform_nil' do
           get :render_resource_with_transform_nil
           response = JSON.parse(@response.body)
           expected = {
@@ -141,7 +141,7 @@ module ActionController
           assert_equal expected, response
         end
 
-        def test_render_resource_with_transform_with_global_config
+        test 'render_resource_with_transform_with_global_config' do
           get :render_resource_with_transform_with_global_config
           response = JSON.parse(@response.body)
           expected =  {

--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -70,15 +70,15 @@ module SerializationScopeTesting
   class DefaultScopeTest < ActionController::TestCase
     tests PostTestController
 
-    def test_default_serialization_scope
+    test 'default_serialization_scope' do
       assert_equal :current_user, @controller._serialization_scope
     end
 
-    def test_default_serialization_scope_object
+    test 'default_serialization_scope_object' do
       assert_equal @controller.current_user, @controller.serialization_scope
     end
 
-    def test_default_scope_non_admin
+    test 'default_scope_non_admin' do
       get :render_post_by_non_admin
       expected_json = {
         post: {
@@ -93,7 +93,7 @@ module SerializationScopeTesting
       assert_equal expected_json, @response.body
     end
 
-    def test_default_scope_admin
+    test 'default_scope_admin' do
       get :render_post_by_admin
       expected_json = {
         post: {
@@ -120,15 +120,15 @@ module SerializationScopeTesting
     end
     tests PostViewContextTestController
 
-    def test_defined_serialization_scope
+    test 'defined_serialization_scope' do
       assert_equal :view_context, @controller._serialization_scope
     end
 
-    def test_defined_serialization_scope_object
+    test 'defined_serialization_scope_object' do
       assert_equal @controller.view_context.class, @controller.serialization_scope.class
     end
 
-    def test_serialization_scope_non_admin
+    test 'serialization_scope_non_admin' do
       get :render_post_by_non_admin
       expected_json = {
         post: {
@@ -143,7 +143,7 @@ module SerializationScopeTesting
       assert_equal expected_json, @response.body
     end
 
-    def test_serialization_scope_admin
+    test 'serialization_scope_admin' do
       get :render_post_by_admin
       expected_json = {
         post: {
@@ -187,15 +187,15 @@ module SerializationScopeTesting
     end
     tests PostViewContextTestController
 
-    def test_nil_serialization_scope
+    test 'nil_serialization_scope' do
       assert_nil @controller._serialization_scope
     end
 
-    def test_nil_serialization_scope_object
+    test 'nil_serialization_scope_object' do
       assert_nil @controller.serialization_scope
     end
 
-    def test_nil_scope
+    test 'nil_scope' do
       exception_matcher = /current_user/
       exception = assert_raises(NameError) do
         get :render_post_with_no_scope
@@ -203,7 +203,7 @@ module SerializationScopeTesting
       assert_match exception_matcher, exception.message
     end
 
-    def test_serialization_scope_is_and_nil_scope_passed_in_current_user
+    test 'serialization_scope_is_and_nil_scope_passed_in_current_user' do
       get :render_post_with_passed_in_scope
       expected_json = {
         post: {
@@ -218,7 +218,7 @@ module SerializationScopeTesting
       assert_equal expected_json, @response.body
     end
 
-    def test_serialization_scope_is_nil_and_scope_passed_in_current_user_without_scope_name
+    test 'serialization_scope_is_nil_and_scope_passed_in_current_user_without_scope_name' do
       exception_matcher = /current_user/
       exception = assert_raises(NameError) do
         get :render_post_with_passed_in_scope_without_scope_name

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -145,7 +145,7 @@ module ActionController
       tests ImplicitSerializationTestController
 
       # We just have Null for now, this will change
-      def test_render_using_implicit_serializer
+      test 'render_using_implicit_serializer' do
         get :render_using_implicit_serializer
 
         expected = {
@@ -157,7 +157,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_using_default_root
+      test 'render_using_default_root' do
         with_adapter :json_api do
           get :render_using_default_adapter_root
         end
@@ -176,7 +176,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_array_using_custom_root
+      test 'render_array_using_custom_root' do
         with_adapter :json do
           get :render_array_using_custom_root
         end
@@ -185,7 +185,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_array_that_is_empty_using_custom_root
+      test 'render_array_that_is_empty_using_custom_root' do
         with_adapter :json do
           get :render_array_that_is_empty_using_custom_root
         end
@@ -195,7 +195,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_object_using_custom_root
+      test 'render_object_using_custom_root' do
         with_adapter :json do
           get :render_object_using_custom_root
         end
@@ -205,7 +205,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_json_object_without_serializer
+      test 'render_json_object_without_serializer' do
         get :render_json_object_without_serializer
 
         assert_equal 'application/json', @response.content_type
@@ -213,7 +213,7 @@ module ActionController
         assert_equal expected_body.to_json, @response.body
       end
 
-      def test_render_json_array_object_without_serializer
+      test 'render_json_array_object_without_serializer' do
         get :render_json_array_object_without_serializer
 
         assert_equal 'application/json', @response.content_type
@@ -221,7 +221,7 @@ module ActionController
         assert_equal expected_body.to_json, @response.body
       end
 
-      def test_render_array_using_implicit_serializer
+      test 'render_array_using_implicit_serializer' do
         get :render_array_using_implicit_serializer
         assert_equal 'application/json', @response.content_type
 
@@ -239,7 +239,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_array_using_implicit_serializer_and_meta
+      test 'render_array_using_implicit_serializer_and_meta' do
         with_adapter :json_api do
           get :render_array_using_implicit_serializer_and_meta
         end
@@ -263,7 +263,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_array_using_implicit_serializer_and_links
+      test 'render_array_using_implicit_serializer_and_links' do
         get :render_array_using_implicit_serializer_and_links
 
         expected = {
@@ -286,7 +286,7 @@ module ActionController
         assert_equal expected.to_json, @response.body
       end
 
-      def test_render_with_cache_enable
+      test 'render_with_cache_enable' do
         expected = {
           id: 1,
           title: 'New Post',
@@ -323,7 +323,7 @@ module ActionController
         assert_not_equal expected.to_json, @response.body
       end
 
-      def test_render_with_cache_enable_and_expired
+      test 'render_with_cache_enable_and_expired' do
         ActionController::Base.cache_store.clear
         get :render_object_expired_with_cache_enabled
 
@@ -357,7 +357,7 @@ module ActionController
         end
       end
 
-      def test_render_with_fragment_only_cache_enable
+      test 'render_with_fragment_only_cache_enable' do
         ActionController::Base.cache_store.clear
         get :render_fragment_changed_object_with_only_cache_enabled
         response = JSON.parse(@response.body)
@@ -367,7 +367,7 @@ module ActionController
         assert_equal 'HUEHUEBRBR', response['description']
       end
 
-      def test_render_with_fragment_except_cache_enable
+      test 'render_with_fragment_except_cache_enable' do
         ActionController::Base.cache_store.clear
         get :render_fragment_changed_object_with_except_cache_enabled
         response = JSON.parse(@response.body)
@@ -377,7 +377,7 @@ module ActionController
         assert_equal 'lol', response['content']
       end
 
-      def test_render_fragment_changed_object_with_relationship
+      test 'render_fragment_changed_object_with_relationship' do
         ActionController::Base.cache_store.clear
 
         Timecop.freeze(Time.zone.now) do
@@ -398,7 +398,7 @@ module ActionController
         end
       end
 
-      def test_cache_expiration_on_update
+      test 'cache_expiration_on_update' do
         ActionController::Base.cache_store.clear
         get :render_object_with_cache_enabled
 
@@ -434,7 +434,7 @@ module ActionController
         end
       end
 
-      def test_warn_overridding_use_adapter_as_falsy_on_controller_instance
+      test 'warn_overridding_use_adapter_as_falsy_on_controller_instance' do
         controller = Class.new(ImplicitSerializationTestController) do
           def use_adapter?
             false
@@ -445,7 +445,7 @@ module ActionController
         end
       end
 
-      def test_dont_warn_overridding_use_adapter_as_truthy_on_controller_instance
+      test 'dont_warn_overridding_use_adapter_as_truthy_on_controller_instance' do
         controller = Class.new(ImplicitSerializationTestController) do
           def use_adapter?
             true
@@ -456,16 +456,18 @@ module ActionController
         end
       end
 
-      def test_render_event_is_emmited
-        subscriber = ::ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |name|
-          @name = name
+      test 'render_event_is_emmited' do
+        begin
+          subscriber = ::ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |name|
+            @name = name
+          end
+
+          get :render_using_implicit_serializer
+
+          assert_equal 'render.active_model_serializers', @name
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
         end
-
-        get :render_using_implicit_serializer
-
-        assert_equal 'render.active_model_serializers', @name
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
     end
   end

--- a/test/active_model_serializers/adapter_for_test.rb
+++ b/test/active_model_serializers/adapter_for_test.rb
@@ -4,20 +4,20 @@ module ActiveModelSerializers
   class AdapterForTest < ::ActiveSupport::TestCase
     UnknownAdapterError = ::ActiveModelSerializers::Adapter::UnknownAdapterError
 
-    def test_serializer_adapter_returns_configured_adapter
+    test 'serializer_adapter_returns_configured_adapter' do
       assert_output(nil, /ActiveModelSerializers::Adapter.configured_adapter/) do
         assert_equal ActiveModelSerializers::Adapter.configured_adapter, ActiveModel::Serializer.adapter
       end
     end
 
-    def test_returns_default_adapter
+    test 'returns_default_adapter' do
       with_adapter_config_setup do
         adapter = ActiveModelSerializers::Adapter.configured_adapter
         assert_equal ActiveModelSerializers::Adapter::Attributes, adapter
       end
     end
 
-    def test_overwrite_adapter_with_symbol
+    test 'overwrite_adapter_with_symbol' do
       with_adapter_config_setup do
         ActiveModelSerializers.config.adapter = :null
 
@@ -26,7 +26,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_overwrite_adapter_with_camelcased_symbol
+    test 'overwrite_adapter_with_camelcased_symbol' do
       with_adapter_config_setup do
         ActiveModelSerializers.config.adapter = :JsonApi
 
@@ -35,7 +35,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_overwrite_adapter_with_string
+    test 'overwrite_adapter_with_string' do
       with_adapter_config_setup do
         ActiveModelSerializers.config.adapter = 'json_api'
 
@@ -44,7 +44,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_overwrite_adapter_with_a_camelcased_string
+    test 'overwrite_adapter_with_a_camelcased_string' do
       with_adapter_config_setup do
         ActiveModelSerializers.config.adapter = 'JsonApi'
 
@@ -53,7 +53,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_overwrite_adapter_with_class
+    test 'overwrite_adapter_with_class' do
       with_adapter_config_setup do
         ActiveModelSerializers.config.adapter = ActiveModelSerializers::Adapter::Null
 
@@ -62,7 +62,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_raises_exception_if_invalid_symbol_given
+    test 'raises_exception_if_invalid_symbol_given' do
       with_adapter_config_setup do
         ActiveModelSerializers.config.adapter = :unknown
 
@@ -72,7 +72,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_raises_exception_if_it_does_not_know_hot_to_infer_adapter
+    test 'raises_exception_if_it_does_not_know_hot_to_infer_adapter' do
       with_adapter_config_setup do
         ActiveModelSerializers.config.adapter = 42
 
@@ -82,18 +82,18 @@ module ActiveModelSerializers
       end
     end
 
-    def test_adapter_class_for_known_adapter
+    test 'adapter_class_for_known_adapter' do
       klass = ActiveModelSerializers::Adapter.adapter_class(:json_api)
       assert_equal ActiveModelSerializers::Adapter::JsonApi, klass
     end
 
-    def test_adapter_class_for_unknown_adapter
+    test 'adapter_class_for_unknown_adapter' do
       assert_raises UnknownAdapterError do
         ActiveModelSerializers::Adapter.adapter_class(:json_simple)
       end
     end
 
-    def test_adapter_map
+    test 'adapter_map' do
       expected_adapter_map = {
         'null'.freeze              => ActiveModelSerializers::Adapter::Null,
         'json'.freeze              => ActiveModelSerializers::Adapter::Json,
@@ -104,7 +104,7 @@ module ActiveModelSerializers
       assert_equal actual, expected_adapter_map
     end
 
-    def test_adapters
+    test 'adapters' do
       assert_equal ActiveModelSerializers::Adapter.adapters.sort, [
         'attributes'.freeze,
         'json'.freeze,
@@ -113,87 +113,97 @@ module ActiveModelSerializers
       ]
     end
 
-    def test_lookup_adapter_by_string_name
+    test 'lookup_adapter_by_string_name' do
       assert_equal ActiveModelSerializers::Adapter.lookup('json'.freeze), ActiveModelSerializers::Adapter::Json
     end
 
-    def test_lookup_adapter_by_symbol_name
+    test 'lookup_adapter_by_symbol_name' do
       assert_equal ActiveModelSerializers::Adapter.lookup(:json), ActiveModelSerializers::Adapter::Json
     end
 
-    def test_lookup_adapter_by_class
+    test 'lookup_adapter_by_class' do
       klass = ActiveModelSerializers::Adapter::Json
       assert_equal ActiveModelSerializers::Adapter.lookup(klass), klass
     end
 
-    def test_lookup_adapter_from_environment_registers_adapter
-      ActiveModelSerializers::Adapter.const_set(:AdapterFromEnvironment, Class.new)
-      klass = ::ActiveModelSerializers::Adapter::AdapterFromEnvironment
-      name = 'adapter_from_environment'.freeze
-      assert_equal ActiveModelSerializers::Adapter.lookup(name), klass
-      assert ActiveModelSerializers::Adapter.adapters.include?(name)
-    ensure
-      ActiveModelSerializers::Adapter.adapter_map.delete(name)
-      ActiveModelSerializers::Adapter.send(:remove_const, :AdapterFromEnvironment)
+    test 'lookup_adapter_from_environment_registers_adapter' do
+      begin
+        ActiveModelSerializers::Adapter.const_set(:AdapterFromEnvironment, Class.new)
+        klass = ::ActiveModelSerializers::Adapter::AdapterFromEnvironment
+        name = 'adapter_from_environment'.freeze
+        assert_equal ActiveModelSerializers::Adapter.lookup(name), klass
+        assert ActiveModelSerializers::Adapter.adapters.include?(name)
+      ensure
+        ActiveModelSerializers::Adapter.adapter_map.delete(name)
+        ActiveModelSerializers::Adapter.send(:remove_const, :AdapterFromEnvironment)
+      end
     end
 
-    def test_lookup_adapter_for_unknown_name
+    test 'lookup_adapter_for_unknown_name' do
       assert_raises UnknownAdapterError do
         ActiveModelSerializers::Adapter.lookup(:json_simple)
       end
     end
 
-    def test_adapter
+    test 'adapter' do
       assert_equal ActiveModelSerializers.config.adapter, :attributes
       assert_equal ActiveModelSerializers::Adapter.configured_adapter, ActiveModelSerializers::Adapter::Attributes
     end
 
-    def test_register_adapter
-      new_adapter_name  = :foo
-      new_adapter_klass = Class.new
-      ActiveModelSerializers::Adapter.register(new_adapter_name, new_adapter_klass)
-      assert ActiveModelSerializers::Adapter.adapters.include?('foo'.freeze)
-      assert ActiveModelSerializers::Adapter.lookup(:foo), new_adapter_klass
-    ensure
-      ActiveModelSerializers::Adapter.adapter_map.delete(new_adapter_name.to_s)
+    test 'register_adapter' do
+      begin
+        new_adapter_name  = :foo
+        new_adapter_klass = Class.new
+        ActiveModelSerializers::Adapter.register(new_adapter_name, new_adapter_klass)
+        assert ActiveModelSerializers::Adapter.adapters.include?('foo'.freeze)
+        assert ActiveModelSerializers::Adapter.lookup(:foo), new_adapter_klass
+      ensure
+        ActiveModelSerializers::Adapter.adapter_map.delete(new_adapter_name.to_s)
+      end
     end
 
-    def test_inherited_adapter_hooks_register_adapter
-      Object.const_set(:MyAdapter, Class.new)
-      my_adapter = MyAdapter
-      ActiveModelSerializers::Adapter::Base.inherited(my_adapter)
-      assert_equal ActiveModelSerializers::Adapter.lookup(:my_adapter), my_adapter
-    ensure
-      ActiveModelSerializers::Adapter.adapter_map.delete('my_adapter'.freeze)
-      Object.send(:remove_const, :MyAdapter)
+    test 'inherited_adapter_hooks_register_adapter' do
+      begin
+        Object.const_set(:MyAdapter, Class.new)
+        my_adapter = MyAdapter
+        ActiveModelSerializers::Adapter::Base.inherited(my_adapter)
+        assert_equal ActiveModelSerializers::Adapter.lookup(:my_adapter), my_adapter
+      ensure
+        ActiveModelSerializers::Adapter.adapter_map.delete('my_adapter'.freeze)
+        Object.send(:remove_const, :MyAdapter)
+      end
     end
 
-    def test_inherited_adapter_hooks_register_namespaced_adapter
-      Object.const_set(:MyNamespace, Module.new)
-      MyNamespace.const_set(:MyAdapter, Class.new)
-      my_adapter = MyNamespace::MyAdapter
-      ActiveModelSerializers::Adapter::Base.inherited(my_adapter)
-      assert_equal ActiveModelSerializers::Adapter.lookup(:'my_namespace/my_adapter'), my_adapter
-    ensure
-      ActiveModelSerializers::Adapter.adapter_map.delete('my_namespace/my_adapter'.freeze)
-      MyNamespace.send(:remove_const, :MyAdapter)
-      Object.send(:remove_const, :MyNamespace)
+    test 'inherited_adapter_hooks_register_namespaced_adapter' do
+      begin
+        Object.const_set(:MyNamespace, Module.new)
+        MyNamespace.const_set(:MyAdapter, Class.new)
+        my_adapter = MyNamespace::MyAdapter
+        ActiveModelSerializers::Adapter::Base.inherited(my_adapter)
+        assert_equal ActiveModelSerializers::Adapter.lookup(:'my_namespace/my_adapter'), my_adapter
+      ensure
+        ActiveModelSerializers::Adapter.adapter_map.delete('my_namespace/my_adapter'.freeze)
+        MyNamespace.send(:remove_const, :MyAdapter)
+        Object.send(:remove_const, :MyNamespace)
+      end
     end
 
-    def test_inherited_adapter_hooks_register_subclass_of_registered_adapter
-      Object.const_set(:MyAdapter, Class.new)
-      my_adapter = MyAdapter
-      Object.const_set(:MySubclassedAdapter, Class.new(MyAdapter))
-      my_subclassed_adapter = MySubclassedAdapter
-      ActiveModelSerializers::Adapter::Base.inherited(my_adapter)
-      ActiveModelSerializers::Adapter::Base.inherited(my_subclassed_adapter)
-      assert_equal ActiveModelSerializers::Adapter.lookup(:my_adapter), my_adapter
-      assert_equal ActiveModelSerializers::Adapter.lookup(:my_subclassed_adapter), my_subclassed_adapter
-    ensure
-      ActiveModelSerializers::Adapter.adapter_map.delete('my_adapter'.freeze)
-      ActiveModelSerializers::Adapter.adapter_map.delete('my_subclassed_adapter'.freeze)
-      Object.send(:remove_const, :MyAdapter)
-      Object.send(:remove_const, :MySubclassedAdapter)
+    test 'inherited_adapter_hooks_register_subclass_of_registered_adapter' do
+      begin
+        Object.const_set(:MyAdapter, Class.new)
+        my_adapter = MyAdapter
+        Object.const_set(:MySubclassedAdapter, Class.new(MyAdapter))
+        my_subclassed_adapter = MySubclassedAdapter
+        ActiveModelSerializers::Adapter::Base.inherited(my_adapter)
+        ActiveModelSerializers::Adapter::Base.inherited(my_subclassed_adapter)
+        assert_equal ActiveModelSerializers::Adapter.lookup(:my_adapter), my_adapter
+        assert_equal ActiveModelSerializers::Adapter.lookup(:my_subclassed_adapter), my_subclassed_adapter
+      ensure
+        ActiveModelSerializers::Adapter.adapter_map.delete('my_adapter'.freeze)
+        ActiveModelSerializers::Adapter.adapter_map.delete('my_subclassed_adapter'.freeze)
+        Object.send(:remove_const, :MyAdapter)
+        Object.send(:remove_const, :MySubclassedAdapter)
+      end
     end
 
     private

--- a/test/active_model_serializers/json_pointer_test.rb
+++ b/test/active_model_serializers/json_pointer_test.rb
@@ -2,18 +2,18 @@ require 'test_helper'
 
 module ActiveModelSerializers
   class JsonPointerTest < ActiveSupport::TestCase
-    def test_attribute_pointer
+    test 'attribute_pointer' do
       attribute_name = 'title'
       pointer = ActiveModelSerializers::JsonPointer.new(:attribute, attribute_name)
       assert_equal '/data/attributes/title', pointer
     end
 
-    def test_primary_data_pointer
+    test 'primary_data_pointer' do
       pointer = ActiveModelSerializers::JsonPointer.new(:primary_data)
       assert_equal '/data', pointer
     end
 
-    def test_unkown_data_pointer
+    test 'unkown_data_pointer' do
       assert_raises(TypeError) do
         ActiveModelSerializers::JsonPointer.new(:unknown)
       end

--- a/test/active_model_serializers/key_transform_test.rb
+++ b/test/active_model_serializers/key_transform_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModelSerializers
   class KeyTransformTest < ActiveSupport::TestCase
-    def test_camel
+    test 'camel' do
       obj = Object.new
       scenarios = [
         {
@@ -68,7 +68,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_camel_lower
+    test 'camel_lower' do
       obj = Object.new
       scenarios = [
         {
@@ -134,7 +134,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_dash
+    test 'dash' do
       obj = Object.new
       scenarios = [
         {
@@ -196,7 +196,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_underscore
+    test 'underscore' do
       obj = Object.new
       scenarios = [
         {

--- a/test/active_model_serializers/logging_test.rb
+++ b/test/active_model_serializers/logging_test.rb
@@ -38,37 +38,37 @@ module ActiveModel
         ActiveModelSerializers.logger = logger
       end
 
-      def test_uses_ams_as_tag
+      test 'uses_ams_as_tag' do
         ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/\[active_model_serializers\]/, @logger.messages)
       end
 
-      def test_logs_when_call_serializable_hash
+      test 'logs_when_call_serializable_hash' do
         ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/Rendered/, @logger.messages)
       end
 
-      def test_logs_when_call_as_json
+      test 'logs_when_call_as_json' do
         ActiveModelSerializers::SerializableResource.new(@post).as_json
         assert_match(/Rendered/, @logger.messages)
       end
 
-      def test_logs_when_call_to_json
+      test 'logs_when_call_to_json' do
         ActiveModelSerializers::SerializableResource.new(@post).to_json
         assert_match(/Rendered/, @logger.messages)
       end
 
-      def test_logs_correct_serializer
+      test 'logs_correct_serializer' do
         ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/PostSerializer/, @logger.messages)
       end
 
-      def test_logs_correct_adapter
+      test 'logs_correct_adapter' do
         ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/ActiveModelSerializers::Adapter::Attributes/, @logger.messages)
       end
 
-      def test_logs_the_duration
+      test 'logs_the_duration' do
         ActiveModelSerializers::SerializableResource.new(@post).serializable_hash
         assert_match(/\(\d+\.\d+ms\)/, @logger.messages)
       end

--- a/test/active_model_serializers/register_jsonapi_renderer_test_isolated.rb
+++ b/test/active_model_serializers/register_jsonapi_renderer_test_isolated.rb
@@ -49,7 +49,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       end
     end
 
-    def test_jsonapi_parser_not_registered
+    test 'jsonapi_parser_not_registered' do
       parsers = if Rails::VERSION::MAJOR >= 5
                   ActionDispatch::Request.parameter_parsers
                 else
@@ -58,7 +58,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       assert_nil parsers[Mime[:jsonapi]]
     end
 
-    def test_jsonapi_renderer_not_registered
+    test 'jsonapi_renderer_not_registered' do
       expected = {
         'data' => {
           'attributes' => {
@@ -73,7 +73,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       assert expected, response.body
     end
 
-    def test_jsonapi_parser
+    test 'jsonapi_parser' do
       assert_parses(
         {},
         '',
@@ -100,7 +100,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       end
     end
 
-    def test_jsonapi_parser_registered
+    test 'jsonapi_parser_registered' do
       if Rails::VERSION::MAJOR >= 5
         parsers = ActionDispatch::Request.parameter_parsers
         assert_equal Proc, parsers[:jsonapi].class
@@ -110,7 +110,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       end
     end
 
-    def test_jsonapi_renderer_registered
+    test 'jsonapi_renderer_registered' do
       expected = {
         'data' => {
           'attributes' => {
@@ -125,7 +125,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       assert expected, response.body
     end
 
-    def test_jsonapi_parser
+    test 'jsonapi_parser' do
       assert_parses(
         {
           'data' => {

--- a/test/active_model_serializers/test/schema_test.rb
+++ b/test/active_model_serializers/test/schema_test.rb
@@ -36,12 +36,12 @@ module ActiveModelSerializers
 
       tests MyController
 
-      def test_that_assert_with_a_valid_schema
+      test 'that_assert_with_a_valid_schema' do
         get :index
         assert_response_schema
       end
 
-      def test_that_raises_a_minitest_error_with_a_invalid_schema
+      test 'that_raises_a_minitest_error_with_a_invalid_schema' do
         message = "#/name: failed schema #/properties/name: For 'properties/name', \"Name 1\" is not an integer. and #/description: failed schema #/properties/description: For 'properties/description', \"Description 1\" is not a boolean."
 
         get :show
@@ -52,7 +52,7 @@ module ActiveModelSerializers
         assert_equal(message, error.message)
       end
 
-      def test_that_raises_error_with_a_custom_message_with_a_invalid_schema
+      test 'that_raises_error_with_a_custom_message_with_a_invalid_schema' do
         message = 'oh boy the show is broken'
         exception_message = "#/name: failed schema #/properties/name: For 'properties/name', \"Name 1\" is not an integer. and #/description: failed schema #/properties/description: For 'properties/description', \"Description 1\" is not a boolean."
         expected_message = "#{message}: #{exception_message}"
@@ -65,22 +65,22 @@ module ActiveModelSerializers
         assert_equal(expected_message, error.message)
       end
 
-      def test_that_assert_with_a_custom_schema
+      test 'that_assert_with_a_custom_schema' do
         get :show
         assert_response_schema('custom/show.json')
       end
 
-      def test_that_assert_with_a_hyper_schema
+      test 'that_assert_with_a_hyper_schema' do
         get :show
         assert_response_schema('hyper_schema.json')
       end
 
-      def test_simple_json_pointers
+      test 'simple_json_pointers' do
         get :show
         assert_response_schema('simple_json_pointers.json')
       end
 
-      def test_simple_json_pointers_that_doesnt_match
+      test 'simple_json_pointers_that_doesnt_match' do
         get :name_as_a_integer
 
         assert_raises Minitest::Assertion do
@@ -88,12 +88,12 @@ module ActiveModelSerializers
         end
       end
 
-      def test_json_api_schema
+      test 'json_api_schema' do
         get :render_using_json_api
         assert_response_schema('render_using_json_api.json')
       end
 
-      def test_that_assert_with_a_custom_schema_directory
+      test 'that_assert_with_a_custom_schema_directory' do
         original_schema_path = ActiveModelSerializers.config.schema_path
         ActiveModelSerializers.config.schema_path = 'test/support/custom_schemas'
 
@@ -103,7 +103,7 @@ module ActiveModelSerializers
         ActiveModelSerializers.config.schema_path = original_schema_path
       end
 
-      def test_with_a_non_existent_file
+      test 'with_a_non_existent_file' do
         message = 'No Schema file at test/support/schemas/non-existent.json'
 
         get :show
@@ -114,7 +114,7 @@ module ActiveModelSerializers
         assert_equal(message, error.message)
       end
 
-      def test_that_raises_with_a_invalid_json_body
+      test 'that_raises_with_a_invalid_json_body' do
         message = 'A JSON text must at least contain two octets!'
 
         get :invalid_json_body

--- a/test/active_model_serializers/test/serializer_test.rb
+++ b/test/active_model_serializers/test/serializer_test.rb
@@ -17,32 +17,32 @@ module ActiveModelSerializers
 
       tests MyController
 
-      def test_supports_specifying_serializers_with_a_serializer_class
+      test 'supports_specifying_serializers_with_a_serializer_class' do
         get :render_using_serializer
         assert_serializer ProfileSerializer
       end
 
-      def test_supports_specifying_serializers_with_a_regexp
+      test 'supports_specifying_serializers_with_a_regexp' do
         get :render_using_serializer
         assert_serializer(/\AProfile.+\Z/)
       end
 
-      def test_supports_specifying_serializers_with_a_string
+      test 'supports_specifying_serializers_with_a_string' do
         get :render_using_serializer
         assert_serializer 'ProfileSerializer'
       end
 
-      def test_supports_specifying_serializers_with_a_symbol
+      test 'supports_specifying_serializers_with_a_symbol' do
         get :render_using_serializer
         assert_serializer :profile_serializer
       end
 
-      def test_supports_specifying_serializers_with_a_nil
+      test 'supports_specifying_serializers_with_a_nil' do
         get :render_some_text
         assert_serializer nil
       end
 
-      def test_raises_descriptive_error_message_when_serializer_was_not_rendered
+      test 'raises_descriptive_error_message_when_serializer_was_not_rendered' do
         get :render_using_serializer
         e = assert_raise ActiveSupport::TestCase::Assertion do
           assert_serializer 'PostSerializer'
@@ -50,7 +50,7 @@ module ActiveModelSerializers
         assert_match 'expecting <"PostSerializer"> but rendering with <["ProfileSerializer"]>', e.message
       end
 
-      def test_raises_argument_error_when_asserting_with_invalid_object
+      test 'raises_argument_error_when_asserting_with_invalid_object' do
         get :render_using_serializer
         e = assert_raise ArgumentError do
           assert_serializer Hash

--- a/test/adapter/deprecation_test.rb
+++ b/test/adapter/deprecation_test.rb
@@ -11,21 +11,21 @@ module ActiveModel
           @serializer = PostSerializer.new(post)
         end
 
-        def test_null_adapter_serialization_deprecation
+        test 'null_adapter_serialization_deprecation' do
           expected = {}
           assert_deprecated do
             assert_equal(expected, Null.new(@serializer).as_json)
           end
         end
 
-        def test_json_adapter_serialization_deprecation
+        test 'json_adapter_serialization_deprecation' do
           expected = { post: { body: 'Hello' } }
           assert_deprecated do
             assert_equal(expected, Json.new(@serializer).as_json)
           end
         end
 
-        def test_jsonapi_adapter_serialization_deprecation
+        test 'jsonapi_adapter_serialization_deprecation' do
           expected = {
             data: {
               id: '1',
@@ -40,38 +40,38 @@ module ActiveModel
           end
         end
 
-        def test_attributes_adapter_serialization_deprecation
+        test 'attributes_adapter_serialization_deprecation' do
           expected = { body: 'Hello' }
           assert_deprecated do
             assert_equal(expected, Attributes.new(@serializer).as_json)
           end
         end
 
-        def test_adapter_create_deprecation
+        test 'adapter_create_deprecation' do
           assert_deprecated do
             Adapter.create(@serializer)
           end
         end
 
-        def test_adapter_adapter_map_deprecation
+        test 'adapter_adapter_map_deprecation' do
           assert_deprecated do
             Adapter.adapter_map
           end
         end
 
-        def test_adapter_adapters_deprecation
+        test 'adapter_adapters_deprecation' do
           assert_deprecated do
             Adapter.adapters
           end
         end
 
-        def test_adapter_adapter_class_deprecation
+        test 'adapter_adapter_class_deprecation' do
           assert_deprecated do
             Adapter.adapter_class(:json_api)
           end
         end
 
-        def test_adapter_register_deprecation
+        test 'adapter_register_deprecation' do
           assert_deprecated do
             begin
               Adapter.register(:test, Class.new)
@@ -81,7 +81,7 @@ module ActiveModel
           end
         end
 
-        def test_adapter_lookup_deprecation
+        test 'adapter_lookup_deprecation' do
           assert_deprecated do
             Adapter.lookup(:json_api)
           end

--- a/test/adapter/json/belongs_to_test.rb
+++ b/test/adapter/json/belongs_to_test.rb
@@ -22,18 +22,18 @@ module ActiveModelSerializers
           ActionController::Base.cache_store.clear
         end
 
-        def test_includes_post
+        test 'includes_post' do
           assert_equal({ id: 42, title: 'New Post', body: 'Body' }, @adapter.serializable_hash[:comment][:post])
         end
 
-        def test_include_nil_author
+        test 'include_nil_author' do
           serializer = PostSerializer.new(@anonymous_post)
           adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
 
           assert_equal({ post: { title: 'Hello!!', body: 'Hello, world!!', id: 43, comments: [], blog: { id: 999, name: 'Custom blog' }, author: nil } }, adapter.serializable_hash)
         end
 
-        def test_include_nil_author_with_specified_serializer
+        test 'include_nil_author_with_specified_serializer' do
           serializer = PostPreviewSerializer.new(@anonymous_post)
           adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
 

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -19,7 +19,7 @@ module ActiveModelSerializers
           ActionController::Base.cache_store.clear
         end
 
-        def test_with_serializer_option
+        test 'with_serializer_option' do
           @blog.special_attribute = 'Special'
           @blog.articles = [@first_post, @second_post]
           serializer = ActiveModel::Serializer::CollectionSerializer.new([@blog], serializer: CustomBlogSerializer)
@@ -33,7 +33,7 @@ module ActiveModelSerializers
           assert_equal expected, adapter.serializable_hash
         end
 
-        def test_include_multiple_posts
+        test 'include_multiple_posts' do
           serializer = ActiveModel::Serializer::CollectionSerializer.new([@first_post, @second_post])
           adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
 
@@ -67,7 +67,7 @@ module ActiveModelSerializers
           assert_equal expected, adapter.serializable_hash
         end
 
-        def test_root_is_underscored
+        test 'root_is_underscored' do
           virtual_value = VirtualValue.new(id: 1)
           serializer = ActiveModel::Serializer::CollectionSerializer.new([virtual_value])
           adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
@@ -75,7 +75,7 @@ module ActiveModelSerializers
           assert_equal 1, adapter.serializable_hash[:virtual_values].length
         end
 
-        def test_include_option
+        test 'include_option' do
           serializer = ActiveModel::Serializer::CollectionSerializer.new([@first_post, @second_post])
           adapter = ActiveModelSerializers::Adapter::Json.new(serializer, include: '')
           actual = adapter.serializable_hash
@@ -85,7 +85,7 @@ module ActiveModelSerializers
           assert_equal(expected, actual)
         end
 
-        def test_fields_with_no_associations_include_option
+        test 'fields_with_no_associations_include_option' do
           actual = ActiveModelSerializers::SerializableResource.new(
             [@first_post, @second_post], adapter: :json, fields: [:id], include: []
           ).as_json

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -20,7 +20,7 @@ module ActiveModelSerializers
           @post.tags = [@tag]
         end
 
-        def test_has_many
+        test 'has_many' do
           serializer = PostSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
           assert_equal([
@@ -29,7 +29,7 @@ module ActiveModelSerializers
                        ], adapter.serializable_hash[:post][:comments])
         end
 
-        def test_has_many_with_no_serializer
+        test 'has_many_with_no_serializer' do
           serializer = PostWithTagsSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
           assert_equal({

--- a/test/adapter/json/transform_test.rb
+++ b/test/adapter/json/transform_test.rb
@@ -25,14 +25,14 @@ module ActiveModelSerializers
           @blog = Blog.new(id: 1, name: 'My Blog!!', special_attribute: 'neat')
         end
 
-        def test_transform_default
+        test 'transform_default' do
           mock_request
           assert_equal({
                          blog: { id: 1, special_attribute: 'neat', articles: nil }
                        }, @adapter.serializable_hash)
         end
 
-        def test_transform_global_config
+        test 'transform_global_config' do
           mock_request
           result = with_config(key_transform: :camel_lower) do
             @adapter.serializable_hash
@@ -42,7 +42,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_transform_serialization_ctx_overrides_global_config
+        test 'transform_serialization_ctx_overrides_global_config' do
           mock_request(:camel)
           result = with_config(key_transform: :camel_lower) do
             @adapter.serializable_hash
@@ -52,7 +52,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_transform_undefined
+        test 'transform_undefined' do
           mock_request(:blam)
           result = nil
           assert_raises NoMethodError do
@@ -60,28 +60,28 @@ module ActiveModelSerializers
           end
         end
 
-        def test_transform_dash
+        test 'transform_dash' do
           mock_request(:dash)
           assert_equal({
                          blog: { id: 1, :"special-attribute" => 'neat', articles: nil }
                        }, @adapter.serializable_hash)
         end
 
-        def test_transform_unaltered
+        test 'transform_unaltered' do
           mock_request(:unaltered)
           assert_equal({
                          blog: { id: 1, special_attribute: 'neat', articles: nil }
                        }, @adapter.serializable_hash)
         end
 
-        def test_transform_camel
+        test 'transform_camel' do
           mock_request(:camel)
           assert_equal({
                          Blog: { Id: 1, SpecialAttribute: 'neat', Articles: nil }
                        }, @adapter.serializable_hash)
         end
 
-        def test_transform_camel_lower
+        test 'transform_camel_lower' do
           mock_request(:camel_lower)
           assert_equal({
                          blog: { id: 1, specialAttribute: 'neat', articles: nil }

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -30,13 +30,13 @@ module ActiveModelSerializers
           ActionController::Base.cache_store.clear
         end
 
-        def test_includes_post_id
+        test 'includes_post_id' do
           expected = { data: { type: 'posts', id: '42' } }
 
           assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:post])
         end
 
-        def test_includes_linked_post
+        test 'includes_linked_post' do
           @adapter = ActiveModelSerializers::Adapter::JsonApi.new(@serializer, include: [:post])
           expected = [{
             id: '42',
@@ -54,7 +54,7 @@ module ActiveModelSerializers
           assert_equal expected, @adapter.serializable_hash[:included]
         end
 
-        def test_limiting_linked_post_fields
+        test 'limiting_linked_post_fields' do
           @adapter = ActiveModelSerializers::Adapter::JsonApi.new(@serializer, include: [:post], fields: { post: [:title, :comments, :blog, :author] })
           expected = [{
             id: '42',
@@ -71,14 +71,14 @@ module ActiveModelSerializers
           assert_equal expected, @adapter.serializable_hash[:included]
         end
 
-        def test_include_nil_author
+        test 'include_nil_author' do
           serializer = PostSerializer.new(@anonymous_post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
 
           assert_equal({ comments: { data: [] }, blog: { data: { type: 'blogs', id: '999' } }, author: { data: nil } }, adapter.serializable_hash[:data][:relationships])
         end
 
-        def test_include_type_for_association_when_different_than_name
+        test 'include_type_for_association_when_different_than_name' do
           serializer = BlogSerializer.new(@blog)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
           relationships = adapter.serializable_hash[:data][:relationships]
@@ -105,7 +105,7 @@ module ActiveModelSerializers
           assert_equal expected, relationships
         end
 
-        def test_include_linked_resources_with_type_name
+        test 'include_linked_resources_with_type_name' do
           serializer = BlogSerializer.new(@blog)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, include: [:writer, :articles])
           linked = adapter.serializable_hash[:included]

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -23,7 +23,7 @@ module ActiveModelSerializers
           ActionController::Base.cache_store.clear
         end
 
-        def test_include_multiple_posts
+        test 'include_multiple_posts' do
           expected = [
             {
               id: '1',
@@ -56,7 +56,7 @@ module ActiveModelSerializers
           assert_equal(expected, @adapter.serializable_hash[:data])
         end
 
-        def test_limiting_fields
+        test 'limiting_fields' do
           actual = ActiveModelSerializers::SerializableResource.new(
             [@first_post, @second_post],
             adapter: :json_api,

--- a/test/adapter/json_api/errors_test.rb
+++ b/test/adapter/json_api/errors_test.rb
@@ -10,7 +10,7 @@ module ActiveModelSerializers
           @resource = ModelWithErrors.new
         end
 
-        def test_active_model_with_error
+        test 'active_model_with_error' do
           options = {
             serializer: ActiveModel::Serializer::ErrorSerializer,
             adapter: :json_api
@@ -33,7 +33,7 @@ module ActiveModelSerializers
           assert_equal serializable_resource.as_json, expected_errors_object
         end
 
-        def test_active_model_with_multiple_errors
+        test 'active_model_with_multiple_errors' do
           options = {
             serializer: ActiveModel::Serializer::ErrorSerializer,
             adapter: :json_api
@@ -58,13 +58,13 @@ module ActiveModelSerializers
         end
 
         # see http://jsonapi.org/examples/
-        def test_parameter_source_type_error
+        test 'parameter_source_type_error' do
           parameter = 'auther'
           error_source = ActiveModelSerializers::Adapter::JsonApi::Error.error_source(:parameter, parameter)
           assert_equal({ parameter: parameter }, error_source)
         end
 
-        def test_unknown_source_type_error
+        test 'unknown_source_type_error' do
           value = 'auther'
           assert_raises(ActiveModelSerializers::Adapter::JsonApi::Error::UnknownSourceTypeError) do
             ActiveModelSerializers::Adapter::JsonApi::Error.error_source(:hyper, value)

--- a/test/adapter/json_api/errors_test.rb
+++ b/test/adapter/json_api/errors_test.rb
@@ -3,14 +3,14 @@ require 'test_helper'
 module ActiveModelSerializers
   module Adapter
     class JsonApi < Base
-      class ErrorsTest < Minitest::Test
+      class ErrorsTest < ActiveSupport::TestCase
         include ActiveModel::Serializer::Lint::Tests
 
         def setup
           @resource = ModelWithErrors.new
         end
 
-        test 'active_model_with_error' do
+        test 'active model with error' do
           options = {
             serializer: ActiveModel::Serializer::ErrorSerializer,
             adapter: :json_api

--- a/test/adapter/json_api/fields_test.rb
+++ b/test/adapter/json_api/fields_test.rb
@@ -36,7 +36,7 @@ module ActiveModelSerializers
           @comment2.post = @post
         end
 
-        def test_fields_attributes
+        test 'fields_attributes' do
           fields = { posts: [:title] }
           hash = serializable(@post, adapter: :json_api, fields: fields).serializable_hash
           expected = {
@@ -46,7 +46,7 @@ module ActiveModelSerializers
           assert_equal(expected, hash[:data][:attributes])
         end
 
-        def test_fields_relationships
+        test 'fields_relationships' do
           fields = { posts: [:author] }
           hash = serializable(@post, adapter: :json_api, fields: fields).serializable_hash
           expected = {
@@ -61,7 +61,7 @@ module ActiveModelSerializers
           assert_equal(expected, hash[:data][:relationships])
         end
 
-        def test_fields_included
+        test 'fields_included' do
           fields = { posts: [:author], comments: [:body] }
           hash = serializable(@post, adapter: :json_api, fields: fields, include: 'comments').serializable_hash
           expected = [

--- a/test/adapter/json_api/has_many_embed_ids_test.rb
+++ b/test/adapter/json_api/has_many_embed_ids_test.rb
@@ -23,7 +23,7 @@ module ActiveModelSerializers
           @adapter = ActiveModelSerializers::Adapter::JsonApi.new(@serializer)
         end
 
-        def test_includes_comment_ids
+        test 'includes_comment_ids' do
           expected = {
             data: [
               { type: 'posts', id: '1' },
@@ -34,7 +34,7 @@ module ActiveModelSerializers
           assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:posts])
         end
 
-        def test_no_includes_linked_comments
+        test 'no_includes_linked_comments' do
           assert_nil @adapter.serializable_hash[:linked]
         end
       end

--- a/test/adapter/json_api/has_many_explicit_serializer_test.rb
+++ b/test/adapter/json_api/has_many_explicit_serializer_test.rb
@@ -27,7 +27,7 @@ module ActiveModelSerializers
           )
         end
 
-        def test_includes_comment_ids
+        test 'includes_comment_ids' do
           expected = {
             data: [
               { type: 'comments', id: '1' },
@@ -38,7 +38,7 @@ module ActiveModelSerializers
           assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:comments])
         end
 
-        def test_includes_linked_data
+        test 'includes_linked_data' do
           # If CommentPreviewSerializer is applied correctly the body text will not be present in the output
           expected = [
             {
@@ -67,7 +67,7 @@ module ActiveModelSerializers
           assert_equal(expected, @adapter.serializable_hash[:included])
         end
 
-        def test_includes_author_id
+        test 'includes_author_id' do
           expected = {
             data: { type: 'authors', id: @author.id.to_s }
           }
@@ -75,7 +75,7 @@ module ActiveModelSerializers
           assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:author])
         end
 
-        def test_explicit_serializer_with_null_resource
+        test 'explicit_serializer_with_null_resource' do
           @post.author = nil
 
           expected = { data: nil }
@@ -83,7 +83,7 @@ module ActiveModelSerializers
           assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:author])
         end
 
-        def test_explicit_serializer_with_null_collection
+        test 'explicit_serializer_with_null_collection' do
           @post.comments = []
 
           expected = { data: [] }

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -34,13 +34,13 @@ module ActiveModelSerializers
           @virtual_value = VirtualValue.new(id: 1)
         end
 
-        def test_includes_comment_ids
+        test 'includes_comment_ids' do
           expected = { data: [{ type: 'comments', id: '1' }, { type: 'comments', id: '2' }] }
 
           assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:comments])
         end
 
-        def test_includes_linked_comments
+        test 'includes_linked_comments' do
           @adapter = ActiveModelSerializers::Adapter::JsonApi.new(@serializer, include: [:comments])
           expected = [{
             id: '1',
@@ -66,7 +66,7 @@ module ActiveModelSerializers
           assert_equal expected, @adapter.serializable_hash[:included]
         end
 
-        def test_limit_fields_of_linked_comments
+        test 'limit_fields_of_linked_comments' do
           @adapter = ActiveModelSerializers::Adapter::JsonApi.new(@serializer, include: [:comments], fields: { comment: [:id, :post, :author] })
           expected = [{
             id: '1',
@@ -86,14 +86,14 @@ module ActiveModelSerializers
           assert_equal expected, @adapter.serializable_hash[:included]
         end
 
-        def test_no_include_linked_if_comments_is_empty
+        test 'no_include_linked_if_comments_is_empty' do
           serializer = PostSerializer.new(@post_without_comments)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
 
           assert_nil adapter.serializable_hash[:linked]
         end
 
-        def test_include_type_for_association_when_different_than_name
+        test 'include_type_for_association_when_different_than_name' do
           serializer = BlogSerializer.new(@blog)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
           actual = adapter.serializable_hash[:data][:relationships][:articles]
@@ -107,7 +107,7 @@ module ActiveModelSerializers
           assert_equal expected, actual
         end
 
-        def test_has_many_with_no_serializer
+        test 'has_many_with_no_serializer' do
           serializer = PostWithTagsSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
 
@@ -122,7 +122,7 @@ module ActiveModelSerializers
                        }, adapter.serializable_hash)
         end
 
-        def test_has_many_with_virtual_value
+        test 'has_many_with_virtual_value' do
           serializer = VirtualValueSerializer.new(@virtual_value)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
 

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -30,13 +30,13 @@ module ActiveModelSerializers
           @adapter = ActiveModelSerializers::Adapter::JsonApi.new(@serializer, include: [:bio, :posts])
         end
 
-        def test_includes_bio_id
+        test 'includes_bio_id' do
           expected = { data: { type: 'bios', id: '43' } }
 
           assert_equal(expected, @adapter.serializable_hash[:data][:relationships][:bio])
         end
 
-        def test_includes_linked_bio
+        test 'includes_linked_bio' do
           @adapter = ActiveModelSerializers::Adapter::JsonApi.new(@serializer, include: [:bio])
 
           expected = [
@@ -56,7 +56,7 @@ module ActiveModelSerializers
           assert_equal(expected, @adapter.serializable_hash[:included])
         end
 
-        def test_has_one_with_virtual_value
+        test 'has_one_with_virtual_value' do
           serializer = VirtualValueSerializer.new(@virtual_value)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
 

--- a/test/adapter/json_api/json_api_test.rb
+++ b/test/adapter/json_api/json_api_test.rb
@@ -17,7 +17,7 @@ module ActiveModelSerializers
         @post.blog = @blog
       end
 
-      def test_custom_keys
+      test 'custom_keys' do
         serializer = PostWithCustomKeysSerializer.new(@post)
         adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
 

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -42,7 +42,7 @@ module ActiveModelSerializers
           @bio2.author = @author2
         end
 
-        def test_include_multiple_posts_and_linked_array
+        test 'include_multiple_posts_and_linked_array' do
           serializer = ActiveModel::Serializer::CollectionSerializer.new([@first_post, @second_post])
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(
             serializer,
@@ -152,7 +152,7 @@ module ActiveModelSerializers
           assert_equal expected, alt_adapter.serializable_hash
         end
 
-        def test_include_multiple_posts_and_linked
+        test 'include_multiple_posts_and_linked' do
           serializer = BioSerializer.new @bio1
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(
             serializer,
@@ -206,7 +206,7 @@ module ActiveModelSerializers
           assert_equal expected, alt_adapter.serializable_hash[:included]
         end
 
-        def test_underscore_model_namespace_for_linked_resource_type
+        test 'underscore_model_namespace_for_linked_resource_type' do
           spammy_post = Post.new(id: 123)
           spammy_post.related = [Spam::UnrelatedLink.new(id: 456)]
           serializer = SpammyPostSerializer.new(spammy_post)
@@ -223,7 +223,7 @@ module ActiveModelSerializers
           assert_equal expected, relationships
         end
 
-        def test_multiple_references_to_same_resource
+        test 'multiple_references_to_same_resource' do
           serializer = ActiveModel::Serializer::CollectionSerializer.new([@first_comment, @second_comment])
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(
             serializer,
@@ -255,7 +255,7 @@ module ActiveModelSerializers
           assert_equal expected, adapter.serializable_hash[:included]
         end
 
-        def test_nil_link_with_specified_serializer
+        test 'nil_link_with_specified_serializer' do
           @first_post.author = nil
           serializer = PostPreviewSerializer.new(@first_post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(
@@ -310,7 +310,7 @@ module ActiveModelSerializers
           @nestedpost2.nested_posts << @nestedpost2
         end
 
-        def test_no_duplicates
+        test 'no_duplicates' do
           hash = ActiveModelSerializers::SerializableResource.new(@post1, adapter: :json_api,
                                                                           include: '*.*')
                                                              .serializable_hash
@@ -338,7 +338,7 @@ module ActiveModelSerializers
           assert_equal(expected, hash[:included])
         end
 
-        def test_no_duplicates_collection
+        test 'no_duplicates_collection' do
           hash = ActiveModelSerializers::SerializableResource.new(
             [@post1, @post2],
             adapter: :json_api,
@@ -360,7 +360,7 @@ module ActiveModelSerializers
           assert_equal(expected, hash[:included])
         end
 
-        def test_no_duplicates_global
+        test 'no_duplicates_global' do
           hash = ActiveModelSerializers::SerializableResource.new(
             @nestedpost1,
             adapter: :json_api,
@@ -380,7 +380,7 @@ module ActiveModelSerializers
           assert_equal(expected, hash[:included])
         end
 
-        def test_no_duplicates_collection_global
+        test 'no_duplicates_collection_global' do
           hash = ActiveModelSerializers::SerializableResource.new(
             [@nestedpost1, @nestedpost2],
             adapter: :json_api,

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -30,7 +30,7 @@ module ActiveModelSerializers
           @author = LinkAuthor.new(id: 1337, posts: [@post])
         end
 
-        def test_toplevel_links
+        test 'toplevel_links' do
           hash = ActiveModelSerializers::SerializableResource.new(
             @post,
             adapter: :json_api,
@@ -54,7 +54,7 @@ module ActiveModelSerializers
           assert_equal(expected, hash[:links])
         end
 
-        def test_nil_toplevel_links
+        test 'nil_toplevel_links' do
           hash = ActiveModelSerializers::SerializableResource.new(
             @post,
             adapter: :json_api,
@@ -63,7 +63,7 @@ module ActiveModelSerializers
           refute hash.key?(:links), 'No links key to be output'
         end
 
-        def test_nil_toplevel_links_json_adapter
+        test 'nil_toplevel_links_json_adapter' do
           hash = ActiveModelSerializers::SerializableResource.new(
             @post,
             adapter: :json,
@@ -72,7 +72,7 @@ module ActiveModelSerializers
           refute hash.key?(:links), 'No links key to be output'
         end
 
-        def test_resource_links
+        test 'resource_links' do
           hash = serializable(@author, adapter: :json_api).serializable_hash
           expected = {
             self: {

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -109,26 +109,26 @@ module ActiveModelSerializers
           end
         end
 
-        def test_pagination_links_using_kaminari
+        test 'pagination_links_using_kaminari' do
           adapter = load_adapter(using_kaminari, mock_request)
 
           assert_equal expected_response_with_pagination_links, adapter.serializable_hash
         end
 
-        def test_pagination_links_using_will_paginate
+        test 'pagination_links_using_will_paginate' do
           adapter = load_adapter(using_will_paginate, mock_request)
 
           assert_equal expected_response_with_pagination_links, adapter.serializable_hash
         end
 
-        def test_pagination_links_with_additional_params
+        test 'pagination_links_with_additional_params' do
           adapter = load_adapter(using_will_paginate, mock_request(test: 'test'))
 
           assert_equal expected_response_with_pagination_links_and_additional_params,
             adapter.serializable_hash
         end
 
-        def test_pagination_links_when_zero_results_kaminari
+        test 'pagination_links_when_zero_results_kaminari' do
           @array = []
 
           adapter = load_adapter(using_kaminari(1), mock_request)
@@ -136,7 +136,7 @@ module ActiveModelSerializers
           assert_equal expected_response_with_no_data_pagination_links, adapter.serializable_hash
         end
 
-        def test_pagination_links_when_zero_results_will_paginate
+        test 'pagination_links_when_zero_results_will_paginate' do
           @array = []
 
           adapter = load_adapter(using_will_paginate(1), mock_request)
@@ -144,25 +144,25 @@ module ActiveModelSerializers
           assert_equal expected_response_with_no_data_pagination_links, adapter.serializable_hash
         end
 
-        def test_last_page_pagination_links_using_kaminari
+        test 'last_page_pagination_links_using_kaminari' do
           adapter = load_adapter(using_kaminari(3), mock_request)
 
           assert_equal expected_response_with_last_page_pagination_links, adapter.serializable_hash
         end
 
-        def test_last_page_pagination_links_using_will_paginate
+        test 'last_page_pagination_links_using_will_paginate' do
           adapter = load_adapter(using_will_paginate(3), mock_request)
 
           assert_equal expected_response_with_last_page_pagination_links, adapter.serializable_hash
         end
 
-        def test_not_showing_pagination_links
+        test 'not_showing_pagination_links' do
           adapter = load_adapter(@array, mock_request)
 
           assert_equal expected_response_without_pagination_links, adapter.serializable_hash
         end
 
-        def test_raises_descriptive_error_when_serialization_context_unset
+        test 'raises_descriptive_error_when_serialization_context_unset' do
           render_options = { adapter: :json_api }
           adapter = serializable(using_kaminari, render_options)
           exception = assert_raises do

--- a/test/adapter/json_api/parse_test.rb
+++ b/test/adapter/json_api/parse_test.rb
@@ -58,25 +58,25 @@ module ActiveModelSerializers
                                    }]
           end
 
-          def test_hash
+          test 'hash' do
             parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash)
             assert_equal(@expected, parsed_hash)
           end
 
-          def test_actioncontroller_parameters
+          test 'actioncontroller_parameters' do
             assert_equal(false, @params.permitted?)
             parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@params)
             assert_equal(@expected, parsed_hash)
           end
 
-          def test_illformed_payloads_safe
+          test 'illformed_payloads_safe' do
             @illformed_payloads.each do |p|
               parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse(p)
               assert_equal({}, parsed_hash)
             end
           end
 
-          def test_illformed_payloads_unsafe
+          test 'illformed_payloads_unsafe' do
             @illformed_payloads.each do |p|
               assert_raises(InvalidDocument) do
                 ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(p)
@@ -84,7 +84,7 @@ module ActiveModelSerializers
             end
           end
 
-          def test_filter_fields_only
+          test 'filter_fields_only' do
             parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, only: [:id, :title, :author])
             expected = {
               id: 'zorglub',
@@ -94,7 +94,7 @@ module ActiveModelSerializers
             assert_equal(expected, parsed_hash)
           end
 
-          def test_filter_fields_except
+          test 'filter_fields_except' do
             parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, except: [:id, :title, :author])
             expected = {
               src: 'http://example.com/images/productivity.png',
@@ -104,7 +104,7 @@ module ActiveModelSerializers
             assert_equal(expected, parsed_hash)
           end
 
-          def test_keys
+          test 'keys' do
             parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, keys: { author: :user, title: :post_title })
             expected = {
               id: 'zorglub',
@@ -117,7 +117,7 @@ module ActiveModelSerializers
             assert_equal(expected, parsed_hash)
           end
 
-          def test_polymorphic
+          test 'polymorphic' do
             parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, polymorphic: [:photographer])
             expected = {
               id: 'zorglub',

--- a/test/adapter/json_api/parse_test.rb
+++ b/test/adapter/json_api/parse_test.rb
@@ -3,7 +3,7 @@ module ActiveModelSerializers
   module Adapter
     class JsonApi
       module Deserialization
-        class ParseTest < Minitest::Test
+        class ParseTest < ActiveSupport::TestCase
           def setup
             @hash = {
               'data' => {

--- a/test/adapter/json_api/relationship_test.rb
+++ b/test/adapter/json_api/relationship_test.rb
@@ -11,7 +11,7 @@ module ActiveModelSerializers
           ActionController::Base.cache_store.clear
         end
 
-        def test_relationship_with_data
+        test 'relationship_with_data' do
           expected = {
             data: {
               id: '1',
@@ -21,19 +21,19 @@ module ActiveModelSerializers
           test_relationship(expected, options: { include_data: true })
         end
 
-        def test_relationship_with_nil_model
+        test 'relationship_with_nil_model' do
           @serializer = BlogSerializer.new(nil)
           expected = { data: nil }
           test_relationship(expected, options: { include_data: true })
         end
 
-        def test_relationship_with_nil_serializer
+        test 'relationship_with_nil_serializer' do
           @serializer = nil
           expected = { data: nil }
           test_relationship(expected, options: { include_data: true })
         end
 
-        def test_relationship_with_data_array
+        test 'relationship_with_data_array' do
           posts = [Post.new(id: 1), Post.new(id: 2)]
           @serializer = ActiveModel::Serializer::CollectionSerializer.new(posts)
           @author.posts = posts
@@ -53,16 +53,16 @@ module ActiveModelSerializers
           test_relationship(expected, options: { include_data: true })
         end
 
-        def test_relationship_data_not_included
+        test 'relationship_data_not_included' do
           test_relationship({}, options: { include_data: false })
         end
 
-        def test_relationship_simple_link
+        test 'relationship_simple_link' do
           links = { self: 'a link' }
           test_relationship({ links: { self: 'a link' } }, links: links)
         end
 
-        def test_relationship_many_links
+        test 'relationship_many_links' do
           links = {
             self: 'a link',
             related: 'another link'
@@ -76,13 +76,13 @@ module ActiveModelSerializers
           test_relationship(expected, links: links)
         end
 
-        def test_relationship_block_link
+        test 'relationship_block_link' do
           links = { self: proc { object.id.to_s } }
           expected = { links: { self: @blog.id.to_s } }
           test_relationship(expected, links: links)
         end
 
-        def test_relationship_block_link_with_meta
+        test 'relationship_block_link_with_meta' do
           links = {
             self: proc do
               href object.id.to_s
@@ -100,13 +100,13 @@ module ActiveModelSerializers
           test_relationship(expected, links: links)
         end
 
-        def test_relationship_simple_meta
+        test 'relationship_simple_meta' do
           meta = { id: '1' }
           expected = { meta: meta }
           test_relationship(expected, meta: meta)
         end
 
-        def test_relationship_block_meta
+        test 'relationship_block_meta' do
           meta =  proc do
             { id: object.id }
           end
@@ -118,7 +118,7 @@ module ActiveModelSerializers
           test_relationship(expected, meta: meta)
         end
 
-        def test_relationship_with_everything
+        test 'relationship_with_everything' do
           links = {
             self: 'a link',
             related: proc do
@@ -150,7 +150,7 @@ module ActiveModelSerializers
 
         private
 
-        def test_relationship(expected, params = {})
+        test 'relationship(expected, params = {})' do
           parent_serializer = AuthorSerializer.new(@author)
           relationship = Relationship.new(parent_serializer, @serializer, nil, params)
           assert_equal(expected, relationship.as_json)

--- a/test/adapter/json_api/relationships_test.rb
+++ b/test/adapter/json_api/relationships_test.rb
@@ -93,7 +93,7 @@ module ActiveModel
             )
           end
 
-          def test_relationship_simple_link
+          test 'relationship_simple_link' do
             expected = {
               data: {
                 id: '1337',
@@ -106,7 +106,7 @@ module ActiveModel
             assert_relationship(:bio, expected)
           end
 
-          def test_relationship_block_link
+          test 'relationship_block_link' do
             expected = {
               data: { id: '1337', type: 'profiles' },
               links: { related: '//example.com/profiles/1337' }
@@ -114,7 +114,7 @@ module ActiveModel
             assert_relationship(:profile, expected)
           end
 
-          def test_relationship_nil_link
+          test 'relationship_nil_link' do
             @author.profile.id = 123
             expected = {
               data: { id: '123', type: 'profiles' }
@@ -122,7 +122,7 @@ module ActiveModel
             assert_relationship(:profile, expected)
           end
 
-          def test_relationship_block_link_href
+          test 'relationship_block_link_href' do
             expected = {
               data: [{ id: '1337', type: 'locations' }],
               links: {
@@ -132,7 +132,7 @@ module ActiveModel
             assert_relationship(:locations, expected)
           end
 
-          def test_relationship_block_link_href_and_meta
+          test 'relationship_block_link_href_and_meta' do
             expected = {
               data: [{ id: '1337', type: 'posts' }],
               links: {
@@ -145,7 +145,7 @@ module ActiveModel
             assert_relationship(:posts, expected)
           end
 
-          def test_relationship_block_link_meta
+          test 'relationship_block_link_meta' do
             expected = {
               data: [{ id: '1337', type: 'comments' }],
               links: {
@@ -157,7 +157,7 @@ module ActiveModel
             assert_relationship(:comments, expected)
           end
 
-          def test_relationship_meta
+          test 'relationship_meta' do
             expected = {
               data: [{ id: 'from-serializer-method', type: 'roles' }],
               meta: { count: 1 }
@@ -165,7 +165,7 @@ module ActiveModel
             assert_relationship(:roles, expected)
           end
 
-          def test_relationship_not_including_data
+          test 'relationship_not_including_data' do
             @author.define_singleton_method(:read_attribute_for_serialization) do |attr|
               fail 'should not be called' if attr == :blog
               super(attr)
@@ -178,7 +178,7 @@ module ActiveModel
             end
           end
 
-          def test_relationship_including_data_explicit
+          test 'relationship_including_data_explicit' do
             expected = {
               data: { id: '1337', type: 'authors' },
               meta: { name: 'Dan Brown' }
@@ -186,7 +186,7 @@ module ActiveModel
             assert_relationship(:reviewer, expected)
           end
 
-          def test_relationship_with_everything
+          test 'relationship_with_everything' do
             expected = {
               data: [{ id: '1337', type: 'likes' }],
               links: {

--- a/test/adapter/json_api/resource_identifier_test.rb
+++ b/test/adapter/json_api/resource_identifier_test.rb
@@ -54,11 +54,13 @@ module ActiveModelSerializers
         private
 
         test 'type_inflection(serializer_class, expected_type, inflection)' do
-          original_inflection = ActiveModelSerializers.config.jsonapi_resource_type
-          ActiveModelSerializers.config.jsonapi_resource_type = inflection
-          test_type(serializer_class, expected_type)
-        ensure
-          ActiveModelSerializers.config.jsonapi_resource_type = original_inflection
+          begin
+            original_inflection = ActiveModelSerializers.config.jsonapi_resource_type
+            ActiveModelSerializers.config.jsonapi_resource_type = inflection
+            test_type(serializer_class, expected_type)
+          ensure
+            ActiveModelSerializers.config.jsonapi_resource_type = original_inflection
+          end
         end
 
         test 'type(serializer_class, expected_type)' do

--- a/test/adapter/json_api/resource_identifier_test.rb
+++ b/test/adapter/json_api/resource_identifier_test.rb
@@ -27,33 +27,33 @@ module ActiveModelSerializers
           ActionController::Base.cache_store.clear
         end
 
-        def test_defined_type
+        test 'defined_type' do
           test_type(WithDefinedTypeSerializer, 'with-defined-type')
         end
 
-        def test_singular_type
+        test 'singular_type' do
           test_type_inflection(AuthorSerializer, 'author', :singular)
         end
 
-        def test_plural_type
+        test 'plural_type' do
           test_type_inflection(AuthorSerializer, 'authors', :plural)
         end
 
-        def test_id_defined_on_object
+        test 'id_defined_on_object' do
           test_id(AuthorSerializer, @model.id.to_s)
         end
 
-        def test_id_defined_on_serializer
+        test 'id_defined_on_serializer' do
           test_id(WithDefinedIdSerializer, 'special_id')
         end
 
-        def test_id_defined_on_fragmented
+        test 'id_defined_on_fragmented' do
           test_id(FragmentedSerializer, 'special_id')
         end
 
         private
 
-        def test_type_inflection(serializer_class, expected_type, inflection)
+        test 'type_inflection(serializer_class, expected_type, inflection)' do
           original_inflection = ActiveModelSerializers.config.jsonapi_resource_type
           ActiveModelSerializers.config.jsonapi_resource_type = inflection
           test_type(serializer_class, expected_type)
@@ -61,7 +61,7 @@ module ActiveModelSerializers
           ActiveModelSerializers.config.jsonapi_resource_type = original_inflection
         end
 
-        def test_type(serializer_class, expected_type)
+        test 'type(serializer_class, expected_type)' do
           serializer = serializer_class.new(@model)
           resource_identifier = ResourceIdentifier.new(serializer, nil)
           expected = {
@@ -72,7 +72,7 @@ module ActiveModelSerializers
           assert_equal(expected, resource_identifier.as_json)
         end
 
-        def test_id(serializer_class, id)
+        test 'id(serializer_class, id)' do
           serializer = serializer_class.new(@model)
           resource_identifier = ResourceIdentifier.new(serializer, nil)
           inflection = ActiveModelSerializers.config.jsonapi_resource_type

--- a/test/adapter/json_api/resource_meta_test.rb
+++ b/test/adapter/json_api/resource_meta_test.rb
@@ -4,7 +4,7 @@ module ActiveModel
   class Serializer
     module Adapter
       class JsonApi
-        class ResourceMetaTest < Minitest::Test
+        class ResourceMetaTest < ActiveSupport::TestCase
           class MetaHashPostSerializer < ActiveModel::Serializer
             attributes :id
             meta stuff: 'value'

--- a/test/adapter/json_api/resource_meta_test.rb
+++ b/test/adapter/json_api/resource_meta_test.rb
@@ -35,7 +35,7 @@ module ActiveModel
             @post = Post.new(id: 1337, comments: [], author: nil)
           end
 
-          def test_meta_hash_object_resource
+          test 'meta_hash_object_resource' do
             hash = ActiveModelSerializers::SerializableResource.new(
               @post,
               serializer: MetaHashPostSerializer,
@@ -47,7 +47,7 @@ module ActiveModel
             assert_equal(expected, hash[:data][:meta])
           end
 
-          def test_meta_block_object_resource
+          test 'meta_block_object_resource' do
             hash = ActiveModelSerializers::SerializableResource.new(
               @post,
               serializer: MetaBlockPostSerializer,
@@ -59,7 +59,7 @@ module ActiveModel
             assert_equal(expected, hash[:data][:meta])
           end
 
-          def test_meta_object_resource_in_array
+          test 'meta_object_resource_in_array' do
             post2 = Post.new(id: 1339, comments: [Comment.new])
             posts = [@post, post2]
             hash = ActiveModelSerializers::SerializableResource.new(
@@ -76,7 +76,7 @@ module ActiveModel
             assert_equal(expected, hash)
           end
 
-          def test_meta_object_blank_omitted
+          test 'meta_object_blank_omitted' do
             hash = ActiveModelSerializers::SerializableResource.new(
               @post,
               serializer: MetaBlockPostBlankMetaSerializer,
@@ -85,7 +85,7 @@ module ActiveModel
             refute hash[:data].key? :meta
           end
 
-          def test_meta_object_empty_string_omitted
+          test 'meta_object_empty_string_omitted' do
             hash = ActiveModelSerializers::SerializableResource.new(
               @post,
               serializer: MetaBlockPostEmptyStringSerializer,

--- a/test/adapter/json_api/toplevel_jsonapi_test.rb
+++ b/test/adapter/json_api/toplevel_jsonapi_test.rb
@@ -26,39 +26,39 @@ module ActiveModelSerializers
           @author.posts = []
         end
 
-        def test_toplevel_jsonapi_defaults_to_false
+        test 'toplevel_jsonapi_defaults_to_false' do
           assert_equal config.fetch(:jsonapi_include_toplevel_object), false
         end
 
-        def test_disable_toplevel_jsonapi
+        test 'disable_toplevel_jsonapi' do
           with_config(jsonapi_include_toplevel_object: false) do
             hash = serialize(@post)
             assert_nil(hash[:jsonapi])
           end
         end
 
-        def test_enable_toplevel_jsonapi
+        test 'enable_toplevel_jsonapi' do
           with_config(jsonapi_include_toplevel_object: true) do
             hash = serialize(@post)
             refute_nil(hash[:jsonapi])
           end
         end
 
-        def test_default_toplevel_jsonapi_version
+        test 'default_toplevel_jsonapi_version' do
           with_config(jsonapi_include_toplevel_object: true) do
             hash = serialize(@post)
             assert_equal('1.0', hash[:jsonapi][:version])
           end
         end
 
-        def test_toplevel_jsonapi_no_meta
+        test 'toplevel_jsonapi_no_meta' do
           with_config(jsonapi_include_toplevel_object: true) do
             hash = serialize(@post)
             assert_nil(hash[:jsonapi][:meta])
           end
         end
 
-        def test_toplevel_jsonapi_meta
+        test 'toplevel_jsonapi_meta' do
           new_config = {
             jsonapi_include_toplevel_object: true,
             jsonapi_toplevel_meta: {

--- a/test/adapter/json_api/transform_test.rb
+++ b/test/adapter/json_api/transform_test.rb
@@ -65,7 +65,7 @@ module ActiveModelSerializers
           @comment2.post = @post
         end
 
-        def test_success_document_transform_default
+        test 'success_document_transform_default' do
           mock_request
           serializer = PostSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
@@ -100,7 +100,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_success_document_transform_global_config
+        test 'success_document_transform_global_config' do
           mock_request
           result = with_config(key_transform: :camel_lower) do
             serializer = PostSerializer.new(@post)
@@ -137,7 +137,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_success_doc_transform_serialization_ctx_overrides_global
+        test 'success_doc_transform_serialization_ctx_overrides_global' do
           mock_request(:camel)
           result = with_config(key_transform: :camel_lower) do
             serializer = PostSerializer.new(@post)
@@ -174,7 +174,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_success_document_transform_dash
+        test 'success_document_transform_dash' do
           mock_request(:dash)
           serializer = PostSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
@@ -209,7 +209,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_success_document_transform_unaltered
+        test 'success_document_transform_unaltered' do
           mock_request(:unaltered)
           serializer = PostSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
@@ -244,7 +244,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_success_document_transform_undefined
+        test 'success_document_transform_undefined' do
           mock_request(:zoot)
           serializer = PostSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
@@ -254,7 +254,7 @@ module ActiveModelSerializers
           assert_match(/undefined method.*zoot/, exception.message)
         end
 
-        def test_success_document_transform_camel
+        test 'success_document_transform_camel' do
           mock_request(:camel)
           serializer = PostSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
@@ -289,7 +289,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_success_document_transform_camel_lower
+        test 'success_document_transform_camel_lower' do
           mock_request(:camel_lower)
           serializer = PostSerializer.new(@post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer, @options)
@@ -324,7 +324,7 @@ module ActiveModelSerializers
                        }, result)
         end
 
-        def test_error_document_transform_default
+        test 'error_document_transform_default' do
           mock_request
           resource = ModelWithErrors.new
           resource.errors.add(:published_at, 'must be in the future')
@@ -347,7 +347,7 @@ module ActiveModelSerializers
           assert_equal expected_errors_object, result
         end
 
-        def test_error_document_transform_global_config
+        test 'error_document_transform_global_config' do
           mock_request
           result = with_config(key_transform: :camel) do
             resource = ModelWithErrors.new
@@ -372,7 +372,7 @@ module ActiveModelSerializers
           assert_equal expected_errors_object, result
         end
 
-        def test_error_document_transform_serialization_ctx_overrides_global
+        test 'error_document_transform_serialization_ctx_overrides_global' do
           mock_request(:camel)
           result = with_config(key_transform: :camel_lower) do
             resource = ModelWithErrors.new
@@ -397,7 +397,7 @@ module ActiveModelSerializers
           assert_equal expected_errors_object, result
         end
 
-        def test_error_document_transform_dash
+        test 'error_document_transform_dash' do
           mock_request(:dash)
 
           resource = ModelWithErrors.new
@@ -423,7 +423,7 @@ module ActiveModelSerializers
           assert_equal expected_errors_object, result
         end
 
-        def test_error_document_transform_unaltered
+        test 'error_document_transform_unaltered' do
           mock_request(:unaltered)
 
           resource = ModelWithErrors.new
@@ -443,7 +443,7 @@ module ActiveModelSerializers
           assert_equal expected_errors_object, result
         end
 
-        def test_error_document_transform_undefined
+        test 'error_document_transform_undefined' do
           mock_request(:krazy)
 
           resource = ModelWithErrors.new
@@ -459,7 +459,7 @@ module ActiveModelSerializers
           assert_match(/undefined method.*krazy/, exception.message)
         end
 
-        def test_error_document_transform_camel
+        test 'error_document_transform_camel' do
           mock_request(:camel)
 
           resource = ModelWithErrors.new
@@ -479,7 +479,7 @@ module ActiveModelSerializers
           assert_equal expected_errors_object, result
         end
 
-        def test_error_document_transform_camel_lower
+        test 'error_document_transform_camel_lower' do
           mock_request(:camel_lower)
 
           resource = ModelWithErrors.new

--- a/test/adapter/json_api/type_test.rb
+++ b/test/adapter/json_api/type_test.rb
@@ -19,23 +19,23 @@ module ActiveModel
             @author = Author.new(id: 1, name: 'Steve K.')
           end
 
-          def test_config_plural
+          test 'config_plural' do
             with_jsonapi_resource_type :plural do
               assert_type(@author, 'authors')
             end
           end
 
-          def test_config_singular
+          test 'config_singular' do
             with_jsonapi_resource_type :singular do
               assert_type(@author, 'author')
             end
           end
 
-          def test_explicit_string_type_value
+          test 'explicit_string_type_value' do
             assert_type(@author, 'profile', serializer: StringTypeSerializer)
           end
 
-          def test_explicit_symbol_type_value
+          test 'explicit_symbol_type_value' do
             assert_type(@author, 'profile', serializer: SymbolTypeSerializer)
           end
 

--- a/test/adapter/json_test.rb
+++ b/test/adapter/json_test.rb
@@ -20,14 +20,14 @@ module ActiveModelSerializers
         @adapter = ActiveModelSerializers::Adapter::Json.new(@serializer)
       end
 
-      def test_has_many
+      test 'has_many' do
         assert_equal([
                        { id: 1, body: 'ZOMG A COMMENT' },
                        { id: 2, body: 'ZOMG ANOTHER COMMENT' }
                      ], @adapter.serializable_hash[:post][:comments])
       end
 
-      def test_custom_keys
+      test 'custom_keys' do
         serializer = PostWithCustomKeysSerializer.new(@post)
         adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
 

--- a/test/adapter/null_test.rb
+++ b/test/adapter/null_test.rb
@@ -10,11 +10,11 @@ module ActiveModelSerializers
         @adapter = Null.new(serializer)
       end
 
-      def test_serializable_hash
+      test 'serializable_hash' do
         assert_equal({}, @adapter.serializable_hash)
       end
 
-      def test_it_returns_empty_json
+      test 'it_returns_empty_json' do
         assert_equal('{}', @adapter.to_json)
       end
     end

--- a/test/adapter/polymorphic_test.rb
+++ b/test/adapter/polymorphic_test.rb
@@ -21,7 +21,7 @@ module ActiveModel
           serializable(tag, adapter: adapter, serializer: PolymorphicTagSerializer, include: '*.*').as_json
         end
 
-        def test_attributes_serialization
+        test 'attributes_serialization' do
           expected =
             {
               id: 1,
@@ -38,7 +38,7 @@ module ActiveModel
           assert_equal(expected, serialization(@picture))
         end
 
-        def test_attributes_serialization_without_polymorphic_association
+        test 'attributes_serialization_without_polymorphic_association' do
           expected =
             {
               id: 2,
@@ -50,7 +50,7 @@ module ActiveModel
           assert_equal(expected, serialization(simple_picture))
         end
 
-        def test_attributes_serialization_with_polymorphic_has_many
+        test 'attributes_serialization_with_polymorphic_has_many' do
           expected =
             {
               id: 1,
@@ -79,7 +79,7 @@ module ActiveModel
           assert_equal(expected, tag_serialization)
         end
 
-        def test_json_serialization
+        test 'json_serialization' do
           expected =
             {
               picture: {
@@ -98,7 +98,7 @@ module ActiveModel
           assert_equal(expected, serialization(@picture, :json))
         end
 
-        def test_json_serialization_without_polymorphic_association
+        test 'json_serialization_without_polymorphic_association' do
           expected =
             {
               picture: {
@@ -112,7 +112,7 @@ module ActiveModel
           assert_equal(expected, serialization(simple_picture, :json))
         end
 
-        def test_json_serialization_with_polymorphic_has_many
+        test 'json_serialization_with_polymorphic_has_many' do
           expected =
             {
               poly_tag: {
@@ -143,7 +143,7 @@ module ActiveModel
           assert_equal(expected, tag_serialization(:json))
         end
 
-        def test_json_api_serialization
+        test 'json_api_serialization' do
           expected =
             {
               data: {

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -15,30 +15,34 @@ module ActiveModelSerializers
     end
 
     test 'serialization_options_ensures_option_is_a_hash' do
-      adapter = Class.new(ActiveModelSerializers::Adapter::Base) do
-        def serializable_hash(options = nil)
-          serialization_options(options)
-        end
-      end.new(@serializer)
-      assert_equal({}, adapter.serializable_hash(nil))
-      assert_equal({}, adapter.serializable_hash({}))
-    ensure
-      ActiveModelSerializers::Adapter.adapter_map.delete_if { |k, _| k =~ /class/ }
+      begin
+        adapter = Class.new(ActiveModelSerializers::Adapter::Base) do
+          def serializable_hash(options = nil)
+            serialization_options(options)
+          end
+        end.new(@serializer)
+        assert_equal({}, adapter.serializable_hash(nil))
+        assert_equal({}, adapter.serializable_hash({}))
+      ensure
+        ActiveModelSerializers::Adapter.adapter_map.delete_if { |k, _| k =~ /class/ }
+      end
     end
 
     test 'serialization_options_ensures_option_is_one_of_valid_options' do
-      adapter = Class.new(ActiveModelSerializers::Adapter::Base) do
-        def serializable_hash(options = nil)
-          serialization_options(options)
+      begin
+        adapter = Class.new(ActiveModelSerializers::Adapter::Base) do
+          def serializable_hash(options = nil)
+            serialization_options(options)
+          end
+        end.new(@serializer)
+        filtered_options = { now: :see_me, then: :not }
+        valid_options = ActiveModel::Serializer::SERIALIZABLE_HASH_VALID_KEYS.each_with_object({}) do |option, result|
+          result[option] = option
         end
-      end.new(@serializer)
-      filtered_options = { now: :see_me, then: :not }
-      valid_options = ActiveModel::Serializer::SERIALIZABLE_HASH_VALID_KEYS.each_with_object({}) do |option, result|
-        result[option] = option
+        assert_equal(valid_options, adapter.serializable_hash(filtered_options.merge(valid_options)))
+      ensure
+        ActiveModelSerializers::Adapter.adapter_map.delete_if { |k, _| k =~ /class/ }
       end
-      assert_equal(valid_options, adapter.serializable_hash(filtered_options.merge(valid_options)))
-    ensure
-      ActiveModelSerializers::Adapter.adapter_map.delete_if { |k, _| k =~ /class/ }
     end
 
     test 'serializer' do

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -8,13 +8,13 @@ module ActiveModelSerializers
       @adapter = ActiveModelSerializers::Adapter::Base.new(@serializer)
     end
 
-    def test_serializable_hash_is_abstract_method
+    test 'serializable_hash_is_abstract_method' do
       assert_raises(NotImplementedError) do
         @adapter.serializable_hash(only: [:name])
       end
     end
 
-    def test_serialization_options_ensures_option_is_a_hash
+    test 'serialization_options_ensures_option_is_a_hash' do
       adapter = Class.new(ActiveModelSerializers::Adapter::Base) do
         def serializable_hash(options = nil)
           serialization_options(options)
@@ -26,7 +26,7 @@ module ActiveModelSerializers
       ActiveModelSerializers::Adapter.adapter_map.delete_if { |k, _| k =~ /class/ }
     end
 
-    def test_serialization_options_ensures_option_is_one_of_valid_options
+    test 'serialization_options_ensures_option_is_one_of_valid_options' do
       adapter = Class.new(ActiveModelSerializers::Adapter::Base) do
         def serializable_hash(options = nil)
           serialization_options(options)
@@ -41,21 +41,21 @@ module ActiveModelSerializers
       ActiveModelSerializers::Adapter.adapter_map.delete_if { |k, _| k =~ /class/ }
     end
 
-    def test_serializer
+    test 'serializer' do
       assert_equal @serializer, @adapter.serializer
     end
 
-    def test_create_adapter
+    test 'create_adapter' do
       adapter = ActiveModelSerializers::Adapter.create(@serializer)
       assert_equal ActiveModelSerializers::Adapter::Attributes, adapter.class
     end
 
-    def test_create_adapter_with_override
+    test 'create_adapter_with_override' do
       adapter = ActiveModelSerializers::Adapter.create(@serializer, adapter: :json_api)
       assert_equal ActiveModelSerializers::Adapter::JsonApi, adapter.class
     end
 
-    def test_inflected_adapter_class_for_known_adapter
+    test 'inflected_adapter_class_for_known_adapter' do
       ActiveSupport::Inflector.inflections(:en) { |inflect| inflect.acronym 'API' }
       klass = ActiveModelSerializers::Adapter.adapter_class(:json_api)
 

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -55,7 +55,7 @@ module ActiveModelSerializers
       @blog_serializer     = BlogSerializer.new(@blog)
     end
 
-    def test_explicit_cache_store
+    test 'explicit_cache_store' do
       default_store = Class.new(ActiveModel::Serializer) do
         cache
       end
@@ -68,14 +68,14 @@ module ActiveModelSerializers
       assert ActiveSupport::Cache::FileStore, explicit_store.cache_store
     end
 
-    def test_inherited_cache_configuration
+    test 'inherited_cache_configuration' do
       inherited_serializer = Class.new(PostSerializer)
 
       assert_equal PostSerializer._cache_key, inherited_serializer._cache_key
       assert_equal PostSerializer._cache_options, inherited_serializer._cache_options
     end
 
-    def test_override_cache_configuration
+    test 'override_cache_configuration' do
       inherited_serializer = Class.new(PostSerializer) do
         cache key: 'new-key'
       end
@@ -84,19 +84,19 @@ module ActiveModelSerializers
       assert_equal inherited_serializer._cache_key, 'new-key'
     end
 
-    def test_cache_definition
+    test 'cache_definition' do
       assert_equal(cache_store, @post_serializer.class._cache)
       assert_equal(cache_store, @author_serializer.class._cache)
       assert_equal(cache_store, @comment_serializer.class._cache)
     end
 
-    def test_cache_key_definition
+    test 'cache_key_definition' do
       assert_equal('post', @post_serializer.class._cache_key)
       assert_equal('writer', @author_serializer.class._cache_key)
       assert_equal(nil, @comment_serializer.class._cache_key)
     end
 
-    def test_cache_key_interpolation_with_updated_at_when_cache_key_is_not_defined_on_object
+    test 'cache_key_interpolation_with_updated_at_when_cache_key_is_not_defined_on_object' do
       uncached_author            = UncachedAuthor.new(name: 'Joao M. D. Moura')
       uncached_author_serializer = AuthorSerializer.new(uncached_author)
 
@@ -106,13 +106,13 @@ module ActiveModelSerializers
       assert_equal(uncached_author_serializer.attributes.to_json, cache_store.fetch(key).to_json)
     end
 
-    def test_default_cache_key_fallback
+    test 'default_cache_key_fallback' do
       render_object_with_cache(@comment)
       key = "#{@comment.cache_key}/#{adapter.cache_key}"
       assert_equal(@comment_serializer.attributes.to_json, cache_store.fetch(key).to_json)
     end
 
-    def test_error_is_raised_if_cache_key_is_not_defined_on_object_or_passed_as_cache_option
+    test 'error_is_raised_if_cache_key_is_not_defined_on_object_or_passed_as_cache_option' do
       article = Article.new(title: 'Must Read')
       e = assert_raises ActiveModel::Serializer::UndefinedCacheKey do
         render_object_with_cache(article)
@@ -120,18 +120,18 @@ module ActiveModelSerializers
       assert_match(/ActiveModelSerializers::CacheTest::Article must define #cache_key, or the 'key:' option must be passed into 'ActiveModelSerializers::CacheTest::ArticleSerializer.cache'/, e.message)
     end
 
-    def test_cache_options_definition
+    test 'cache_options_definition' do
       assert_equal({ expires_in: 0.1, skip_digest: true }, @post_serializer.class._cache_options)
       assert_equal(nil, @blog_serializer.class._cache_options)
       assert_equal({ expires_in: 1.day, skip_digest: true }, @comment_serializer.class._cache_options)
     end
 
-    def test_fragment_cache_definition
+    test 'fragment_cache_definition' do
       assert_equal([:name, :slug], @role_serializer.class._cache_only)
       assert_equal([:content], @bio_serializer.class._cache_except)
     end
 
-    def test_associations_separately_cache
+    test 'associations_separately_cache' do
       cache_store.clear
       assert_equal(nil, cache_store.fetch(@post.cache_key))
       assert_equal(nil, cache_store.fetch(@comment.cache_key))
@@ -146,7 +146,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_associations_cache_when_updated
+    test 'associations_cache_when_updated' do
       Timecop.freeze(Time.current) do
         # Generate a new Cache of Post object and each objects related to it.
         render_object_with_cache(@post)
@@ -173,7 +173,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_fragment_fetch_with_virtual_associations
+    test 'fragment_fetch_with_virtual_associations' do
       expected_result = {
         id: @location.id,
         lat: @location.lat,
@@ -188,7 +188,7 @@ module ActiveModelSerializers
       assert_equal({ address: 'Nowhere' }, cache_store.fetch(key))
     end
 
-    def test_fragment_cache_with_inheritance
+    test 'fragment_cache_with_inheritance' do
       inherited = render_object_with_cache(@role, serializer: InheritedRoleSerializer)
       base = render_object_with_cache(@role)
 
@@ -196,7 +196,7 @@ module ActiveModelSerializers
       refute_includes(base.keys, :special_attribute)
     end
 
-    def test_uses_adapter_in_cache_key
+    test 'uses_adapter_in_cache_key' do
       render_object_with_cache(@post)
       key = "#{@post.cache_key}/#{adapter.class.to_s.demodulize.underscore}"
       assert_equal(@post_serializer.attributes, cache_store.fetch(key))
@@ -204,7 +204,7 @@ module ActiveModelSerializers
 
     # Based on original failing test by @kevintyll
     # rubocop:disable Metrics/AbcSize
-    def test_a_serializer_rendered_by_two_adapter_returns_differently_fetch_attributes
+    test 'a_serializer_rendered_by_two_adapter_returns_differently_fetch_attributes' do
       Object.const_set(:Alert, Class.new(ActiveModelSerializers::Model) do
         attr_accessor :id, :status, :resource, :started_at, :ended_at, :updated_at, :created_at
       end)
@@ -274,17 +274,17 @@ module ActiveModelSerializers
     end
     # rubocop:enable Metrics/AbcSize
 
-    def test_uses_file_digest_in_cache_key
+    test 'uses_file_digest_in_cache_key' do
       render_object_with_cache(@blog)
       key = "#{@blog.cache_key}/#{adapter.cache_key}/#{::Model::FILE_DIGEST}"
       assert_equal(@blog_serializer.attributes, cache_store.fetch(key))
     end
 
-    def test_cache_digest_definition
+    test 'cache_digest_definition' do
       assert_equal(::Model::FILE_DIGEST, @post_serializer.class._cache_digest)
     end
 
-    def test_object_cache_keys
+    test 'object_cache_keys' do
       serializable = ActiveModelSerializers::SerializableResource.new([@comment, @comment])
       include_directive = JSONAPI::IncludeDirective.new('*', allow_wildcard: true)
 
@@ -296,7 +296,7 @@ module ActiveModelSerializers
       assert actual.any? { |key| key =~ %r{author/author-\d+} }
     end
 
-    def test_fetch_attributes_from_cache
+    test 'fetch_attributes_from_cache' do
       serializers = ActiveModel::Serializer::CollectionSerializer.new([@comment, @comment])
 
       Timecop.freeze(Time.current) do
@@ -321,7 +321,7 @@ module ActiveModelSerializers
       end
     end
 
-    def test_cache_read_multi_with_fragment_cache_enabled
+    test 'cache_read_multi_with_fragment_cache_enabled' do
       post_serializer = Class.new(ActiveModel::Serializer) do
         cache except: [:body]
       end
@@ -349,32 +349,32 @@ module ActiveModelSerializers
       end
     end
 
-    def test_serializer_file_path_on_nix
+    test 'serializer_file_path_on_nix' do
       path = '/Users/git/emberjs/ember-crm-backend/app/serializers/lead_serializer.rb'
       caller_line = "#{path}:1:in `<top (required)>'"
       assert_equal caller_line[ActiveModel::Serializer::CALLER_FILE], path
     end
 
-    def test_serializer_file_path_on_windows
+    test 'serializer_file_path_on_windows' do
       path = 'c:/git/emberjs/ember-crm-backend/app/serializers/lead_serializer.rb'
       caller_line = "#{path}:1:in `<top (required)>'"
       assert_equal caller_line[ActiveModel::Serializer::CALLER_FILE], path
     end
 
-    def test_serializer_file_path_with_space
+    test 'serializer_file_path_with_space' do
       path = '/Users/git/ember js/ember-crm-backend/app/serializers/lead_serializer.rb'
       caller_line = "#{path}:1:in `<top (required)>'"
       assert_equal caller_line[ActiveModel::Serializer::CALLER_FILE], path
     end
 
-    def test_serializer_file_path_with_submatch
+    test 'serializer_file_path_with_submatch' do
       # The submatch in the path ensures we're using a correctly greedy regexp.
       path = '/Users/git/ember js/ember:123:in x/app/serializers/lead_serializer.rb'
       caller_line = "#{path}:1:in `<top (required)>'"
       assert_equal caller_line[ActiveModel::Serializer::CALLER_FILE], path
     end
 
-    def test_digest_caller_file
+    test 'digest_caller_file' do
       contents = "puts 'AMS rocks'!"
       dir = Dir.mktmpdir('space char')
       file = Tempfile.new('some_ruby.rb', dir)
@@ -388,7 +388,7 @@ module ActiveModelSerializers
       FileUtils.remove_entry dir
     end
 
-    def test_warn_on_serializer_not_defined_in_file
+    test 'warn_on_serializer_not_defined_in_file' do
       called = false
       serializer = Class.new(ActiveModel::Serializer)
       assert_output(nil, /_cache_digest/) do
@@ -398,21 +398,21 @@ module ActiveModelSerializers
       assert called
     end
 
-    def test_cached_false_without_cache_store
+    test 'cached_false_without_cache_store' do
       cached_serializer = build_cached_serializer do |serializer|
         serializer._cache = nil
       end
       refute cached_serializer.class.cache_enabled?
     end
 
-    def test_cached_true_with_cache_store_and_without_cache_only_and_cache_except
+    test 'cached_true_with_cache_store_and_without_cache_only_and_cache_except' do
       cached_serializer = build_cached_serializer do |serializer|
         serializer._cache = Object
       end
       assert cached_serializer.class.cache_enabled?
     end
 
-    def test_cached_false_with_cache_store_and_with_cache_only
+    test 'cached_false_with_cache_store_and_with_cache_only' do
       cached_serializer = build_cached_serializer do |serializer|
         serializer._cache = Object
         serializer._cache_only = [:name]
@@ -420,7 +420,7 @@ module ActiveModelSerializers
       refute cached_serializer.class.cache_enabled?
     end
 
-    def test_cached_false_with_cache_store_and_with_cache_except
+    test 'cached_false_with_cache_store_and_with_cache_except' do
       cached_serializer = build_cached_serializer do |serializer|
         serializer._cache = Object
         serializer._cache_except = [:content]
@@ -428,7 +428,7 @@ module ActiveModelSerializers
       refute cached_serializer.class.cache_enabled?
     end
 
-    def test_fragment_cached_false_without_cache_store
+    test 'fragment_cached_false_without_cache_store' do
       cached_serializer = build_cached_serializer do |serializer|
         serializer._cache = nil
         serializer._cache_only = [:name]
@@ -436,7 +436,7 @@ module ActiveModelSerializers
       refute cached_serializer.class.fragment_cache_enabled?
     end
 
-    def test_fragment_cached_true_with_cache_store_and_cache_only
+    test 'fragment_cached_true_with_cache_store_and_cache_only' do
       cached_serializer = build_cached_serializer do |serializer|
         serializer._cache = Object
         serializer._cache_only = [:name]
@@ -444,7 +444,7 @@ module ActiveModelSerializers
       assert cached_serializer.class.fragment_cache_enabled?
     end
 
-    def test_fragment_cached_true_with_cache_store_and_cache_except
+    test 'fragment_cached_true_with_cache_store_and_cache_except' do
       cached_serializer = build_cached_serializer do |serializer|
         serializer._cache = Object
         serializer._cache_except = [:content]
@@ -452,7 +452,7 @@ module ActiveModelSerializers
       assert cached_serializer.class.fragment_cache_enabled?
     end
 
-    def test_fragment_cached_false_with_cache_store_and_cache_except_and_cache_only
+    test 'fragment_cached_false_with_cache_store_and_cache_except_and_cache_only' do
       cached_serializer = build_cached_serializer do |serializer|
         serializer._cache = Object
         serializer._cache_except = [:content]
@@ -461,7 +461,7 @@ module ActiveModelSerializers
       refute cached_serializer.class.fragment_cache_enabled?
     end
 
-    def test_fragment_fetch_with_virtual_attributes
+    test 'fragment_fetch_with_virtual_attributes' do
       author          = Author.new(name: 'Joao M. D. Moura')
       role            = Role.new(name: 'Great Author', description: nil)
       role.author     = [author]
@@ -485,7 +485,7 @@ module ActiveModelSerializers
       assert_equal(expected_result.merge(id: role.id), role_hash)
     end
 
-    def test_fragment_fetch_with_except
+    test 'fragment_fetch_with_except' do
       adapter_instance = ActiveModelSerializers::Adapter.configured_adapter.new(@bio_serializer)
       expected_result = {
         id: @bio.id,
@@ -504,7 +504,7 @@ module ActiveModelSerializers
       assert_equal(expected_result.merge(content: @bio.content), bio_hash)
     end
 
-    def test_fragment_fetch_with_namespaced_object
+    test 'fragment_fetch_with_namespaced_object' do
       @spam            = Spam::UnrelatedLink.new(id: 'spam-id-1')
       @spam_serializer = Spam::UnrelatedLinkSerializer.new(@spam)
       adapter_instance = ActiveModelSerializers::Adapter.configured_adapter.new(@spam_serializer)

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -23,15 +23,15 @@ module ActiveModel
         resource
       end
 
-      def test_has_object_reader_serializer_interface
+      test 'has_object_reader_serializer_interface' do
         assert_equal @serializer.object, @resource
       end
 
-      def test_respond_to_each
+      test 'respond_to_each' do
         assert_respond_to @serializer, :each
       end
 
-      def test_each_object_should_be_serialized_with_appropriate_serializer
+      test 'each_object_should_be_serialized_with_appropriate_serializer' do
         serializers =  @serializer.to_a
 
         assert_kind_of CommentSerializer, serializers.first
@@ -43,64 +43,64 @@ module ActiveModel
         assert_equal :options, serializers.last.custom_options[:some]
       end
 
-      def test_serializer_option_not_passed_to_each_serializer
+      test 'serializer_option_not_passed_to_each_serializer' do
         serializers = collection_serializer.new([@post], serializer: PostSerializer).to_a
 
         refute serializers.first.custom_options.key?(:serializer)
       end
 
-      def test_root_default
+      test 'root_default' do
         @serializer = collection_serializer.new([@comment, @post])
         assert_nil @serializer.root
       end
 
-      def test_root
+      test 'root' do
         expected =  'custom_root'
         @serializer = collection_serializer.new([@comment, @post], root: expected)
         assert_equal expected, @serializer.root
       end
 
-      def test_root_with_no_serializers
+      test 'root_with_no_serializers' do
         expected =  'custom_root'
         @serializer = collection_serializer.new([], root: expected)
         assert_equal expected, @serializer.root
       end
 
-      def test_json_key_with_resource_with_serializer
+      test 'json_key_with_resource_with_serializer' do
         singular_key = @serializer.send(:serializers).first.json_key
         assert_equal singular_key.pluralize, @serializer.json_key
       end
 
-      def test_json_key_with_resource_with_name_and_no_serializers
+      test 'json_key_with_resource_with_name_and_no_serializers' do
         serializer = collection_serializer.new(build_named_collection)
         assert_equal 'me_resources', serializer.json_key
       end
 
-      def test_json_key_with_resource_with_nil_name_and_no_serializers
+      test 'json_key_with_resource_with_nil_name_and_no_serializers' do
         resource = []
         resource.define_singleton_method(:name) { nil }
         serializer = collection_serializer.new(resource)
         assert_nil serializer.json_key
       end
 
-      def test_json_key_with_resource_without_name_and_no_serializers
+      test 'json_key_with_resource_without_name_and_no_serializers' do
         serializer = collection_serializer.new([])
         assert_nil serializer.json_key
       end
 
-      def test_json_key_with_empty_resources_with_serializer
+      test 'json_key_with_empty_resources_with_serializer' do
         resource = []
         serializer = collection_serializer.new(resource, serializer: MessagesSerializer)
         assert_equal 'messages', serializer.json_key
       end
 
-      def test_json_key_with_root
+      test 'json_key_with_root' do
         expected = 'custom_root'
         serializer = collection_serializer.new(@resource, root: expected)
         assert_equal expected, serializer.json_key
       end
 
-      def test_json_key_with_root_and_no_serializers
+      test 'json_key_with_root_and_no_serializers' do
         expected = 'custom_root'
         serializer = collection_serializer.new(build_named_collection, root: expected)
         assert_equal expected, serializer.json_key

--- a/test/generators/scaffold_controller_generator_test.rb
+++ b/test/generators/scaffold_controller_generator_test.rb
@@ -8,7 +8,7 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
   tests Rails::Generators::ResourceGenerator
   arguments %w(account)
 
-  def test_serializer_file_is_generated
+  test 'serializer_file_is_generated' do
     run_generator
 
     assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < ActiveModel::Serializer/

--- a/test/generators/serializer_generator_test.rb
+++ b/test/generators/serializer_generator_test.rb
@@ -9,17 +9,17 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
   tests Rails::Generators::SerializerGenerator
   arguments %w(account name:string description:text business:references)
 
-  def test_generates_a_serializer
+  test 'generates_a_serializer' do
     run_generator
     assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < ActiveModel::Serializer/
   end
 
-  def test_generates_a_namespaced_serializer
+  test 'generates_a_namespaced_serializer' do
     run_generator ['admin/account']
     assert_file 'app/serializers/admin/account_serializer.rb', /class Admin::AccountSerializer < ActiveModel::Serializer/
   end
 
-  def test_uses_application_serializer_if_one_exists
+  test 'uses_application_serializer_if_one_exists' do
     Object.const_set(:ApplicationSerializer, Class.new)
     run_generator
     assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < ApplicationSerializer/
@@ -27,7 +27,7 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
     Object.send :remove_const, :ApplicationSerializer
   end
 
-  def test_uses_given_parent
+  test 'uses_given_parent' do
     Object.const_set(:ApplicationSerializer, Class.new)
     run_generator ['Account', '--parent=MySerializer']
     assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < MySerializer/
@@ -35,7 +35,7 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
     Object.send :remove_const, :ApplicationSerializer
   end
 
-  def test_generates_attributes_and_associations
+  test 'generates_attributes_and_associations' do
     run_generator
     assert_file 'app/serializers/account_serializer.rb' do |serializer|
       assert_match(/^  attributes :id, :name, :description$/, serializer)
@@ -44,7 +44,7 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_with_no_attributes_does_not_add_extra_space
+  test 'with_no_attributes_does_not_add_extra_space' do
     run_generator ['account']
     assert_file 'app/serializers/account_serializer.rb' do |content|
       if RUBY_PLATFORM =~ /mingw/

--- a/test/generators/serializer_generator_test.rb
+++ b/test/generators/serializer_generator_test.rb
@@ -20,19 +20,23 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
   end
 
   test 'uses_application_serializer_if_one_exists' do
-    Object.const_set(:ApplicationSerializer, Class.new)
-    run_generator
-    assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < ApplicationSerializer/
-  ensure
-    Object.send :remove_const, :ApplicationSerializer
+    begin
+      Object.const_set(:ApplicationSerializer, Class.new)
+      run_generator
+      assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < ApplicationSerializer/
+    ensure
+      Object.send :remove_const, :ApplicationSerializer
+    end
   end
 
   test 'uses_given_parent' do
-    Object.const_set(:ApplicationSerializer, Class.new)
-    run_generator ['Account', '--parent=MySerializer']
-    assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < MySerializer/
-  ensure
-    Object.send :remove_const, :ApplicationSerializer
+    begin
+      Object.const_set(:ApplicationSerializer, Class.new)
+      run_generator ['Account', '--parent=MySerializer']
+      assert_file 'app/serializers/account_serializer.rb', /class AccountSerializer < MySerializer/
+    ensure
+      Object.send :remove_const, :ApplicationSerializer
+    end
   end
 
   test 'generates_attributes_and_associations' do

--- a/test/grape_test.rb
+++ b/test/grape_test.rb
@@ -93,7 +93,7 @@ module ActiveModelSerializers
       Grape::Middleware::Globals.new(GrapeTest.new)
     end
 
-    def test_formatter_returns_json
+    test 'formatter_returns_json' do
       get '/grape/render'
 
       post = Models.model1
@@ -103,7 +103,7 @@ module ActiveModelSerializers
       assert_equal serializable_resource.to_json, last_response.body
     end
 
-    def test_render_helper_passes_through_options_correctly
+    test 'render_helper_passes_through_options_correctly' do
       get '/grape/render_with_json_api'
 
       post = Models.model1
@@ -113,7 +113,7 @@ module ActiveModelSerializers
       assert_equal serializable_resource.to_json, last_response.body
     end
 
-    def test_formatter_handles_arrays
+    test 'formatter_handles_arrays' do
       get '/grape/render_array_with_json_api'
 
       posts = Models.all
@@ -125,7 +125,7 @@ module ActiveModelSerializers
       Models.reset_all
     end
 
-    def test_formatter_handles_collections
+    test 'formatter_handles_collections' do
       get '/grape/render_collection_with_json_api'
       assert last_response.ok?
 
@@ -136,7 +136,7 @@ module ActiveModelSerializers
       assert representation['links'].count > 0
     end
 
-    def test_implicit_formatter
+    test 'implicit_formatter' do
       post = Models.model1
       serializable_resource = serializable(post, adapter: :json_api)
 
@@ -148,7 +148,7 @@ module ActiveModelSerializers
       assert_equal serializable_resource.to_json, last_response.body
     end
 
-    def test_implicit_formatter_handles_arrays
+    test 'implicit_formatter_handles_arrays' do
       posts = Models.all
       serializable_resource = serializable(posts, adapter: :json_api)
 
@@ -162,7 +162,7 @@ module ActiveModelSerializers
       Models.reset_all
     end
 
-    def test_implicit_formatter_handles_collections
+    test 'implicit_formatter_handles_collections' do
       with_adapter :json_api do
         get '/grape/render_collection_with_implicit_formatter'
       end

--- a/test/grape_test.rb
+++ b/test/grape_test.rb
@@ -114,15 +114,17 @@ module ActiveModelSerializers
     end
 
     test 'formatter_handles_arrays' do
-      get '/grape/render_array_with_json_api'
+      begin
+        get '/grape/render_array_with_json_api'
 
-      posts = Models.all
-      serializable_resource = serializable(posts, adapter: :json_api)
+        posts = Models.all
+        serializable_resource = serializable(posts, adapter: :json_api)
 
-      assert last_response.ok?
-      assert_equal serializable_resource.to_json, last_response.body
-    ensure
-      Models.reset_all
+        assert last_response.ok?
+        assert_equal serializable_resource.to_json, last_response.body
+      ensure
+        Models.reset_all
+      end
     end
 
     test 'formatter_handles_collections' do
@@ -149,17 +151,19 @@ module ActiveModelSerializers
     end
 
     test 'implicit_formatter_handles_arrays' do
-      posts = Models.all
-      serializable_resource = serializable(posts, adapter: :json_api)
+      begin
+        posts = Models.all
+        serializable_resource = serializable(posts, adapter: :json_api)
 
-      with_adapter :json_api do
-        get '/grape/render_array_with_implicit_formatter'
+        with_adapter :json_api do
+          get '/grape/render_array_with_implicit_formatter'
+        end
+
+        assert last_response.ok?
+        assert_equal serializable_resource.to_json, last_response.body
+      ensure
+        Models.reset_all
       end
-
-      assert last_response.ok?
-      assert_equal serializable_resource.to_json, last_response.body
-    ensure
-      Models.reset_all
     end
 
     test 'implicit_formatter_handles_collections' do

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -7,14 +7,16 @@ module ActiveModelSerializers
     end
 
     test 'logger_can_be_set' do
-      original_logger = ActiveModelSerializers.logger
-      logger = Logger.new(STDOUT)
+      begin
+        original_logger = ActiveModelSerializers.logger
+        logger = Logger.new(STDOUT)
 
-      ActiveModelSerializers.logger = logger
+        ActiveModelSerializers.logger = logger
 
-      assert_equal ActiveModelSerializers.logger, logger
-    ensure
-      ActiveModelSerializers.logger = original_logger
+        assert_equal ActiveModelSerializers.logger, logger
+      ensure
+        ActiveModelSerializers.logger = original_logger
+      end
     end
   end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 module ActiveModelSerializers
   class LoggerTest < ActiveSupport::TestCase
-    def test_logger_is_set_to_action_controller_logger_when_initializer_runs
+    test 'logger_is_set_to_action_controller_logger_when_initializer_runs' do
       assert_equal $action_controller_logger, ActionController::Base.logger # rubocop:disable Style/GlobalVars
     end
 
-    def test_logger_can_be_set
+    test 'logger_can_be_set' do
       original_logger = ActiveModelSerializers.logger
       logger = Logger.new(STDOUT)
 

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -9,38 +9,38 @@ module ActiveModelSerializers
       @serializable_resource = SerializableResource.new(@resource)
     end
 
-    def test_deprecation
+    test 'deprecation' do
       assert_output(nil, /deprecated/) do
         deprecated_serializable_resource = ActiveModel::SerializableResource.new(@resource)
         assert_equal(@serializable_resource.as_json, deprecated_serializable_resource.as_json)
       end
     end
 
-    def test_serializable_resource_delegates_serializable_hash_to_the_adapter
+    test 'serializable_resource_delegates_serializable_hash_to_the_adapter' do
       options = nil
       assert_equal @adapter.serializable_hash(options), @serializable_resource.serializable_hash(options)
     end
 
-    def test_serializable_resource_delegates_to_json_to_the_adapter
+    test 'serializable_resource_delegates_to_json_to_the_adapter' do
       options = nil
       assert_equal @adapter.to_json(options), @serializable_resource.to_json(options)
     end
 
-    def test_serializable_resource_delegates_as_json_to_the_adapter
+    test 'serializable_resource_delegates_as_json_to_the_adapter' do
       options = nil
       assert_equal @adapter.as_json(options), @serializable_resource.as_json(options)
     end
 
-    def test_use_adapter_with_adapter_option
+    test 'use_adapter_with_adapter_option' do
       assert SerializableResource.new(@resource, adapter: 'json').use_adapter?
     end
 
-    def test_use_adapter_with_adapter_option_as_false
+    test 'use_adapter_with_adapter_option_as_false' do
       refute SerializableResource.new(@resource, adapter: false).use_adapter?
     end
 
     class SerializableResourceErrorsTest < Minitest::Test
-      def test_serializable_resource_with_errors
+      test 'serializable_resource_with_errors' do
         options = nil
         resource = ModelWithErrors.new
         resource.errors.add(:name, 'must be awesome')
@@ -56,7 +56,7 @@ module ActiveModelSerializers
         assert_equal serializable_resource.as_json(options), expected_response_document
       end
 
-      def test_serializable_resource_with_collection_containing_errors
+      test 'serializable_resource_with_collection_containing_errors' do
         options = nil
         resources = []
         resources << resource = ModelWithErrors.new

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -39,7 +39,7 @@ module ActiveModelSerializers
       refute SerializableResource.new(@resource, adapter: false).use_adapter?
     end
 
-    class SerializableResourceErrorsTest < Minitest::Test
+    class SerializableResourceErrorsTest < ActiveSupport::TestCase
       test 'serializable_resource_with_errors' do
         options = nil
         resource = ModelWithErrors.new

--- a/test/serializers/association_macros_test.rb
+++ b/test/serializers/association_macros_test.rb
@@ -15,19 +15,19 @@ module ActiveModel
         @reflections = AssociationsTestSerializer._reflections.values
       end
 
-      def test_has_one_defines_reflection
+      test 'has_one_defines_reflection' do
         has_one_reflection = HasOneReflection.new(:category, {})
 
         assert_includes(@reflections, has_one_reflection)
       end
 
-      def test_has_many_defines_reflection
+      test 'has_many_defines_reflection' do
         has_many_reflection = HasManyReflection.new(:comments, {})
 
         assert_includes(@reflections, has_many_reflection)
       end
 
-      def test_belongs_to_defines_reflection
+      test 'belongs_to_defines_reflection' do
         belongs_to_reflection = BelongsToReflection.new(:author, serializer: AuthorSummarySerializer)
 
         assert_includes(@reflections, belongs_to_reflection)

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -133,28 +133,30 @@ module ActiveModel
       end
 
       test 'virtual_attribute_block' do
-        comment1 = ::ARModels::Comment.create!(contents: 'first comment')
-        comment2 = ::ARModels::Comment.create!(contents: 'last comment')
-        post = ::ARModels::Post.create!(
-          title: 'inline association test',
-          body: 'etc',
-          comments: [comment1, comment2]
-        )
-        actual = serializable(post, adapter: :attributes, serializer: InlineAssociationTestPostSerializer).as_json
-        expected = {
-          comments: [
-            { id: 1, contents: 'first comment' },
-            { id: 2, contents: 'last comment' }
-          ],
-          last_comments: [
-            { id: 2, contents: 'last comment' }
-          ]
-        }
+        begin
+          comment1 = ::ARModels::Comment.create!(contents: 'first comment')
+          comment2 = ::ARModels::Comment.create!(contents: 'last comment')
+          post = ::ARModels::Post.create!(
+            title: 'inline association test',
+            body: 'etc',
+            comments: [comment1, comment2]
+          )
+          actual = serializable(post, adapter: :attributes, serializer: InlineAssociationTestPostSerializer).as_json
+          expected = {
+            comments: [
+              { id: 1, contents: 'first comment' },
+              { id: 2, contents: 'last comment' }
+            ],
+            last_comments: [
+              { id: 2, contents: 'last comment' }
+            ]
+          }
 
-        assert_equal expected, actual
-      ensure
-        ::ARModels::Post.delete_all
-        ::ARModels::Comment.delete_all
+          assert_equal expected, actual
+        ensure
+          ::ARModels::Post.delete_all
+          ::ARModels::Comment.delete_all
+        end
       end
 
       class NamespacedResourcesTest < ActiveSupport::TestCase

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -23,7 +23,7 @@ module ActiveModel
         @comment_serializer = CommentSerializer.new(@comment)
       end
 
-      def test_has_many_and_has_one
+      test 'has_many_and_has_one' do
         @author_serializer.associations.each do |association|
           key = association.key
           serializer = association.serializer
@@ -45,7 +45,7 @@ module ActiveModel
         end
       end
 
-      def test_has_many_with_no_serializer
+      test 'has_many_with_no_serializer' do
         PostWithTagsSerializer.new(@post).associations.each do |association|
           key = association.key
           serializer = association.serializer
@@ -57,7 +57,7 @@ module ActiveModel
         end
       end
 
-      def test_serializer_options_are_passed_into_associations_serializers
+      test 'serializer_options_are_passed_into_associations_serializers' do
         association = @post_serializer
                       .associations
                       .detect { |assoc| assoc.key == :comments }
@@ -65,7 +65,7 @@ module ActiveModel
         assert association.serializer.first.custom_options[:custom_options]
       end
 
-      def test_belongs_to
+      test 'belongs_to' do
         @comment_serializer.associations.each do |association|
           key = association.key
           serializer = association.serializer
@@ -83,7 +83,7 @@ module ActiveModel
         end
       end
 
-      def test_belongs_to_with_custom_method
+      test 'belongs_to_with_custom_method' do
         assert(
           @post_serializer.associations.any? do |association|
             association.key == :blog
@@ -91,13 +91,13 @@ module ActiveModel
         )
       end
 
-      def test_associations_inheritance
+      test 'associations_inheritance' do
         inherited_klass = Class.new(PostSerializer)
 
         assert_equal(PostSerializer._reflections, inherited_klass._reflections)
       end
 
-      def test_associations_inheritance_with_new_association
+      test 'associations_inheritance_with_new_association' do
         inherited_klass = Class.new(PostSerializer) do
           has_many :top_comments, serializer: CommentSerializer
         end
@@ -115,7 +115,7 @@ module ActiveModel
         )
       end
 
-      def test_associations_custom_keys
+      test 'associations_custom_keys' do
         serializer = PostWithCustomKeysSerializer.new(@post)
 
         expected_association_keys = serializer.associations.map(&:key)
@@ -132,7 +132,7 @@ module ActiveModel
         end
       end
 
-      def test_virtual_attribute_block
+      test 'virtual_attribute_block' do
         comment1 = ::ARModels::Comment.create!(contents: 'first comment')
         comment2 = ::ARModels::Comment.create!(contents: 'last comment')
         post = ::ARModels::Post.create!(
@@ -183,7 +183,7 @@ module ActiveModel
           @post_serializer = ResourceNamespace::PostSerializer.new(@post)
         end
 
-        def test_associations_namespaced_resources
+        test 'associations_namespaced_resources' do
           @post_serializer.associations.each do |association|
             case association.key
             when :comments
@@ -223,7 +223,7 @@ module ActiveModel
           @post_serializer = PostSerializer.new(@post)
         end
 
-        def test_associations_namespaced_resources
+        test 'associations_namespaced_resources' do
           @post_serializer.associations.each do |association|
             case association.key
             when :comments
@@ -239,7 +239,7 @@ module ActiveModel
         end
 
         # rubocop:disable Metrics/AbcSize
-        def test_conditional_associations
+        test 'conditional_associations' do
           model = ::Model.new(true: true, false: false)
 
           scenarios = [
@@ -279,7 +279,7 @@ module ActiveModel
           end
         end
 
-        def test_illegal_conditional_associations
+        test 'illegal_conditional_associations' do
           exception = assert_raises(TypeError) do
             Class.new(ActiveModel::Serializer) do
               belongs_to :x, if: nil

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -8,24 +8,24 @@ module ActiveModel
         @blog_serializer = AlternateBlogSerializer.new(@blog)
       end
 
-      def test_attributes_definition
+      test 'attributes_definition' do
         assert_equal([:id, :title],
           @blog_serializer.class._attributes)
       end
 
-      def test_json_serializable_hash
+      test 'json_serializable_hash' do
         adapter = ActiveModelSerializers::Adapter::Json.new(@blog_serializer)
         assert_equal({ blog: { id: 1, title: 'AMS Hints' } }, adapter.serializable_hash)
       end
 
-      def test_attribute_inheritance_with_key
+      test 'attribute_inheritance_with_key' do
         inherited_klass = Class.new(AlternateBlogSerializer)
         blog_serializer = inherited_klass.new(@blog)
         adapter = ActiveModelSerializers::Adapter::Attributes.new(blog_serializer)
         assert_equal({ id: 1, title: 'AMS Hints' }, adapter.serializable_hash)
       end
 
-      def test_multiple_calls_with_the_same_attribute
+      test 'multiple_calls_with_the_same_attribute' do
         serializer_class = Class.new(ActiveModel::Serializer) do
           attribute :title
           attribute :title
@@ -34,7 +34,7 @@ module ActiveModel
         assert_equal([:title], serializer_class._attributes)
       end
 
-      def test_id_attribute_override
+      test 'id_attribute_override' do
         serializer = Class.new(ActiveModel::Serializer) do
           attribute :name, key: :id
         end
@@ -43,7 +43,7 @@ module ActiveModel
         assert_equal({ blog: { id: 'AMS Hints' } }, adapter.serializable_hash)
       end
 
-      def test_object_attribute_override
+      test 'object_attribute_override' do
         serializer = Class.new(ActiveModel::Serializer) do
           attribute :name, key: :object
         end
@@ -52,7 +52,7 @@ module ActiveModel
         assert_equal({ blog: { object: 'AMS Hints' } }, adapter.serializable_hash)
       end
 
-      def test_type_attribute
+      test 'type_attribute' do
         attribute_serializer = Class.new(ActiveModel::Serializer) do
           attribute :id, key: :type
         end
@@ -67,7 +67,7 @@ module ActiveModel
         assert_equal({ blog: { type: 'stuff' } }, adapter.serializable_hash)
       end
 
-      def test_id_attribute_override_before
+      test 'id_attribute_override_before' do
         serializer = Class.new(ActiveModel::Serializer) do
           def id
             'custom'
@@ -88,7 +88,7 @@ module ActiveModel
         end
       end
 
-      def test_virtual_attribute_block
+      test 'virtual_attribute_block' do
         post = PostWithVirtualAttribute.new(first_name: 'Lucas', last_name: 'Hosseini')
         hash = serializable(post).serializable_hash
         expected = { name: 'Lucas Hosseini' }
@@ -97,7 +97,7 @@ module ActiveModel
       end
 
       # rubocop:disable Metrics/AbcSize
-      def test_conditional_associations
+      test 'conditional_associations' do
         model = ::Model.new(true: true, false: false)
 
         scenarios = [
@@ -137,7 +137,7 @@ module ActiveModel
         end
       end
 
-      def test_illegal_conditional_attributes
+      test 'illegal_conditional_attributes' do
         exception = assert_raises(TypeError) do
           Class.new(ActiveModel::Serializer) do
             attribute :x, if: nil

--- a/test/serializers/attributes_test.rb
+++ b/test/serializers/attributes_test.rb
@@ -13,33 +13,33 @@ module ActiveModel
         end
       end
 
-      def test_attributes_definition
+      test 'attributes_definition' do
         assert_equal([:name, :description],
           @profile_serializer.class._attributes)
       end
 
-      def test_attributes_inheritance_definition
+      test 'attributes_inheritance_definition' do
         assert_equal([:id, :body], @serializer_klass._attributes)
       end
 
-      def test_attributes_inheritance
+      test 'attributes_inheritance' do
         serializer = @serializer_klass.new(@comment)
         assert_equal({ id: 1, body: 'ZOMG!!' },
           serializer.attributes)
       end
 
-      def test_attribute_inheritance_with_new_attribute_definition
+      test 'attribute_inheritance_with_new_attribute_definition' do
         assert_equal([:id, :body, :date, :likes], @serializer_klass_with_new_attributes._attributes)
         assert_equal([:id, :body], CommentSerializer._attributes)
       end
 
-      def test_attribute_inheritance_with_new_attribute
+      test 'attribute_inheritance_with_new_attribute' do
         serializer = @serializer_klass_with_new_attributes.new(@comment)
         assert_equal({ id: 1, body: 'ZOMG!!', date: '2015', likes: nil },
           serializer.attributes)
       end
 
-      def test_multiple_calls_with_the_same_attribute
+      test 'multiple_calls_with_the_same_attribute' do
         serializer_class = Class.new(ActiveModel::Serializer) do
           attributes :id, :title
           attributes :id, :title, :title, :body

--- a/test/serializers/configuration_test.rb
+++ b/test/serializers/configuration_test.rb
@@ -3,15 +3,15 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class ConfigurationTest < ActiveSupport::TestCase
-      def test_collection_serializer
+      test 'collection_serializer' do
         assert_equal ActiveModel::Serializer::CollectionSerializer, ActiveModelSerializers.config.collection_serializer
       end
 
-      def test_array_serializer
+      test 'array_serializer' do
         assert_equal ActiveModel::Serializer::CollectionSerializer, ActiveModelSerializers.config.array_serializer
       end
 
-      def test_setting_array_serializer_sets_collection_serializer
+      test 'setting_array_serializer_sets_collection_serializer' do
         config = ActiveModelSerializers.config
         old_config = config.dup
         begin
@@ -24,7 +24,7 @@ module ActiveModel
         end
       end
 
-      def test_default_adapter
+      test 'default_adapter' do
         assert_equal :attributes, ActiveModelSerializers.config.adapter
       end
     end

--- a/test/serializers/fieldset_test.rb
+++ b/test/serializers/fieldset_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class FieldsetTest < ActiveSupport::TestCase
-      def test_fieldset_with_hash
+      test 'fieldset_with_hash' do
         fieldset = ActiveModel::Serializer::Fieldset.new('post' => %w(id title), 'comment' => ['body'])
         expected = { post: [:id, :title], comment: [:body] }
 

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -10,7 +10,7 @@ module ActiveModel
                          articles: [Post.new(id: 3, title: 'AMS')])
       end
 
-      def test_meta_is_present_with_root
+      test 'meta_is_present_with_root' do
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json,
@@ -29,7 +29,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_is_not_included_when_blank
+      test 'meta_is_not_included_when_blank' do
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json,
@@ -45,7 +45,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_is_not_included_when_empty_string
+      test 'meta_is_not_included_when_empty_string' do
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json,
@@ -61,7 +61,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_is_not_included_when_root_is_missing
+      test 'meta_is_not_included_when_root_is_missing' do
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :attributes,
@@ -75,7 +75,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_key_is_used
+      test 'meta_key_is_used' do
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json,
@@ -95,7 +95,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_key_is_not_used_with_json_api
+      test 'meta_key_is_not_used_with_json_api' do
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
@@ -114,7 +114,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_key_is_not_present_when_empty_hash_with_json_api
+      test 'meta_key_is_not_present_when_empty_hash_with_json_api' do
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
@@ -131,7 +131,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_key_is_not_present_when_empty_string_with_json_api
+      test 'meta_key_is_not_present_when_empty_string_with_json_api' do
         actual = ActiveModelSerializers::SerializableResource.new(
           @blog,
           adapter: :json_api,
@@ -148,7 +148,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_is_not_present_on_arrays_without_root
+      test 'meta_is_not_present_on_arrays_without_root' do
         actual = ActiveModelSerializers::SerializableResource.new(
           [@blog],
           adapter: :attributes,
@@ -170,7 +170,7 @@ module ActiveModel
         assert_equal(expected, actual)
       end
 
-      def test_meta_is_present_on_arrays_with_root
+      test 'meta_is_present_on_arrays_with_root' do
         actual = ActiveModelSerializers::SerializableResource.new(
           [@blog],
           adapter: :json,

--- a/test/serializers/options_test.rb
+++ b/test/serializers/options_test.rb
@@ -7,12 +7,12 @@ module ActiveModel
         @profile = Profile.new(name: 'Name 1', description: 'Description 1')
       end
 
-      def test_options_are_accessible
+      test 'options_are_accessible' do
         @profile_serializer = ProfileSerializer.new(@profile, my_options: :accessible)
         assert @profile_serializer.arguments_passed_in?
       end
 
-      def test_no_option_is_passed_in
+      test 'no_option_is_passed_in' do
         @profile_serializer = ProfileSerializer.new(@profile)
         refute @profile_serializer.arguments_passed_in?
       end

--- a/test/serializers/read_attribute_for_serialization_test.rb
+++ b/test/serializers/read_attribute_for_serialization_test.rb
@@ -21,7 +21,7 @@ module ActiveModel
         attributes :name
       end
 
-      def test_child_serializer_calls_dynamic_method_in_parent_serializer
+      test 'child_serializer_calls_dynamic_method_in_parent_serializer' do
         parent = ParentSerializer.new(Parent.new(id: 5))
         child  = ChildSerializer.new(Child.new(id: 6, name: 'Child'))
         assert_equal 5, parent.read_attribute_for_serialization(:$id)
@@ -50,7 +50,7 @@ module ActiveModel
         end
       end
 
-      def test_child_serializer_with_error_attribute
+      test 'child_serializer_with_error_attribute' do
         error = ErrorResponse.new(error: 'i have an error')
         serializer = ErrorResponseSerializer.new(error)
         serializer_with_super = ErrorResponseWithSuperSerializer.new(error)
@@ -58,7 +58,7 @@ module ActiveModel
         assert_equal false, serializer_with_super.read_attribute_for_serialization(:status)
       end
 
-      def test_child_serializer_with_errors
+      test 'child_serializer_with_errors' do
         error = ErrorResponse.new
         error.errors.add(:invalid, 'i am not valid')
         serializer = ErrorResponseSerializer.new(error)
@@ -67,7 +67,7 @@ module ActiveModel
         assert_equal false, serializer_with_super.read_attribute_for_serialization(:status)
       end
 
-      def test_child_serializer_no_error_attribute_or_errors
+      test 'child_serializer_no_error_attribute_or_errors' do
         error = ErrorResponse.new
         serializer = ErrorResponseSerializer.new(error)
         serializer_with_super = ErrorResponseWithSuperSerializer.new(error)

--- a/test/serializers/root_test.rb
+++ b/test/serializers/root_test.rb
@@ -7,12 +7,12 @@ module ActiveModel
         @virtual_value = VirtualValue.new(id: 1)
       end
 
-      def test_overwrite_root
+      test 'overwrite_root' do
         serializer = VirtualValueSerializer.new(@virtual_value, root: 'smth')
         assert_equal('smth', serializer.json_key)
       end
 
-      def test_underscore_in_root
+      test 'underscore_in_root' do
         serializer = VirtualValueSerializer.new(@virtual_value)
         assert_equal('virtual_value', serializer.json_key)
       end

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -13,12 +13,12 @@ module ActiveModel
           ActiveModelSerializers.config.collection_serializer = @previous_collection_serializer
         end
 
-        def test_serializer_for_array
+        test 'serializer_for_array' do
           serializer = ActiveModel::Serializer.serializer_for(@array)
           assert_equal ActiveModelSerializers.config.collection_serializer, serializer
         end
 
-        def test_overwritten_serializer_for_array
+        test 'overwritten_serializer_for_array' do
           new_collection_serializer = Class.new
           ActiveModelSerializers.config.collection_serializer = new_collection_serializer
           serializer = ActiveModel::Serializer.serializer_for(@array)
@@ -57,59 +57,59 @@ module ActiveModel
           @tweet = Tweet.new
         end
 
-        def test_serializer_for_non_ams_serializer
+        test 'serializer_for_non_ams_serializer' do
           serializer = ActiveModel::Serializer.serializer_for(@tweet)
           assert_equal nil, serializer
         end
 
-        def test_serializer_for_existing_serializer
+        test 'serializer_for_existing_serializer' do
           serializer = ActiveModel::Serializer.serializer_for(@profile)
           assert_equal ProfileSerializer, serializer
         end
 
-        def test_serializer_for_existing_serializer_with_lookup_disabled
+        test 'serializer_for_existing_serializer_with_lookup_disabled' do
           serializer = with_serializer_lookup_disabled do
             ActiveModel::Serializer.serializer_for(@profile)
           end
           assert_equal nil, serializer
         end
 
-        def test_serializer_for_not_existing_serializer
+        test 'serializer_for_not_existing_serializer' do
           serializer = ActiveModel::Serializer.serializer_for(@model)
           assert_equal nil, serializer
         end
 
-        def test_serializer_inherited_serializer
+        test 'serializer_inherited_serializer' do
           serializer = ActiveModel::Serializer.serializer_for(@my_profile)
           assert_equal ProfileSerializer, serializer
         end
 
-        def test_serializer_inherited_serializer_with_lookup_disabled
+        test 'serializer_inherited_serializer_with_lookup_disabled' do
           serializer = with_serializer_lookup_disabled do
             ActiveModel::Serializer.serializer_for(@my_profile)
           end
           assert_equal nil, serializer
         end
 
-        def test_serializer_custom_serializer
+        test 'serializer_custom_serializer' do
           serializer = ActiveModel::Serializer.serializer_for(@custom_profile)
           assert_equal ProfileSerializer, serializer
         end
 
-        def test_serializer_custom_serializer_with_lookup_disabled
+        test 'serializer_custom_serializer_with_lookup_disabled' do
           serializer = with_serializer_lookup_disabled do
             ActiveModel::Serializer.serializer_for(@custom_profile)
           end
           assert_equal ProfileSerializer, serializer
         end
 
-        def test_serializer_for_namespaced_resource
+        test 'serializer_for_namespaced_resource' do
           post = ResourceNamespace::Post.new
           serializer = ActiveModel::Serializer.serializer_for(post)
           assert_equal ResourceNamespace::PostSerializer, serializer
         end
 
-        def test_serializer_for_namespaced_resource_with_lookup_disabled
+        test 'serializer_for_namespaced_resource_with_lookup_disabled' do
           post = ResourceNamespace::Post.new
           serializer = with_serializer_lookup_disabled do
             ActiveModel::Serializer.serializer_for(post)
@@ -117,13 +117,13 @@ module ActiveModel
           assert_equal nil, serializer
         end
 
-        def test_serializer_for_nested_resource
+        test 'serializer_for_nested_resource' do
           comment = ResourceNamespace::Comment.new
           serializer = ResourceNamespace::PostSerializer.serializer_for(comment)
           assert_equal ResourceNamespace::PostSerializer::CommentSerializer, serializer
         end
 
-        def test_serializer_for_nested_resource_with_lookup_disabled
+        test 'serializer_for_nested_resource_with_lookup_disabled' do
           comment = ResourceNamespace::Comment.new
           serializer = with_serializer_lookup_disabled do
             ResourceNamespace::PostSerializer.serializer_for(comment)


### PR DESCRIPTION
#### Purpose

Using morre proper test naming

#### Changes

find `def test_(.+)$`
replace with `test '$1' do`

also, replace
```ruby
def my_method

ensure

end
```
with
```ruby
test 'my_method'
  begin
  ensure
  end
end
```

#### Caveats

ensure can no longer be used by itself, as test blocks aren't methods

#### Related GitHub issues

#1850 

#### Additional helpful information

Hopefully this will encourage future contributions to use the same test style

