### PR TITLE
Makes serializer available to resource meta blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Features:
 
 Fixes:
 
+- [#1960](https://github.com/rails-api/active_model_serializers/pull/1960) Pass serializer to resource `meta` block (@groyoh)
 - [#1984](https://github.com/rails-api/active_model_serializers/pull/1984) Mutation of ActiveModelSerializers::Model now changes the attributes. (@bf4)
 
 Misc:

--- a/lib/active_model_serializers/adapter/json_api/meta.rb
+++ b/lib/active_model_serializers/adapter/json_api/meta.rb
@@ -18,7 +18,7 @@ module ActiveModelSerializers
 
           # Use the return value of the block unless it is nil.
           if serializer._meta.respond_to?(:call)
-            @value = instance_eval(&serializer._meta)
+            @value = instance_exec(serializer, &serializer._meta)
           else
             @value = serializer._meta
           end


### PR DESCRIPTION
#### Purpose

Resolves #1940.

It is now possible to access the serializer from the
resource meta block e.g.

``` ruby
class FooSerializer
  meta do |serializer|
    { foo: serializer.foo! }
  end

  def foo!
    "foo!"
  end
end
```
#### Changes

Pass serializer to the meta block.
#### Caveats

This does not provide `instance_options` to the `meta` block as `instance_options` are protected attributes.
#### Related GitHub issues
#1940
