### PR TITLE
Deprecate ActiveModelSerializers::Model

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -59,4 +59,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'grape', ['>= 0.13', '< 1.0']
   spec.add_development_dependency 'json_schema'
   spec.add_development_dependency 'rake', ['>= 10.0', '< 12.0']
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'm'
 end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -191,10 +191,24 @@ module ActiveModel
     end
 
     def read_attribute_for_serialization(attr)
+      # Start by favoring serializers method override
       if respond_to?(attr)
         send(attr)
       else
-        object.read_attribute_for_serialization(attr)
+        # Otherwise, check read_attribute_for_serialization
+        if object.respond_to?(:read_attribute_for_serialization)
+          object.read_attribute_for_serialization(attr)
+        else
+          # Fall back to object property/method
+          if object.respond_to?(attr)
+            object.send(attr)
+          else
+            # Special logic for hashes
+            if object.is_a?(Hash)
+              object[attr] || object[attr.to_s]
+            end
+          end
+        end
       end
     end
 

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -3,6 +3,11 @@ require 'active_support'
 require 'active_support/core_ext/object/with_options'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/json'
+
+require 'active_model_serializers/model_mixin'
+
+require 'pry-byebug'
+
 module ActiveModelSerializers
   extend ActiveSupport::Autoload
   autoload :Model

--- a/lib/active_model_serializers/model_mixin.rb
+++ b/lib/active_model_serializers/model_mixin.rb
@@ -1,0 +1,57 @@
+# ActiveModelSerializers::Model is a convenient
+# serializable class to inherit from when making
+# serializable non-activerecord objects.
+module ActiveModelSerializers
+  module ModelMixin
+    def self.included(klass)
+      klass.class_eval do
+        include ActiveModel::Model
+        include ActiveModel::Serializers::JSON
+
+        def read_attribute_for_serialization(key)
+          if key == :id || key == 'id'
+            send(key)
+          else
+            if is_a?(ActiveModelSerializers::Model)
+              # Support legacy behavior
+              attributes[key] || (send(key) if respond_to?(key))
+            else
+              send(key) if respond_to?(key)
+            end
+          end
+        end
+      end
+    end
+
+    #def id
+      #self.class.name.downcase
+    #end
+
+    #def cache_key
+    #end
+
+    #def errors
+      #@errors ||= ActiveModel::Errors.new(self)
+    #end
+
+    #def updated_at
+    #end
+
+    # This is just to make lint pass
+    # We shouldnt have this...
+    #def attributes
+      #{}
+    #end
+
+    # The following methods are needed to be minimally implemented for ActiveModel::Errors
+    # :nocov:
+    #def self.human_attribute_name(attr, _options = {})
+      #attr
+    #end
+
+    #def self.lookup_ancestors
+      #[self]
+    #end
+    # :nocov:
+  end
+end

--- a/test/action_controller/json_api/fields_test.rb
+++ b/test/action_controller/json_api/fields_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-
+require 'pry-byebug'
 module ActionController
   module Serialization
     class JsonApi

--- a/test/active_model_serializers/model_mixin_test.rb
+++ b/test/active_model_serializers/model_mixin_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+module ActiveModelSerializers
+  class ModelMixinTest < ActiveSupport::TestCase
+    def setup
+      @klass = Class.new do
+        #include ActiveModelSerializers::ModelMixin
+        attr_accessor :key, :id
+        def self.name
+          'TestModel'
+        end
+      end
+    end
+
+    def test_poro_serialize
+      serializer = Class.new(ActiveModel::Serializer) do
+        attributes :key
+      end
+      model_instance = @klass.new
+      model_instance.key = 'value'
+
+      json = serializer.new(model_instance, {}).as_json
+      assert_equal({ key: 'value' }, json)
+    end
+  end
+end

--- a/test/active_model_serializers/model_test.rb
+++ b/test/active_model_serializers/model_test.rb
@@ -6,17 +6,73 @@ module ActiveModelSerializers
 
     def setup
       @resource = ActiveModelSerializers::Model.new
+
+      @klass = Class.new(ActiveModelSerializers::Model) do
+        attr_accessor :key
+
+        def self.name
+          'TestModel'
+        end
+      end
     end
 
     def test_initialization_with_string_keys
-      klass = Class.new(ActiveModelSerializers::Model) do
-        attr_accessor :key
+      model_instance = @klass.new('key' => 'value')
+
+      assert_equal 'value', model_instance.read_attribute_for_serialization(:key)
+    end
+
+    def test_direct_accessor_assignment
+      model_instance = @klass.new
+      model_instance.key = 'value'
+      assert_equal 'value', model_instance.read_attribute_for_serialization(:key)
+    end
+
+    def test_fetch_id_from_attributes
+      model_instance = @klass.new(id: 1)
+      assert_equal 1, model_instance.id
+    end
+
+    # Note: 'id' defined by attr_accessor
+    # is mutually exclusive from default id behavior
+    # IOW, defined attr_accessors 'win'
+    def test_id_from_accessor
+      @klass.class_eval do
+        attr_accessor :id
       end
