### PR TITLE
Disable pagination links via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Features:
 - [#1791](https://github.com/rails-api/active_model_serializers/pull/1791) (@bf4, @youroff, @NullVoxPopuli)
   - Added `jsonapi_namespace_separator` config option.
 - [#1889](https://github.com/rails-api/active_model_serializers/pull/1889) Support key transformation for Attributes adapter (@iancanderson, @danbee)
+- [#1917](https://github.com/rails-api/active_model_serializers/pull/1917) Add `jsonapi_pagination_links_enabled` configuration option (@richmolj)
 
 Fixes:
 

--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -52,7 +52,8 @@ module ActiveModel
       # rubocop:enable Metrics/CyclomaticComplexity
 
       def paginated?
-        object.respond_to?(:current_page) &&
+        ActiveModelSerializers.config.jsonapi_pagination_links_enabled &&
+          object.respond_to?(:current_page) &&
           object.respond_to?(:total_pages) &&
           object.respond_to?(:size)
       end

--- a/lib/active_model/serializer/concerns/configuration.rb
+++ b/lib/active_model/serializer/concerns/configuration.rb
@@ -22,6 +22,7 @@ module ActiveModel
         config.default_includes = '*'
         config.adapter = :attributes
         config.key_transform = nil
+        config.jsonapi_pagination_links_enabled = true
         config.jsonapi_resource_type = :plural
         config.jsonapi_namespace_separator = '-'.freeze
         config.jsonapi_version = '1.0'

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -76,7 +76,7 @@ module ActiveModelSerializers
           }
         end
 
-        def expected_response_without_pagination_links
+        def expected_response_when_unpaginatable
           data
         end
 
@@ -84,6 +84,12 @@ module ActiveModelSerializers
           {}.tap do |hash|
             hash[:data] = data.values.flatten[2..3]
             hash.merge! links
+          end
+        end
+
+        def expected_response_without_pagination_links
+          {}.tap do |hash|
+            hash[:data] = data.values.flatten[2..3]
           end
         end
 
@@ -159,7 +165,7 @@ module ActiveModelSerializers
         def test_not_showing_pagination_links
           adapter = load_adapter(@array, mock_request)
 
-          assert_equal expected_response_without_pagination_links, adapter.serializable_hash
+          assert_equal expected_response_when_unpaginatable, adapter.serializable_hash
         end
 
         def test_raises_descriptive_error_when_serialization_context_unset
@@ -171,6 +177,15 @@ module ActiveModelSerializers
           exception_class = ActiveModelSerializers::Adapter::JsonApi::PaginationLinks::MissingSerializationContextError
           assert_equal exception_class, exception.class
           assert_match(/CollectionSerializer#paginated\?/, exception.message)
+        end
+
+        def test_pagination_links_not_present_when_disabled
+          ActiveModel::Serializer.config.jsonapi_pagination_links_enabled = false
+          adapter = load_adapter(using_kaminari, mock_request)
+
+          assert_equal expected_response_without_pagination_links, adapter.serializable_hash
+        ensure
+          ActiveModel::Serializer.config.jsonapi_pagination_links_enabled = true
         end
       end
     end


### PR DESCRIPTION
#### Purpose

Add configuration option to disable automatic jsonapi pagination links.

As my application does not make use of these links, I'd like to avoid the extra database query they cause (a `count` to get the total pages).

#### Changes

Adds `ActiveModel::Serializer.config.jsonapi_pagination_links_enabled`. Default is `true`.

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/pull/1596
https://github.com/rails-api/active_model_serializers/issues/1823