### PR TITLE
Add helpful testing gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ group :test do
   gem 'sqlite3',                          platform: (@windows_platforms + [:ruby])
   gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
   gem 'codeclimate-test-reporter', require: false
+  gem 'm', '~> 1.5'
+  gem 'pry', '~> 0.10'
+  gem 'pry-byebug', '~> 3.4', platform: :ruby
 end
 
 group :development, :test do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ rescue LoadError
   STDERR.puts 'Running without SimpleCov'
 end
 
+require 'pry'
 require 'timecop'
 require 'rails'
 require 'action_controller'


### PR DESCRIPTION
Adds gems [m](https://github.com/qrush/m) (run minitest by line numbers like rspec) and [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug) (for binding.pry support).

Addresses https://github.com/rails-api/active_model_serializers/pull/1911#discussion_r77548416