### PR TITLE
Infer serializer from collection name for empty results root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
 Fixes:
 
 - [#1833](https://github.com/rails-api/active_model_serializers/pull/1833) Remove relationship links if they are null (@groyoh)
+- [#1867](https://github.com/rails-api/active_model_serializers/pull/1867) Infer collection root preferably from serializer matching collection name, if a named collection. (@mchitten)
 
 Misc:
 

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -23,6 +23,21 @@ module ActiveModel
         resource
       end
 
+      def build_named_collection_with_matching_serializer(*resource)
+        serialized_resource = Class.new(::Model)
+        serializer = Class.new(ActiveModel::Serializer) do
+          def json_key
+            'resources'
+          end
+        end
+
+        Object.const_set(:SerializedResource, serialized_resource)
+        Object.const_set(:SerializedResourceSerializer, serializer)
+
+        resource.define_singleton_method(:name) { 'SerializedResource' }
+        resource
+      end
+
       def test_has_object_reader_serializer_interface
         assert_equal @serializer.object, @resource
       end
@@ -74,6 +89,11 @@ module ActiveModel
       def test_json_key_with_resource_with_name_and_no_serializers
         serializer = collection_serializer.new(build_named_collection)
         assert_equal 'me_resources', serializer.json_key
+      end
+
+      def test_json_key_with_resource_with_name_and_serializer
+        serializer = collection_serializer.new(build_named_collection_with_matching_serializer)
+        assert_equal 'resources', serializer.json_key
       end
 
       def test_json_key_with_resource_with_nil_name_and_no_serializers


### PR DESCRIPTION
#### Purpose

In the event that a collection object is empty and has a name, it's possible to determine the serializer from the name of the object. This may not always be the case -- this could raise `NameError` for a class that does not exist, or `NoSerializerError` if its matching serializer does not exist, in which case this falls back to the original `name.underscore` implementation.
#### Changes

Updates `CollectionSerializer` to try to determine serializer from object name.
#### Related GitHub issues

Possibly(?) a fix for #1745.
