### PR TITLE
make serialization_context available in link

### DIFF
--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -467,7 +467,7 @@ module ActiveModelSerializers
       #   }.reject! {|_,v| v.nil? }
       def links_for(serializer)
         serializer._links.each_with_object({}) do |(name, value), hash|
-          result = Link.new(serializer, value).as_json
+          result = Link.new(serializer, value, instance_options).as_json
           hash[name] = result if result
         end
       end

--- a/lib/active_model_serializers/adapter/json_api/link.rb
+++ b/lib/active_model_serializers/adapter/json_api/link.rb
@@ -41,11 +41,12 @@ module ActiveModelSerializers
       class Link
         include SerializationContext::UrlHelpers
 
-        def initialize(serializer, value)
+        def initialize(serializer, value, adapter_options)
           @_routes ||= nil # handles warning
           # actionpack-4.0.13/lib/action_dispatch/routing/route_set.rb:417: warning: instance variable @_routes not initialized
           @object = serializer.object
           @scope = serializer.scope
+          @context = adapter_options[:serialization_context]
           # Use the return value of the block unless it is nil.
           if value.respond_to?(:call)
             @value = instance_eval(&value)
@@ -76,7 +77,7 @@ module ActiveModelSerializers
 
         protected
 
-        attr_reader :object, :scope
+        attr_reader :object, :scope, :context
       end
     end
   end

--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -48,7 +48,7 @@ module ActiveModelSerializers
 
         def links_for(association)
           association.links.each_with_object({}) do |(key, value), hash|
-            result = Link.new(parent_serializer, value).as_json
+            result = Link.new(parent_serializer, value, serializable_resource_options).as_json
             hash[key] = result if result
           end
         end

--- a/lib/active_model_serializers/serialization_context.rb
+++ b/lib/active_model_serializers/serialization_context.rb
@@ -21,7 +21,7 @@ module ActiveModelSerializers
       end
     end
 
-    attr_reader :request_url, :query_parameters, :key_transform
+    attr_reader :request_url, :query_parameters, :key_transform, :url_helpers
 
     def initialize(*args)
       options = args.extract_options!


### PR DESCRIPTION
#### Purpose
```ruby
module MyEngine
  class Engine < Rails::Engine
    isolate_namespace MyEngine
  end
end
```

```ruby
class MySerializer < ActiveModel::Serializer
  link :self do
    context.url_helpers.api_resource_url(object)
  end
end
```

```ruby
module MyEngine
  class MyController < ApplicationController
    def index
      render json: @resources, url_helpers: my_engine
    end
  end
end
```

Makes it possible to build urls of engines with isolated namespace by passing the `ActionDispatch::Routing::RoutesProxy` (`my_engine`).

#### Changes
Pass serialization_context to link.

