### PR TITLE
Add include_data :if_sideloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Features:
   - Added `jsonapi_namespace_separator` config option.
 - [#1889](https://github.com/rails-api/active_model_serializers/pull/1889) Support key transformation for Attributes adapter (@iancanderson, @danbee)
 - [#1917](https://github.com/rails-api/active_model_serializers/pull/1917) Add `jsonapi_pagination_links_enabled` configuration option (@richmolj)
+- [#1797](https://github.com/rails-api/active_model_serializers/pull/1797) Only include 'relationships' when sideloading (@richmolj)
 
 Fixes:
 

--- a/lib/active_model/serializer/concerns/associations.rb
+++ b/lib/active_model/serializer/concerns/associations.rb
@@ -83,7 +83,8 @@ module ActiveModel
       #   +default_include_directive+ config value when not provided)
       # @return [Enumerator<Association>]
       #
-      def associations(include_directive = ActiveModelSerializers.default_include_directive)
+      def associations(include_directive = ActiveModelSerializers.default_include_directive, include_slice = nil)
+        include_slice ||= include_directive
         return unless object
 
         Enumerator.new do |y|
@@ -91,7 +92,8 @@ module ActiveModel
             next if reflection.excluded?(self)
             key = reflection.options.fetch(:key, reflection.name)
             next unless include_directive.key?(key)
-            y.yield reflection.build_association(self, instance_options)
+
+            y.yield reflection.build_association(self, instance_options, include_slice)
           end
         end
       end

--- a/lib/active_model/serializer/concerns/configuration.rb
+++ b/lib/active_model/serializer/concerns/configuration.rb
@@ -30,6 +30,7 @@ module ActiveModel
         # Make JSON API top-level jsonapi member opt-in
         # ref: http://jsonapi.org/format/#document-top-level
         config.jsonapi_include_toplevel_object = false
+        config.include_data_default = true
 
         config.schema_path = 'test/support/schemas'
       end

--- a/test/adapter/json_api/include_data_if_sideloaded_test.rb
+++ b/test/adapter/json_api/include_data_if_sideloaded_test.rb
@@ -1,0 +1,166 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    module Adapter
+      class JsonApi
+        class IncludeParamTest < ActiveSupport::TestCase
+          IncludeParamAuthor = Class.new(::Model)
+
+          class CustomCommentLoader
+            def all
+              [{ foo: 'bar' }]
+            end
+          end
+
+          class TagSerializer < ActiveModel::Serializer
+            attributes :id, :name
+          end
+
+          class IncludeParamAuthorSerializer < ActiveModel::Serializer
+            class_attribute :comment_loader
+
+            has_many :tags, serializer: TagSerializer do
+              link :self, '//example.com/link_author/relationships/tags'
+              include_data :if_sideloaded
+            end
+
+            has_many :unlinked_tags, serializer: TagSerializer do
+              include_data :if_sideloaded
+            end
+
+            has_many :posts, serializer: PostWithTagsSerializer do
+              include_data :if_sideloaded
+            end
+            has_many :locations do
+              include_data :if_sideloaded
+            end
+            has_many :comments do
+              include_data :if_sideloaded
+              IncludeParamAuthorSerializer.comment_loader.all
+            end
+          end
+
+          def setup
+            IncludeParamAuthorSerializer.comment_loader = Class.new(CustomCommentLoader).new
+            @tag = Tag.new(id: 1337, name: 'mytag')
+            @author = IncludeParamAuthor.new(
+              id: 1337,
+              tags: [@tag]
+            )
+          end
+
+          def test_relationship_not_loaded_when_not_included
+            expected = {
+              links: {
+                self: '//example.com/link_author/relationships/tags'
+              }
+            }
+
+            @author.define_singleton_method(:read_attribute_for_serialization) do |attr|
+              fail 'should not be called' if attr == :tags
+              super(attr)
+            end
+
+            assert_relationship(:tags, expected)
+          end
+
+          def test_relationship_included
+            expected = {
+              data: [
+                {
+                  id: '1337',
+                  type: 'tags'
+                }
+              ],
+              links: {
+                self: '//example.com/link_author/relationships/tags'
+              }
+            }
+
+            assert_relationship(:tags, expected, include: :tags)
+          end
+
+          def test_sideloads_included
+            expected = [
+              {
+                id: '1337',
+                type: 'tags',
+                attributes: { name: 'mytag' }
+              }
+            ]
+            hash = result(include: :tags)
+            assert_equal(expected, hash[:included])
+          end
+
+          def test_nested_relationship
+            expected = {
+              data: [
+                {
+                  id: '1337',
+                  type: 'tags'
+                }
+              ],
+              links: {
+                self: '//example.com/link_author/relationships/tags'
+              }
+            }
+
+            expected_no_data = {
+              links: {
+                self: '//example.com/link_author/relationships/tags'
+              }
+            }
+
+            assert_relationship(:tags, expected, include: [:tags, { posts: :tags }])
+
+            @author.define_singleton_method(:read_attribute_for_serialization) do |attr|
+              fail 'should not be called' if attr == :tags
+              super(attr)
+            end
+
+            assert_relationship(:tags, expected_no_data, include: { posts: :tags })
+          end
+
+          def test_include_params_with_no_block
+            @author.define_singleton_method(:read_attribute_for_serialization) do |attr|
+              fail 'should not be called' if attr == :locations
+              super(attr)
+            end
+
+            expected = { meta: {} }
+
+            assert_relationship(:locations, expected)
+          end
+
+          def test_block_relationship
+            expected = {
+              data: [
+                { 'foo' => 'bar' }
+              ]
+            }
+
+            assert_relationship(:comments, expected, include: [:comments])
+          end
+
+          def test_node_not_included_when_no_link
+            expected = nil
+            assert_relationship(:unlinked_tags, expected)
+          end
+
+          private
+
+          def result(opts)
+            opts = { adapter: :json_api }.merge(opts)
+            serializable(@author, opts).serializable_hash
+          end
+
+          def assert_relationship(relationship_name, expected, opts = {})
+            hash = result(opts)
+            assert_equal(expected, hash[:data][:relationships][relationship_name])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Purpose

Currently, AMS will populate `relationships` even when said relationships are not part of the `include` directive. This is problematic, as it causes activerecord queries to fire to populate an unnecessary part of the payload.

#### Changes

This now adds only one new variable name, include_slice. This is the slice of the include directive hash being processed by the current serializer. All the changes to lib/active_model/serializer/associations.rb and lib/active_model_serializers/adapter/json_api.rb are just passing that slice around so we can access it when we finally decide whether or not to have the data key in the response. The changes to lib/active_model/serializer/reflection.rb access that variable to make the decision.

Users now opt-in to this pattern **using the current DSL**. The current DSL conditionally includes the `data` key in the response via `include_data true/false`:

```ruby
class PostSerializer < ActiveModel::Serializer
  has_many :comments do
    include_data false
  end
end
```

We now add another option `:if_sideloaded`. This means we only include the `data` key when the relationship is being sideloaded:

```ruby
class PostSerializer < ActiveModel::Serializer
  has_many :comments do
    include_data :if_sideloaded
  end
end
```

Instead of specifying this for every relationship in every serializer, users can make this the default:

```ruby
ActiveModelSerializers.config.include_data_default = :if_sideloaded
```

#### Caveats

* I believe there is broad consensus that `include_data_default` should be `:if_sideloaded` by default. However, this would break backwards compatibility, so I have avoiding doing so. If I can get consensus we are OK with the breaking change, I will make the update.

* There is an existing issue with AMS, that in order to figure out `links` we need to execute the block given to the relationship. This block may provide a custom way to fetch the data. This means if you have an association with an in-line block customizing that association's value, this PR doesn't really help you - the DB query is firing in any case. Fixing this issue is out of scope for this PR.

#### Related GitHub issues

* https://github.com/rails-api/active_model_serializers/pull/1797
* https://github.com/rails-api/active_model_serializers/pull/1720
* https://github.com/rails-api/active_model_serializers/issues/1555

#### Additional helpful information

* `:if_sideloaded` is the default behavior of [jsonapi-resources](https://github.com/cerebris/jsonapi-resources). In fact, it's the *only* supported behavior.

* Since this has been a source of confusion in the past, I'd like to point out AMS already supports `include_data true/false`. We are adding one more option, `:if_sideloaded`.

* This adds a variable `include_slice` to the jsonapi adapter. Why do we need the current slice instead of the whole directive? Because multiple entities can have the same relationship, e.g. `/blogs/?include=posts.tags,tags` should include both blog tags and post tags, but `/blogs/?include=posts.tags` should only include post tags. `include_slice` is the slice of the overall include directive relevant to the current serializer.

* `include_slice` is somewhat of an eyesore, but cannot go away without fundamentally refactoring the way adapters and serializers work.
