### PR TITLE
ActiveModelSerializers::Model successor initialized with string keys fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features:
 Fixes:
 
 - [#1833](https://github.com/rails-api/active_model_serializers/pull/1833) Remove relationship links if they are null (@groyoh)
+- [#1881](https://github.com/rails-api/active_model_serializers/pull/1881) ActiveModelSerializers::Model correctly works with string keys (@yevhene)
 
 Misc:
 

--- a/lib/active_model_serializers/model.rb
+++ b/lib/active_model_serializers/model.rb
@@ -9,7 +9,7 @@ module ActiveModelSerializers
     attr_reader :attributes, :errors
 
     def initialize(attributes = {})
-      @attributes = attributes
+      @attributes = attributes && attributes.symbolize_keys
       @errors = ActiveModel::Errors.new(self)
       super
     end

--- a/test/active_model_serializers/model_test.rb
+++ b/test/active_model_serializers/model_test.rb
@@ -7,5 +7,16 @@ module ActiveModelSerializers
     def setup
       @resource = ActiveModelSerializers::Model.new
     end
+
+    def test_initialization_with_string_keys
+      klass = Class.new(ActiveModelSerializers::Model) do
+        attr_accessor :key
+      end
+      value = 'value'
+
+      model_instance = klass.new('key' => value)
+
+      assert_equal model_instance.read_attribute_for_serialization(:key), value
+    end
   end
 end


### PR DESCRIPTION
#### Purpose
Fixing strange behavior of ActiveModelSerializers::Model successor when initialized with string keys hash

#### Changes
ActiveModelSerializers::Model is stringify keys on initialization

#### Additional helpful information
Example:
```ruby
class User < ActiveModelSerializers::Model
  attr_accessor :name
end

class UserSerializer < ActiveModel::Serializer
  attribute :name
end

resource = User.new('key' => value)
serializer = UserSerializer.new(resource)
serializer.to_json #=> '{"name": null}'
```
