### PR TITLE
Fix namespace lookup for collections and has_many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 
 Fixes:
 
+- [#1973](https://github.com/rails-api/active_model_serializers/pull/1973) Fix namespace lookup for collections and has_many relationships (@groyoh)
 - [#1887](https://github.com/rails-api/active_model_serializers/pull/1887) Make the comment reflect what the function does (@johnnymo87)
 - [#1890](https://github.com/rails-api/active_model_serializers/issues/1890) Ensure generator inherits from ApplicationSerializer when available (@richmolj)
 - [#1922](https://github.com/rails-api/active_model_serializers/pull/1922) Make railtie an optional dependency in runtime (@ggpasqualino)

--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -71,7 +71,9 @@ module ActiveModel
       end
 
       def serializer_from_resource(resource, serializer_context_class, options)
-        serializer_class = options.fetch(:serializer) { serializer_context_class.serializer_for(resource) }
+        serializer_class = options.fetch(:serializer) do
+          serializer_context_class.serializer_for(resource, namespace: options[:namespace])
+        end
 
         if serializer_class.nil?
           ActiveModelSerializers.logger.debug "No serializer found for resource: #{resource.inspect}"


### PR DESCRIPTION
#### Purpose

Due to the `CollectionSerializer` [not passing the `namespace` option to the lookup](https://github.com/rails-api/active_model_serializers/blob/c9a96a05eddd7381b502f5c8097803547d93f75a/lib/active_model/serializer/collection_serializer.rb#L74), the namespace lookup doesn't work for collections and has_many relationships. This PR fixes it.

#### Changes

Pass the `namespace` option to the serializer lookup from the `CollectionSerializer`.

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/pull/1757#issuecomment-260602042


