### PR TITLE
added active record benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'tzinfo-data', platforms: (@windows_platforms + [:jruby])
 
 group :bench do
   # https://github.com/rails-api/active_model_serializers/commit/cb4459580a6f4f37f629bf3185a5224c8624ca76
-  gem 'benchmark-ips', require: false, group: :development
+  gem 'benchmark-ips', '>= 2.7.2', require: false, group: :development
 end
 
 group :test do

--- a/test/benchmark/benchmarking_support.rb
+++ b/test/benchmark/benchmarking_support.rb
@@ -36,7 +36,7 @@ module Benchmark
         version: ::ActiveModel::Serializer::VERSION.to_s,
         rails_version: ::Rails.version.to_s,
         iterations_per_second: entry.ips,
-        iterations_per_second_standard_deviation: entry.stddev_percentage,
+        iterations_per_second_standard_deviation: entry.error_percentage,
         total_allocated_objects_per_iteration: count_total_allocated_objects(&block)
       }.to_json
 

--- a/test/benchmark/bm_active_record.rb
+++ b/test/benchmark/bm_active_record.rb
@@ -3,6 +3,8 @@ require_relative './app'
 
 time = 10
 disable_gc = true
+
+# This is to disable any key transform effects that may impact performance
 ActiveModelSerializers.config.key_transform = :unaltered
 
 ###########################################
@@ -10,6 +12,8 @@ ActiveModelSerializers.config.key_transform = :unaltered
 ##########################################
 require 'active_record'
 require 'sqlite3'
+
+# For debugging SQL output
 # ActiveRecord::Base.logger = Logger.new(STDERR)
 
 # Change the following to reflect your database settings
@@ -17,6 +21,9 @@ ActiveRecord::Base.establish_connection(
   adapter:  'sqlite3',
   database:     ':memory:'
 )
+
+# Don't show migration output when constructing fake db
+ActiveRecord::Migration.verbose = false
 
 ActiveRecord::Schema.define do
   create_table :authors, force: true do |t|
@@ -60,8 +67,6 @@ Profile.create(project_url: 'https://github.com/NullVoxPopuli', author: author)
     author: author
   )
 end
-
-puts ActiveModelSerializers::SerializableResource.new(author, adapter: :attributes, include: 'profile,posts').serializable_hash
 
 Benchmark.ams('AR: attributes', time: time, disable_gc: disable_gc) do
   ActiveModelSerializers::SerializableResource.new(author, adapter: :attributes, include: 'profile,posts').serializable_hash

--- a/test/benchmark/bm_active_record.rb
+++ b/test/benchmark/bm_active_record.rb
@@ -1,0 +1,76 @@
+require_relative './benchmarking_support'
+require_relative './app'
+
+time = 10
+disable_gc = true
+ActiveModelSerializers.config.key_transform = :unaltered
+
+###########################################
+# Setup active record models
+##########################################
+require 'active_record'
+require 'sqlite3'
+# ActiveRecord::Base.logger = Logger.new(STDERR)
+
+# Change the following to reflect your database settings
+ActiveRecord::Base.establish_connection(
+  adapter:  'sqlite3',
+  database:     ':memory:'
+)
+
+ActiveRecord::Schema.define do
+  create_table :authors, force: true do |t|
+    t.string :name
+  end
+
+  create_table :posts, force: true do |t|
+    t.text :body
+    t.string :title
+    t.references :author
+  end
+
+  create_table :profiles, force: true do |t|
+    t.text :project_url
+    t.text :bio
+    t.date :birthday
+    t.references :author
+  end
+end
+
+class Author < ActiveRecord::Base
+  has_one :profile
+  has_many :posts
+end
+
+class Post < ActiveRecord::Base
+  belongs_to :author
+end
+
+class Profile < ActiveRecord::Base
+  belongs_to :author
+end
+
+# Build out the data to serialize
+author = Author.create(name: 'Preston Sego')
+Profile.create(project_url: 'https://github.com/NullVoxPopuli', author: author)
+50.times do
+  Post.create(
+    body: 'something about how password restrictions are evil, and less secure, and with the math to prove it.',
+    title: 'Your bank is does not know how to do security',
+    author: author
+  )
+end
+
+puts ActiveModelSerializers::SerializableResource.new(author, adapter: :attributes, include: 'profile,posts').serializable_hash
+
+Benchmark.ams('AR: attributes', time: time, disable_gc: disable_gc) do
+  ActiveModelSerializers::SerializableResource.new(author, adapter: :attributes, include: 'profile,posts').serializable_hash
+end
+
+Benchmark.ams('AR: json', time: time, disable_gc: disable_gc) do
+  ActiveModelSerializers::SerializableResource.new(author, adapter: :json, include: 'profile,posts').serializable_hash
+end
+
+Benchmark.ams('AR: JSON API', time: time, disable_gc: disable_gc) do
+  ActiveModelSerializers::SerializableResource.new(author, adapter: :json_api, include: 'profile,posts').serializable_hash
+end

--- a/test/benchmark/bm_active_record.rb
+++ b/test/benchmark/bm_active_record.rb
@@ -18,8 +18,8 @@ require 'sqlite3'
 
 # Change the following to reflect your database settings
 ActiveRecord::Base.establish_connection(
-  adapter:  'sqlite3',
-  database:     ':memory:'
+  adapter: 'sqlite3',
+  database: ':memory:'
 )
 
 # Don't show migration output when constructing fake db


### PR DESCRIPTION
#### Purpose

To show how the different adapters affect ActiveRecord

```
AR: attributes 15277.978149616774/ips; 97 objects
AR: json 17804.33171514443/ips; 97 objects
AR: JSON API 17274.89231241766/ips; 97 objects
Benchmark results:
{
  "commit_hash": "11bd778",
  "version": "0.10.2",
  "rails_version": "4.2.7.1",
  "benchmark_run[environment]": "2.3.0p0",
  "runs": [
    {
      "benchmark_type[category]": "AR: attributes",
      "benchmark_run[result][iterations_per_second]": 15277.978,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 97
    },
    {
      "benchmark_type[category]": "AR: json",
      "benchmark_run[result][iterations_per_second]": 17804.332,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 97
    },
    {
      "benchmark_type[category]": "AR: JSON API",
      "benchmark_run[result][iterations_per_second]": 17274.892,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 97
    }
  ]
}

```

#### Changes

Adds active record benchmark file.

#### Caveats

Uses in-memory sqlite database, so it's quite a bit faster than a real pg/mysql database would be.

@bf4, the fact that all tests have the same total allocated objects per iteration seems fishy to me. Any thoughts on that?