### PR TITLE
Add object equality test for model serializers

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -130,6 +130,10 @@ module ActiveModel
       define_singleton_method scope_name, -> { scope }
     end
 
+    def ==(other)
+      other.respond_to?(:object) && other.object == object
+    end
+
     def success?
       true
     end

--- a/test/serializers/equality_test.rb
+++ b/test/serializers/equality_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class EqualityTest < ActiveSupport::TestCase
+      class DummySerializer < ActiveModel::Serializer; end
+      def setup
+        comment_1 = Comment.new(id: 1)
+        comment_2 = Comment.new(id: 2)
+
+        @comment_serializer = CommentSerializer.new(comment_1)
+        @comment_serializer_copy = CommentSerializer.new(comment_1)
+        @another_comment_serializer = CommentSerializer.new(comment_2)
+      end
+
+      def test_equal
+        assert_equal @comment_serializer, @comment_serializer_copy
+      end
+
+      def test_not_equal
+        assert_not_equal @comment_serializer, @another_comment_serializer
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Purpose
Make `SomeSerializer.new(some_object)` == `SomeSerializer.new(some_object)`

#### Changes
Add `ActiveModel::Serializer#==` that checks if `object` is the same.

