### PR TITLE
Underscore incoming params before filtering during Deserialization

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -141,6 +141,7 @@ module ActiveModelSerializers
 
         # @api private
         def filter_fields(fields, options)
+          KeyTransform.send(:underscore, fields)
           if (only = options[:only])
             fields.slice!(*Array(only).map(&:to_s))
           elsif (except = options[:except])


### PR DESCRIPTION
#### Purpose

**TL;DR** Ensure general use case of using snake case for permitted params i.e. `jsonapi_parse(params, only: [:first_name])` even when deserializing dasherized or camel cased params.

**Long version**: In Rails-land, we generally default to snake case when describing variables, symbols, etc. Right now, if we have incoming params with kebab or camel cased fields, we have to match the case when deserializing in the controller. 

E.g.

If we send dasherized parameters such as
```
{
  'data' => {
    'type' => 'users',
    'id' => 'blah',
    'attributes' => {
      'first-name' => 'Freddie',
      'last-name' => 'Mercury'
    }
  }
}
```
to a UserController containing this (fairly standard) method
```
def user_params
  ActiveModelSerializers::Deserialization.jsonapi_parse(params,
    only: [:first_name, :last_name])
end
```
the result will be empty `user_params` as both 'first-name' and 'last-name' are filtered out by the `only` option before the params are ever parsed.

The current (ugly and unsatisfying) workaround is to list out the kebabed or camel cased parameters as strings (i.e. `only: ['first-name', 'last-name']` or to convince whoever is building a front end for your API to patch their Ember adapter or whatever to match whatever you're using (snake case FTW). 

I'd much rather be able to use snake case for permitted params consistently across all of my Rails apps and not worry about remembering how one particular front end is configured to send params over (and not worry about having to change the casing of all of my permitted params in all of my controllers in the event the status quo changes!).

#### Changes

Call existing underscore function on incoming parameter field keys when filtering against options passed into the `parse` method

#### Caveats

Might be overkill.

#### Related GitHub issues

Possible made obsolete by #1927 if there's ever any movement on it.

#### Additional helpful information



