### PR TITLE
Use ActiveSupport::Cache.expand_cache_key for cache key expansions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Fixes:
 
 Misc:
 
+- [#1878](https://github.com/rails-api/active_model_serializers/pull/1878) Cache key generation for serializers now uses `ActiveSupport::Cache.expand_cache_key` instead of `Enumerable#join` by default and is also overridable. This change should be backward-compatible. (@markiz)
+
 ### [v0.10.2 (2016-07-05)](https://github.com/rails-api/active_model_serializers/compare/v0.10.1...v0.10.2)
 
 Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Fixes:
 
 Misc:
 
-- [#1878](https://github.com/rails-api/active_model_serializers/pull/1878) Cache key generation for serializers now uses `ActiveSupport::Cache.expand_cache_key` instead of `Enumerable#join` by default and is also overridable. This change should be backward-compatible. (@markiz)
+- [#1878](https://github.com/rails-api/active_model_serializers/pull/1878) Cache key generation for serializers now uses `ActiveSupport::Cache.expand_cache_key` instead of `Array#join` by default and is also overridable. This change should be backward-compatible. (@markiz)
 
 ### [v0.10.2 (2016-07-05)](https://github.com/rails-api/active_model_serializers/compare/v0.10.1...v0.10.2)
 

--- a/lib/active_model/serializer/caching.rb
+++ b/lib/active_model/serializer/caching.rb
@@ -263,7 +263,11 @@ module ActiveModel
         parts << object_cache_key
         parts << adapter_instance.cache_key
         parts << serializer_class._cache_digest unless serializer_class._skip_digest?
-        @cache_key = parts.join('/')
+        @cache_key = expand_cache_key(parts)
+      end
+
+      def expand_cache_key(parts)
+        ActiveSupport::Cache.expand_cache_key(parts)
       end
 
       # Use object's cache_key if available, else derive a key from the object


### PR DESCRIPTION
#### Purpose

Allows using non-primitive objects as object cache key. 
For example, we might want to return an array of objects that define `#cache_key` as our serialized object's `#cache_key`

#### Changes

`join("/")` changed to `ActiveSupport::Cache.expand_cache_key`

#### Caveats

Dependency on ActiveSupport (which we already have)

#### Additional helpful information

The test is a bit contrived, sorry about that.
`#expand_cache_key` can be redefined to change the actual implementation.

Previous version of AMS did use `ActiveSupport::Cache.expand_cache_key`