### PR TITLE
STI type deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 Features:
 
 - [#1982](https://github.com/rails-api/active_model_serializers/pull/1982) Add ActiveModelSerializers::Model.attributes to configure PORO attributes (@bf4).
+- [#1995](https://github.com/rails-api/active_model_serializers/pull/1995) Allow STI type deserialization (@gauthier-delacroix).
 
 Fixes:
 

--- a/docs/general/deserialization.md
+++ b/docs/general/deserialization.md
@@ -95,6 +95,24 @@ ActiveModelSerializers::Deserialization
 # }
 ```
 
+A [Single Table Inheritance](http://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html) type key can be set via the options or config key `sti_key_type` to get the original class name:
+
+```ruby
+ActiveModelSerializers::Deserialization
+  .jsonapi_parse(document, sti_key_type: :type)
+#=>
+# {
+#   type: 'Post',
+#   title: 'Title 1',
+#   date: '2015-12-20',
+#   author_id: 2,
+#   second_author_id: nil
+#   comment_ids: [3, 4]
+# }
+```
+
+Note that [jsonapi_namespace_separator](configuration_options.md#jsonapi_namespace_separator) has to be changed to something different than [key_transform](configuration_options.md#key_transform) to allow deserialization of namespaced STI models.
+
 ## Attributes/Json
 
 There is currently no deserialization for those adapters.

--- a/lib/active_model/serializer/concerns/configuration.rb
+++ b/lib/active_model/serializer/concerns/configuration.rb
@@ -22,6 +22,7 @@ module ActiveModel
         config.default_includes = '*'
         config.adapter = :attributes
         config.key_transform = nil
+        config.sti_type_key = nil
         config.jsonapi_pagination_links_enabled = true
         config.jsonapi_resource_type = :plural
         config.jsonapi_namespace_separator = '-'.freeze

--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -97,6 +97,7 @@ module ActiveModelSerializers
           filter_fields(relationships, options)
 
           hash = {}
+          hash.merge!(parse_type(primary_data['type'], options))
           hash.merge!(parse_attributes(attributes, options))
           hash.merge!(parse_relationships(relationships, options))
 
@@ -200,6 +201,17 @@ module ActiveModelSerializers
           transform_keys(relationships, options)
             .map { |(k, v)| parse_relationship(k, v['data'], options) }
             .reduce({}, :merge)
+        end
+
+        # @api private
+        def parse_type(type, options)
+          sti_type_key = options.fetch(:sti_type_key, ActiveModelSerializers.config.sti_type_key)
+          if sti_type_key && type
+            type = type.gsub(ActiveModelSerializers.config.jsonapi_namespace_separator, '/')
+            type = transform_keys(type, options).classify
+            { sti_type_key => type }
+          else {}
+          end
         end
 
         # @api private

--- a/test/adapter/json_api/parse_test.rb
+++ b/test/adapter/json_api/parse_test.rb
@@ -130,6 +130,25 @@ module ActiveModelSerializers
             }
             assert_equal(expected, parsed_hash)
           end
+
+          def test_sti_type
+            parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, sti_type_key: :_type)
+            assert_equal(@expected.merge(_type: 'Photo'), parsed_hash)
+
+            with_config(sti_type_key: :_type) do
+              parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash)
+              assert_equal(@expected.merge(_type: 'Photo'), parsed_hash)
+            end
+          end
+
+          def test_namespaced_sti_type
+            hash = @hash
+            hash['data']['type'] = 'content--user-photos'
+            with_namespace_separator '--' do
+              parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(hash, sti_type_key: :_type)
+              assert_equal(@expected.merge(_type: 'Content::UserPhoto'), parsed_hash)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
#### Purpose
Allows STI type deserialization from JSONAPI attributes.

The type key has to be customized (`:type`for Active Record, `:_type` for Mongoid) to enable the feature so there's no breaking change.

#### Changes
Added `sti_key_type` global config key and `parse` option to enable/customize the feature.
Added `parse_type` private method to deserialize class name.
Added doc
Added 2 tests:

- Simple type deserialization
- Namespaced type deserialization

#### Caveats
Requires `jsonapi_namespace_separator` to be different than `key_transform` which is not the current default (note added in the doc).

#### Related GitHub issues
None found

#### Additional helpful information



