### PR TITLE
Add link to info on setting polymorphic serializers

### DIFF
--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -140,7 +140,7 @@ class PictureSerializer < ActiveModel::Serializer
 end
 ```
 
-For more context, see the [tests](../../test/adapter/polymorphic_test.rb) for each adapter.
+You can specify the serializers by [overriding serializer_for](serializers.md#overriding-association-serializer-lookup). For more context about polymorphic relationships, see the [tests](../../test/adapter/polymorphic_test.rb) for each adapter.
 
 ### Caching
 


### PR DESCRIPTION
#### Purpose

Add a reference to show how to set sterilizers on polymorphic relationships.

#### Changes

Add a single sentence with a link that points to a header further down the page.

#### Additional helpful information

While this same document provides details on how to override the serializer_for, not all users will realize this could be used to set the sterilizers for polymorphic relationships.  This change just adds a link to that documentation and makes that point obvious.