### PR TITLE
Ensure valid jsonapi when blank relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Fixes:
 - [#1887](https://github.com/rails-api/active_model_serializers/pull/1887) Make the comment reflect what the function does (@johnnymo87)
 - [#1890](https://github.com/rails-api/active_model_serializers/issues/1890) Ensure generator inherits from ApplicationSerializer when available (@richmolj)
 - [#1922](https://github.com/rails-api/active_model_serializers/pull/1922) Make railtie an optional dependency in runtime (@ggpasqualino)
+- [#1930](https://github.com/rails-api/active_model_serializers/pull/1930) Ensure valid jsonapi when relationship has no links or data (@richmolj)
 
 Features:
 

--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -24,6 +24,7 @@ module ActiveModelSerializers
 
           meta = meta_for(association)
           hash[:meta] = meta if meta
+          hash[:meta] = {} if hash.empty?
 
           hash
         end

--- a/test/adapter/json_api/relationship_test.rb
+++ b/test/adapter/json_api/relationship_test.rb
@@ -54,7 +54,7 @@ module ActiveModelSerializers
         end
 
         def test_relationship_data_not_included
-          test_relationship({}, options: { include_data: false })
+          test_relationship({ meta: {} }, options: { include_data: false })
         end
 
         def test_relationship_simple_link


### PR DESCRIPTION
#### Purpose

If you specify include_data false, and do not have any links for this
relationship, we would output something like:

`{ relationships: { comments: {} } }`

This is not valid jsonapi. 

#### Changes

We will now render

`{ relationships: { comments: { meta: {} } } }`

#### Caveats

N/A

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/pull/1797

#### Additional helpful information

Relevant jsonapi spec: http://jsonapi.org/format/#document-resource-object-relationships