### PR TITLE
Add explicit serializer not found policy

### DIFF
--- a/lib/active_model/serializer/concerns/configuration.rb
+++ b/lib/active_model/serializer/concerns/configuration.rb
@@ -10,6 +10,7 @@ module ActiveModel
         config = base.config
         config.collection_serializer = ActiveModel::Serializer::CollectionSerializer
         config.serializer_lookup_enabled = true
+        config.on_serializer_not_found = -> {}
 
         def config.array_serializer=(collection_serializer)
           self.collection_serializer = collection_serializer


### PR DESCRIPTION
#### Purpose

Allow users to setup a policy to fail explicity when an `ActiveRecord::Base` inherited model is being used without an explicit `Serializer` defined.

Currently, when rendering a `ActiveRecord::Base` model it falls back on the default JSON serializer, exposing all attributes.
#### Changes
- `ActiveModel::Serializer#get_serializer_for`
#### Related GitHub issues
- https://github.com/rails-api/active_model_serializers/issues/1853
