### PR TITLE
Add jsonapi_include_toplevel_object option to serializer

### DIFF
--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # {http://jsonapi.org/format/ JSON API specification}
 # rubocop:disable Style/AsciiComments
 # TODO: implement!
@@ -135,7 +136,7 @@ module ActiveModelSerializers
         #     ]
         hash[:included] = included if included.any?
 
-        Jsonapi.add!(hash)
+        Jsonapi.add!(hash, instance_options)
 
         if instance_options[:links]
           hash[:links] ||= {}
@@ -170,7 +171,7 @@ module ActiveModelSerializers
       def failure_document
         hash = {}
         # PR Please :)
-        # Jsonapi.add!(hash)
+        # Jsonapi.add!(hash, instance_options)
 
         # toplevel_errors
         # definition:

--- a/lib/active_model_serializers/adapter/json_api/jsonapi.rb
+++ b/lib/active_model_serializers/adapter/json_api/jsonapi.rb
@@ -23,12 +23,15 @@ module ActiveModelSerializers
       module Jsonapi
         module_function
 
-        def add!(hash)
-          hash.merge!(object) if include_object?
+        def add!(hash, instance_options)
+          hash.merge!(object) if include_object?(instance_options)
         end
 
-        def include_object?
-          ActiveModelSerializers.config.jsonapi_include_toplevel_object
+        def include_object?(instance_options)
+          instance_options.fetch(
+            :jsonapi_include_toplevel_object,
+            ActiveModelSerializers.config.jsonapi_include_toplevel_object
+          )
         end
 
         # TODO: see if we can cache this

--- a/lib/active_model_serializers/serializable_resource.rb
+++ b/lib/active_model_serializers/serializable_resource.rb
@@ -2,7 +2,7 @@ require 'set'
 
 module ActiveModelSerializers
   class SerializableResource
-    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links, :serialization_context, :key_transform])
+    ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links, :serialization_context, :key_transform, :jsonapi_include_toplevel_object])
     include ActiveModelSerializers::Logging
 
     delegate :serializable_hash, :as_json, :to_json, to: :adapter

--- a/test/adapter/json_api/toplevel_jsonapi_test.rb
+++ b/test/adapter/json_api/toplevel_jsonapi_test.rb
@@ -37,9 +37,23 @@ module ActiveModelSerializers
           end
         end
 
+        def test_disable_toplevel_jsonapi_using_instance_options
+          with_config(jsonapi_include_toplevel_object: true) do
+            hash = serialize(@post, jsonapi_include_toplevel_object: false)
+            assert_nil(hash[:jsonapi])
+          end
+        end
+
         def test_enable_toplevel_jsonapi
           with_config(jsonapi_include_toplevel_object: true) do
             hash = serialize(@post)
+            refute_nil(hash[:jsonapi])
+          end
+        end
+
+        def test_enable_toplevel_jsonapi_using_instance_options
+          with_config(jsonapi_include_toplevel_object: false) do
+            hash = serialize(@post, jsonapi_include_toplevel_object: true)
             refute_nil(hash[:jsonapi])
           end
         end


### PR DESCRIPTION
#### Purpose

Sometimes, I have the need to include the JSON-API top level object while it's disabled in the config.  This PR adds the functionality to include it on the fly using an option to the serializer:

```
 ActiveModelSerializers::SerializableResource.new(
  UserSerializer.new(obj),
  adapter:                         :json_api,
  jsonapi_include_toplevel_object: true
).as_json
```

#### Changes

Pass instance options to the `ActiveModelSerializers::Adapter::JsonApi::Jsonapi` model, and modify the `include_object?` method to use the value of the instance option `:jsonapi_include_toplevel_object` instead of the global config, if given.

#### Caveats

-

#### Related GitHub issues

-

#### Additional helpful information

-

