### PR TITLE
Fix ActiveRecord::Relation serializer when model has explicit serializer

### DIFF
--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -2,6 +2,7 @@ require 'rails/railtie'
 require 'action_controller'
 require 'action_controller/railtie'
 require 'action_controller/serialization'
+require 'active_record/relation_serialization'
 
 module ActiveModelSerializers
   class Railtie < Rails::Railtie
@@ -12,6 +13,12 @@ module ActiveModelSerializers
     initializer 'active_model_serializers.action_controller' do
       ActiveSupport.on_load(:action_controller) do
         include(::ActionController::Serialization)
+      end
+    end
+
+    initializer 'active_model_serializers.active_record_relation' do
+      ActiveSupport.on_load(:active_record) do
+        ActiveRecord::Relation.include ActiveRecord::RelationSerialization
       end
     end
 

--- a/lib/active_record/relation_serialization.rb
+++ b/lib/active_record/relation_serialization.rb
@@ -1,0 +1,7 @@
+module ActiveRecord
+  module RelationSerialization
+    def serializer_class
+      ActiveModelSerializers.config.collection_serializer
+    end
+  end
+end

--- a/test/active_record/relation_serialization_test.rb
+++ b/test/active_record/relation_serialization_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+module ActiveRecord
+  class RelationSerializationTest < ActiveSupport::TestCase
+    def test_relation_serializer_when_no_serializer_class
+      serializer = ActiveModel::Serializer.serializer_for(ARModels::Post.all)
+      assert_equal serializer, ActiveModelSerializers.config.collection_serializer
+    end
+
+    def test_relation_serializer_when_has_serializer_class
+      serializer = ActiveModel::Serializer.serializer_for(ARModels::Post::Special.all)
+      assert_equal serializer, ActiveModelSerializers.config.collection_serializer
+    end
+  end
+end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -46,6 +46,12 @@ module ARModels
   class Post < ActiveRecord::Base
     has_many :comments
     belongs_to :author
+
+    class Special < self
+      def self.serializer_class
+        PostSerializer::Special
+      end
+    end
   end
 
   class Comment < ActiveRecord::Base
@@ -62,6 +68,14 @@ module ARModels
 
     has_many :comments
     belongs_to :author
+
+    class Special < self
+      attributes :special
+
+      def special
+        true
+      end
+    end
   end
 
   class CommentSerializer < ActiveModel::Serializer


### PR DESCRIPTION
#### Purpose

Due to ActiveRecord _magic_ AMS fails to correctly determine serializer for AR::Relation.
Example:

```ruby
class Post < ActiveRecord::Base
   def self.serializer_class
      PostSpecialSerializer
   end
end

class PostsController < ApplicationController
  def index
    # AMS mistakenly uses PostSpecialSerializer to render relation here instead of using CollectionSerializer
    # 'cause Relation responds to all underlying model's class methods
    render json: Post.all
  end
end 
```

#### Changes

Explicitly set `serializer_class` for `ActiveRecord::Relation`.