### PR TITLE
Add documentation for root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Misc:
 
 - [#1799](https://github.com/rails-api/active_model_serializers/pull/1799) Add documentation for setting the adapter. (@ScottKbka)
 - [#1909](https://github.com/rails-api/active_model_serializers/pull/1909) Add documentation for relationship links. (@vasilakisfil, @NullVoxPopuli)
+- [#1959](https://github.com/rails-api/active_model_serializers/pull/1959) Add documentation for root. (@shunsuke227ono)
 
 ### [v0.10.2 (2016-07-05)](https://github.com/rails-api/active_model_serializers/compare/v0.10.1...v0.10.2)
 

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -217,15 +217,17 @@ The object being serialized.
 
 #### #root
 
-Resource root which is included in `JSON` adapter. As you can see at [Adapters Document](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/adapters.md), `Attribute` adapter (default) and `JSON API` adapter dose not include root at top level.
-By default, the resource root comes from the class name of the serialized class.
+Resource root which is included in `JSON` adapter. As you can see at [Adapters Document](adapters.md), `Attribute` adapter (default) and `JSON API` adapter does not include root at top level.
+By default, the resource root comes from the `model_name` of the serialized object's class.
 
-There are some ways to specify root like below:
-* [Overriding the root key](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/rendering.md#overriding-the-root-key)
-* [Setting `type`](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/serializers.md#type)
-* Passing an argument like `root: 'specific_name'` to the serializer's initialization.
+There are several ways to specify root:
+* [Overriding the root key](rendering.md#overriding-the-root-key)
+* [Setting `type`](serializers.md#type)
+* Specifying the `root` option, e.g. `root: 'specific_name'`, during the serializer's initialization:
 
-You can also see examples of root at linked pages above.
+```ruby
++ActiveModelSerializers::SerializableResource.new(foo, root: 'bar')
+```
 
 #### #scope
 

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -217,7 +217,15 @@ The object being serialized.
 
 #### #root
 
-PR please :)
+Resource root which is included in `JSON` adapter. As you can see at [Adapters Document](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/adapters.md), `Attribute` adapter (default) and `JSON API` adapter dose not include root at top level.
+By default, the resource root comes from the class name of the serialized class.
+
+There are some ways to specify root like below:
+* [Overriding the root key](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/rendering.md#overriding-the-root-key)
+* [Setting `type`](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/serializers.md#type)
+* Passing an argument like `root: 'specific_name'` to the serializer's initialization.
+
+You can also see examples of root at linked pages above.
 
 #### #scope
 

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -226,7 +226,7 @@ There are several ways to specify root:
 * Specifying the `root` option, e.g. `root: 'specific_name'`, during the serializer's initialization:
 
 ```ruby
-+ActiveModelSerializers::SerializableResource.new(foo, root: 'bar')
+ActiveModelSerializers::SerializableResource.new(foo, root: 'bar')
 ```
 
 #### #scope


### PR DESCRIPTION
#### Purpose

Provide a document for `root` at [serializers#root](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/serializers.md#root). 
#### Changes

Adds new lines to `docs/general/serializers.md`.
#### Caveats

Nothing.
#### Related GitHub issues

No issue.
#### Additional helpful information
