### PR TITLE
Fix typos and capitalization in Relationship Links docs

### DIFF
--- a/docs/howto/add_relationship_links.md
+++ b/docs/howto/add_relationship_links.md
@@ -37,7 +37,7 @@ class Api::V1::UserSerializer < ActiveModel::Serializer
 end
 ```
 
-This will resilt in (example is in jsonapi adapter):
+This will result in (example is in jsonapi adapter):
 ```json
 {
   "data": {
@@ -69,7 +69,7 @@ class Api::V1::UserSerializer < ActiveModel::Serializer
 end
 ```
 
-This will resilt in (example is in jsonapi adapter):
+This will result in (example is in jsonapi adapter):
 ```json
 {
   "data": {

--- a/docs/howto/add_relationship_links.md
+++ b/docs/howto/add_relationship_links.md
@@ -37,7 +37,7 @@ class Api::V1::UserSerializer < ActiveModel::Serializer
 end
 ```
 
-This will result in (example is in jsonapi adapter):
+This will result in (example is in JSONAPI adapter):
 ```json
 {
   "data": {
@@ -69,7 +69,7 @@ class Api::V1::UserSerializer < ActiveModel::Serializer
 end
 ```
 
-This will result in (example is in jsonapi adapter):
+This will result in (example is in JSONAPI adapter):
 ```json
 {
   "data": {


### PR DESCRIPTION
#### Purpose

Some quick fixes to improve the documentation.