### PR TITLE
Update docs for JSONAPI relationship links

### DIFF
--- a/docs/howto/add_relationship_links.md
+++ b/docs/howto/add_relationship_links.md
@@ -37,7 +37,7 @@ class Api::V1::UserSerializer < ActiveModel::Serializer
 end
 ```
 
-This will resilt in (example is in jsonapi adapter):
+This will result in (example is in jsonapi adapter):
 ```json
 {
   "data": {
@@ -69,7 +69,7 @@ class Api::V1::UserSerializer < ActiveModel::Serializer
 end
 ```
 
-This will resilt in (example is in jsonapi adapter):
+This will result in (example is in jsonapi adapter):
 ```json
 {
   "data": {
@@ -104,12 +104,7 @@ class Api::V1::UserSerializer < ActiveModel::Serializer
 
   has_many :microposts, serializer: Api::V1::MicropostSerializer do
     link(:related) { api_v1_microposts_path(user_id: object.id) }
-  end
-
-  #this is needed to avoid n+1, gem core devs are working to remove this necessity
-  #more on: https://github.com/rails-api/active_model_serializers/issues/1325
-  def microposts
-    object.microposts.loaded ? object.microposts : object.microposts.none
+    include_data false
   end
 end
 ```
@@ -126,7 +121,6 @@ This will result in:
     },
     "relationships": {
       "microposts": {
-        "data": [],
         "links": {
           "related": "/api/v1/microposts?user_id=1"
         }


### PR DESCRIPTION
#### Purpose
Fixes small typos and updated the docs on relationship links for JSONAPI.

#### Changes
Removed the 'data' key in the serialized relationship. Including it according to the current docs leads to unexpected behavior when using it with libraries like Ember Data.


This [method](https://github.com/rails-api/active_model_serializers/blame/master/docs/howto/add_relationship_links.md#L111) returns an empty array if the relationship is not loaded even though they might exist. Passing an empty array as data tells clients that there are no existing relationships.

Instead data should not be sent at all so that the client uses the given nested resource link to fetch them.

#### Caveats


#### Related GitHub issues


#### Additional helpful information