-      value = 'value'
+      model_instance = @klass.new
+      model_instance.id = 1
+      assert_equal 1, model_instance.id
+    end
 
-      model_instance = klass.new('key' => value)
+    # not needed, out superclass
+    #def test_id_as_defined_method
+      #@klass.class_eval do
+        #def id
+          #@id
+        #end
 
-      assert_equal model_instance.read_attribute_for_serialization(:key), value
+        #def id=(val)
+          #@id = val
+        #end
+      #end
+
+      #model_instance = @klass.new
+      #model_instance.id = 1
+      #assert_equal 1, model_instance.id
+    #end
+
+    # Note: This does not work if @klass defines
+    # attr_accessor :id
+    def test_default_id
+      model_instance = @klass.new
+      assert_equal 'testmodel', model_instance.id
+    end
+
+    def test_errors
+      model_instance = @klass.new
+      model_instance.errors.add(:key, 'is blank')
+      assert_equal true, model_instance.errors[:key].present?
     end
   end
 end

--- a/test/adapter/json_api/resource_identifier_test.rb
+++ b/test/adapter/json_api/resource_identifier_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+require 'pry-byebug'
+
 module ActiveModelSerializers
   module Adapter
     class JsonApi

--- a/test/serializers/read_attribute_for_serialization_test.rb
+++ b/test/serializers/read_attribute_for_serialization_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'pry-byebug'
 
 module ActiveModel
   class Serializer
@@ -51,7 +52,8 @@ module ActiveModel
       end
 
       def test_child_serializer_with_error_attribute
-        error = ErrorResponse.new(error: 'i have an error')
+        error = ErrorResponse.new
+        error.error = 'i have an error'
         serializer = ErrorResponseSerializer.new(error)
         serializer_with_super = ErrorResponseWithSuperSerializer.new(error)
         assert_equal false, serializer.read_attribute_for_serialization(:status)


### PR DESCRIPTION
#### Purpose

Deprecate `ActiveModelSerializers::Model`. We don't need it. We can easily support PORO serialization without this class, whether it be a superclass or rewritten as a mixin.

[The docs make it seem like we're providing the ability to do PORO serialization](https://github.com/rails-api/active_model_serializers/blob/master/docs/howto/serialize_poro.md). We're actually providing more functionality than we need to do this.

Minimum requirement we need:

```ruby
alias :read_attribute_for_serialization, :send
```

But this ActiveModelSerializers::Model provides extra stuff like

```ruby
post = Post.new(title: 'my title')
post.title # 'my title'
post.attributes # { title: 'my title' }
post.as_json # { title: 'my title' }
```

So these are really solving two problems:

* Ability to make an object serializable by AMS
* A class that provides ActiveModel objects (constructor params, `#attributes`, etc).

While the latter is nice to have in tests and such, it's not really required by this gem AFAIK. I'd say it should be out of scope, actually, and better handled by a separate library like [Virtus](https://github.com/solnic/virtus).

In other words, we're linting that we quack like more of a duck than we really need to quack like.

This PR attempts to allow serializing POROs **out of the box, with no extra superclass or mixin required**.

#### Changes

This PR is a WIP but I think the meat of the change is altering `read_attribute_for_serialization`:

```ruby
    # active_model/serializer.rb
   # obv refactor this
    def read_attribute_for_serialization(attr)
      # Start by favoring serializers method override
      if respond_to?(attr)
        send(attr)
      else
        # Otherwise, check read_attribute_for_serialization
        if object.respond_to?(:read_attribute_for_serialization)
          object.read_attribute_for_serialization(attr)
        else
          # Fall back to object property/method
          if object.respond_to?(attr)
            object.send(attr)
          else
            # Special logic for hashes
            if object.is_a?(Hash)
              object[attr] || object[attr.to_s]
            end
          end
        end
      end
    end
```

You can now serialize any PORO, including ruby hashes, with no extra code.

The other changes in this PR are mostly related to reorganizing `ActiveModelSerializers::Model` (this intended to convert it to a mixin). I suggest we end up not making these changes and instead write a deprecation any time `ActiveModelSerializer::Model` is extended or initialized.

#### Caveats

One issue is with the current tests, which currently use `ActiveModelSerializer::Model` for POROs. In particular heavy use of the constructor. We would probably want to rearrange the tests so they keep this behavior but inherit from some internal test class instead.

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/issues/1877
https://github.com/rails-api/active_model_serializers/issues/1283
https://github.com/rails-api/active_model_serializers/pull/1873

#### Additional helpful information

This code is **not ready to be merged**. It's what I have working and available for discussion. If we can reach consensus I'll flesh it out.