### PR TITLE
add bm_adapter

### DIFF
--- a/test/benchmark/bm_adapter.rb
+++ b/test/benchmark/bm_adapter.rb
@@ -1,0 +1,38 @@
+require_relative './benchmarking_support'
+require_relative './app'
+
+time = 10
+disable_gc = true
+ActiveModelSerializers.config.key_transform = :unaltered
+has_many_relationships = (0..60).map do |i|
+  HasManyRelationship.new(id: i, body: 'ZOMG A HAS MANY RELATIONSHIP')
+end
+has_one_relationship = HasOneRelationship.new(
+  id: 42,
+  first_name: 'Joao',
+  last_name: 'Moura'
+)
+primary_resource = PrimaryResource.new(
+  id: 1337,
+  title: 'New PrimaryResource',
+  virtual_attribute: nil,
+  body: 'Body',
+  has_many_relationships: has_many_relationships,
+  has_one_relationship: has_one_relationship
+)
+serializer = PrimaryResourceSerializer.new(primary_resource)
+
+Benchmark.ams('attributes', time: time, disable_gc: disable_gc) do
+  attributes = ActiveModelSerializers::Adapter::Attributes.new(serializer)
+  attributes.as_json
+end
+
+Benchmark.ams('json_api', time: time, disable_gc: disable_gc) do
+  json_api = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
+  json_api.as_json
+end
+
+Benchmark.ams('json', time: time, disable_gc: disable_gc) do
+  json = ActiveModelSerializers::Adapter::Json.new(serializer)
+  json.as_json
+end


### PR DESCRIPTION
#### Purpose

Compores the different adapters
#### Changes

added bm_adapter.rb


```bash
$ bin/bench
attributes 1124.3438848105818/ips; 1784 objects
json_api 261.8025877761349/ips; 3873 objects
json 1071.236972223799/ips; 1839 objects
Benchmark results:
{
  "commit_hash": "1dc2b74",
  "version": "0.10.2",
  "rails_version": "4.2.4",
  "benchmark_run[environment]": "2.3.1p112",
  "runs": [
    {
      "benchmark_type[category]": "attributes",
      "benchmark_run[result][iterations_per_second]": 1124.344,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1784
    },
    {
      "benchmark_type[category]": "json_api",
      "benchmark_run[result][iterations_per_second]": 261.803,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 3873
    },
    {
      "benchmark_type[category]": "json",
      "benchmark_run[result][iterations_per_second]": 1071.237,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1839
    }
  ]
}
```

System:
![image](https://cloud.githubusercontent.com/assets/199018/18258741/8140c41a-73a9-11e6-938a-2404ed31a3ef.png)


ruby -v
```bash
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
```

The other benchmarks for reference:
```bash
camel 354.91746231137375/ips; 3653 objects
camel_lower 431.25456403665754/ips; 2622 objects
dash 2792.965163577614/ips; 770 objects
unaltered 7149615.074971388/ips; 1 objects
underscore 5023.107909424926/ips; 313 objects
Benchmark results:
{
  "commit_hash": "1dc2b74",
  "version": "0.10.2",
  "rails_version": "4.2.4",
  "benchmark_run[environment]": "2.3.1p112",
  "runs": [
    {
      "benchmark_type[category]": "camel",
      "benchmark_run[result][iterations_per_second]": 354.917,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 3653
    },
    {
      "benchmark_type[category]": "camel_lower",
      "benchmark_run[result][iterations_per_second]": 431.255,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 2622
    },
    {
      "benchmark_type[category]": "dash",
      "benchmark_run[result][iterations_per_second]": 2792.965,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 770
    },
    {
      "benchmark_type[category]": "unaltered",
      "benchmark_run[result][iterations_per_second]": 7149615.075,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1
    },
    {
      "benchmark_type[category]": "underscore",
      "benchmark_run[result][iterations_per_second]": 5023.108,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 313
    }
  ]
}

caching on: caching serializers: gc off 992.4002533974954/ips; 1270 objects
caching on: fragment caching serializers: gc off 969.5608152595304/ips; 1367 objects
caching on: non-caching serializers: gc off 1103.4800266979528/ips; 1219 objects
caching off: caching serializers: gc off 1031.1505750964488/ips; 1270 objects
caching off: fragment caching serializers: gc off 974.1763206821167/ips; 1367 objects
caching off: non-caching serializers: gc off 1107.8862969827758/ips; 1219 objects
Benchmark results:
{
  "commit_hash": "1dc2b74",
  "version": "0.10.2",
  "rails_version": "4.2.4",
  "benchmark_run[environment]": "2.3.1p112",
  "runs": [
    {
      "benchmark_type[category]": "caching on: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 992.4,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1270
    },
    {
      "benchmark_type[category]": "caching on: fragment caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 969.561,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1367
    },
    {
      "benchmark_type[category]": "caching on: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1103.48,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1219
    },
    {
      "benchmark_type[category]": "caching off: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1031.151,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1270
    },
    {
      "benchmark_type[category]": "caching off: fragment caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 974.176,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1367
    },
    {
      "benchmark_type[category]": "caching off: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1107.886,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1219
    }
  ]
}
```