### PR TITLE
Add an ability to manually include relationships

### DIFF
--- a/lib/active_model/serializer/associations.rb
+++ b/lib/active_model/serializer/associations.rb
@@ -90,7 +90,7 @@ module ActiveModel
           self.class._reflections.values.each do |reflection|
             next if reflection.excluded?(self)
             key = reflection.options.fetch(:key, reflection.name)
-            next unless include_directive.key?(key)
+            next if !include_directive.key?(key) && !reflection.options[:included]
             y.yield reflection.build_association(self, instance_options)
           end
         end


### PR DESCRIPTION
The option allows to explicitly include a certain relationship using the options object:

```ruby
has_one :job, included: true
```

Before this commit, there was no ability to do that except via the query: `/invoices?include=job`.

The PR has no tests, docs, etc., but I going to include that if the PR has a chance to be merged. WDYT?