### PR TITLE
Pin jsonapi version.

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
     # 'minitest'
     # 'thread_safe'
 
-  spec.add_runtime_dependency 'jsonapi', '~> 0.1.1.beta2'
+  spec.add_runtime_dependency 'jsonapi', '0.1.1.beta2'
 
   spec.add_development_dependency 'activerecord', rails_versions
     # arel


### PR DESCRIPTION
#### Purpose
The `jsonapi` gem is still in beta, so semantic versioning gives no guarantee. This bit people when I yanked version `0.1.1.beta5` and released `0.1.1.beta6`.
As a precaution, I'll refrain from yanking from now on, but this should solve any foreseeable issue.

#### Changes
Pin `jsonapi` dependency to `0.0.1.beta2` (was `~>0.1.1.beta2`).

#### Related GitHub issues
https://github.com/beauby/jsonapi/issues/50
