### PR TITLE
Make railties an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Fixes:
 
 - [#1887](https://github.com/rails-api/active_model_serializers/pull/1887) Make the comment reflect what the function does (@johnnymo87)
 - [#1890](https://github.com/rails-api/active_model_serializers/issues/1890) Ensure generator inherits from ApplicationSerializer when available (@richmolj)
+- [#1922](https://github.com/rails-api/active_model_serializers/pull/1922) Make railtie an optional dependency in runtime (@ggpasqualino)
 
 Features:
 

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # 'rack'
   # 'rack-test', '~> 0.6.2'
 
-  spec.add_runtime_dependency 'railties', rails_versions
+  spec.add_development_dependency 'railties', rails_versions
   # 'activesupport', rails_versions
   # 'actionpack', rails_versions
   # 'rake', '>= 0.8.7'


### PR DESCRIPTION
#### Purpose
Make railties an optional dependency in order to use active_model_serializers in non rails projects again.

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/1921


