### PR TITLE
Ensure generator picks up ApplicationSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 Fixes:
 
 - [#1887](https://github.com/rails-api/active_model_serializers/pull/1887) Make the comment reflect what the function does (@johnnymo87)
+- [#1890](https://github.com/rails-api/active_model_serializers/issues/1890) Ensure generator inherits from ApplicationSerializer when available (@richmolj)
 
 Features:
 

--- a/lib/generators/rails/serializer_generator.rb
+++ b/lib/generators/rails/serializer_generator.rb
@@ -25,7 +25,7 @@ module Rails
       def parent_class_name
         if options[:parent]
           options[:parent]
-        elsif defined?(::ApplicationSerializer)
+        elsif 'ApplicationSerializer'.safe_constantize
           'ApplicationSerializer'
         else
           'ActiveModel::Serializer'


### PR DESCRIPTION
#### Purpose

Fixes https://github.com/rails-api/active_model_serializers/issues/1890

#### Changes

Look at filesystem instead of using `defined?`

#### Caveats

If the file was there but the class was not named correctly, I think you'd get an unfriendly error.

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/issues/1890

#### Additional helpful information

ApplicationSerializer could exist, but not be loaded. So, we check
existence by looking at the filesystem instead of defined?.