### PR TITLE
add test and fix for collection not supporting namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Breaking changes:
 
 Fixes:
 
--[#1974](https://github.com/rails-api/active_model_serializers/pull/1974) Support namespace option in collections (@groyoh, @NullVoxPopuli)
+- [#1974](https://github.com/rails-api/active_model_serializers/pull/1974) Support namespace option in collections (@groyoh, @NullVoxPopuli)
 - [#1887](https://github.com/rails-api/active_model_serializers/pull/1887) Make the comment reflect what the function does (@johnnymo87)
 - [#1890](https://github.com/rails-api/active_model_serializers/issues/1890) Ensure generator inherits from ApplicationSerializer when available (@richmolj)
 - [#1922](https://github.com/rails-api/active_model_serializers/pull/1922) Make railtie an optional dependency in runtime (@ggpasqualino)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 
 Fixes:
 
+-[#1974](https://github.com/rails-api/active_model_serializers/pull/1974) Support namespace option in collections (@groyoh, @NullVoxPopuli)
 - [#1887](https://github.com/rails-api/active_model_serializers/pull/1887) Make the comment reflect what the function does (@johnnymo87)
 - [#1890](https://github.com/rails-api/active_model_serializers/issues/1890) Ensure generator inherits from ApplicationSerializer when available (@richmolj)
 - [#1922](https://github.com/rails-api/active_model_serializers/pull/1922) Make railtie an optional dependency in runtime (@ggpasqualino)

--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -71,7 +71,7 @@ module ActiveModel
       end
 
       def serializer_from_resource(resource, serializer_context_class, options)
-        serializer_class = options.fetch(:serializer) { serializer_context_class.serializer_for(resource) }
+        serializer_class = options.fetch(:serializer) { serializer_context_class.serializer_for(resource, options) }
 
         if serializer_class.nil?
           ActiveModelSerializers.logger.debug "No serializer found for resource: #{resource.inspect}"

--- a/test/action_controller/namespace_lookup_test.rb
+++ b/test/action_controller/namespace_lookup_test.rb
@@ -37,6 +37,14 @@ module ActionController
               render json: book
             end
 
+            def implicit_namespaced_collection_serializer
+              writer = Writer.new(name: 'Bob')
+              book = Book.new(title: 'New Post', body: 'Body', writer: writer)
+              book2 = Book.new(title: 'New Post2', body: 'Body', writer: writer)
+
+              render json: [book, book2]
+            end
+
             def explicit_namespace_as_module
               book = Book.new(title: 'New Post', body: 'Body')
 
@@ -85,6 +93,18 @@ module ActionController
         assert_serializer Api::V3::BookSerializer
 
         expected = { 'title' => 'New Post', 'body' => 'Body', 'writer' => { 'name' => 'Bob' } }
+        actual = JSON.parse(@response.body)
+
+        assert_equal expected, actual
+      end
+
+      test 'implicitly uses namespaced serializer for collection' do
+        get :implicit_namespaced_collection_serializer
+
+        expected = [
+          { 'title' => 'New Post', 'body' => 'Body', 'writer' => { 'name' => 'Bob' } },
+          { 'title' => 'New Post2', 'body' => 'Body', 'writer' => { 'name' => 'Bob' } }
+        ]
         actual = JSON.parse(@response.body)
 
         assert_equal expected, actual


### PR DESCRIPTION
#### Purpose

Allow collection serializers to utilize the namespace option

#### Changes

Pass options to collection serializer's call to serializer_for

#### Caveats

Unknown

#### Related GitHub issues

https://github.com/rails-api/active_model_serializers/pull/1757#issuecomment-260599490

#### Additional helpful information

Found by @groyoh 

