### PR TITLE
Preserve path when string is camelized

### DIFF
--- a/lib/active_model_serializers/key_transform.rb
+++ b/lib/active_model_serializers/key_transform.rb
@@ -4,6 +4,7 @@ module ActiveModelSerializers
   module KeyTransform
     module_function
 
+    SLASH_SYMBOL = "/".freeze
     # Transforms values to UpperCamelCase or PascalCase.
     #
     # @example:
@@ -14,7 +15,7 @@ module ActiveModelSerializers
       when Array then value.map { |item| camel(item) }
       when Hash then value.deep_transform_keys! { |key| camel(key) }
       when Symbol then camel(value.to_s).to_sym
-      when String then value.underscore.camelize
+      when String then camelize(value, :upper)
       else value
       end
     end
@@ -29,7 +30,7 @@ module ActiveModelSerializers
       when Array then value.map { |item| camel_lower(item) }
       when Hash then value.deep_transform_keys! { |key| camel_lower(key) }
       when Symbol then camel_lower(value.to_s).to_sym
-      when String then value.underscore.camelize(:lower)
+      when String then camelize(value, :lower)
       else value
       end
     end
@@ -69,6 +70,10 @@ module ActiveModelSerializers
     # Returns the value unaltered
     def unaltered(value)
       value
+    end
+
+    def camelize(value, first_letter)
+      value.split(SLASH_SYMBOL).map { |ch| ch.underscore.camelize(first_letter) }.join(SLASH_SYMBOL)
     end
   end
 end

--- a/test/active_model_serializers/key_transform_test.rb
+++ b/test/active_model_serializers/key_transform_test.rb
@@ -68,6 +68,10 @@ module ActiveModelSerializers
           expected: [
             { SomeValue: 'value' }
           ]
+        },
+        {
+          value: 'scope/some_value',
+          expected: 'Scope/SomeValue'
         }
       ]
       scenarios.each do |s|
@@ -142,6 +146,10 @@ module ActiveModelSerializers
           expected: [
             { someValue: 'value' }
           ]
+        },
+        {
+          value: 'scope/some_value',
+          expected: 'scope/someValue'
         }
       ]
       scenarios.each do |s|


### PR DESCRIPTION
#### Purpose
In my project I have some cases when I need to make a `POST` request with nested data. The following data may be provided:

```
{
  "data": {
    "type": "offers",
    "attributes": {
      "bid": { "amount": 1.12, "currency": "USD" }
    }
  }
}
```

Bid attribute may have validation errors so the response should provide this information:

```
{
  "errors": [
    { "source": { "pointer": "/data/attributes/bid/amount" }, "detail": "too_low" }
  ]
}
```

But when I use camel key transformation I receive `/data/attributes/bid::Amount` instead of `/data/attributes/bid/amount`

This PR fixes this behavior for `camel` and `camel_lower` key transformations

#### Changes

In `camel` and `camel_lower` key transformations 

#### Caveats

I saw work at https://github.com/rails-api/active_model_serializers/pull/1928 and introduction of [case_transform](https://github.com/NullVoxPopuli/case_transform). I can make PR to this gem also.

#### Related GitHub issues
#1928 

#### Additional helpful information



