### PR TITLE
Updated ember integration guide to use the proper renderer

### DIFF
--- a/docs/integrations/ember-and-json-api.md
+++ b/docs/integrations/ember-and-json-api.md
@@ -117,7 +117,7 @@ will generate the path `/posts/{postId}?include='comments'`
 
 So then in your controller, you'll want to be sure to have something like:
 ```ruby
-render json: @post, include: params[:include]
+render jsonapi: @post, include: params[:include]
 ```
 
 If you want to use `include` on a collection, you'd write something like this:

--- a/docs/integrations/ember-and-json-api.md
+++ b/docs/integrations/ember-and-json-api.md
@@ -42,7 +42,9 @@ Lastly, in order to properly handle JSON API responses, we need to register a JS
 
 ```ruby
 # config/initializers/active_model_serializers.rb
-require 'active_model_serializers/register_jsonapi_renderer'
+ActiveSupport.on_load(:action_controller) do
+  require 'active_model_serializers/register_jsonapi_renderer'
+end
 ```
 
 ### Adapter Changes


### PR DESCRIPTION
#### Purpose

Update the guide to use the proper renderer
#### Changes

Uses the `jsonapi` rendered that is registered in [register_jsonapi_renderer](https://github.com/rails-api/active_model_serializers/blob/49ee823a5311799b3e96b0384ca4fd7a9cf39a34/lib/active_model_serializers/register_jsonapi_renderer.rb)


