### PR TITLE
Fix doc for meta_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The above usage of `:meta` will produce the following:
 If you would like to change the meta key name you can use the `:meta_key` option:
 
 ```ruby
-render json: @posts, serializer: CustomArraySerializer, meta_object: {total: 10}, meta_key: 'meta_object'
+render json: @posts, serializer: CustomArraySerializer, meta_object: { total: 10 }, meta_key: :meta_object
 ```
 
 The above usage of `:meta_key` will produce the following:


### PR DESCRIPTION
#### Purpose

In the documentation, the example for changing the meta key name is incorrect.  The example has a string, but only a symbol will work.

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/issues/1868
https://github.com/rails-api/active_model_serializers/issues/1328




