### PR TITLE
Fix relationship links doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Fixes:
 
 Misc:
 
+- [#1981](https://github.com/rails-api/active_model_serializers/pull/1981) Fix relationship link documentation. (@groyoh)
 - [#1984](https://github.com/rails-api/active_model_serializers/pull/1984) Make test attributes explicit. Test models have 'associations' support. (@bf4)
 - [#1993](https://github.com/rails-api/active_model_serializers/pull/1993) Swap out KeyTransform for CaseTransform gem for the possibility of native extension use (@NullVoxPopuli)
 


### PR DESCRIPTION
#### Purpose
The relationship links contained incorrect information that mislead users in using AMS improperly. More precisely, JSONAPI does not allow an attribute to be named `links`. This documentation was fixed and reworked at certain parts to match the latest API.

#### Changes

Only documentation.

#### Related GitHub issues

#1971 
#1935

#### Additional helpful information
 
I haven't reviewed everything yet but I wanted some feedback to see if I'm going in the right direction with theses changes.

@michael-reeves if you have some time, maybe you could also tell me if this documentation is clearer or not.