### PR TITLE
Fix #1956, migrating jsonapi from 0.1.1.beta2 to 0.1.1.beta3,

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   # 'minitest'
   # 'thread_safe'
 
-  spec.add_runtime_dependency 'jsonapi', '~> 0.1.1.beta2'
+  spec.add_runtime_dependency 'jsonapi', '~> 0.1.1.beta3'
 
   spec.add_development_dependency 'activerecord', rails_versions
   # arel


### PR DESCRIPTION
#### Purpose

jsonapi-parser 0.1.1-beta2 was yanked, change dependency to jsonapi-0.1.1.beta3
#### Related GitHub issues

  #1956
### ps:
- this is my first contribution on a open source project, i don't know if i do the right thing
- sorry for my bad english
