### PR TITLE
Fix typos

### DIFF
--- a/lib/active_model/serializer/concerns/attributes.rb
+++ b/lib/active_model/serializer/concerns/attributes.rb
@@ -66,7 +66,7 @@ module ActiveModel
         end
 
         # @api private
-        # maps attribute value to explict key name
+        # maps attribute value to explicit key name
         # @see Serializer::attribute
         # @see FragmentCache#fragment_serializer
         def _attributes_keys

--- a/test/action_controller/json_api/errors_test.rb
+++ b/test/action_controller/json_api/errors_test.rb
@@ -14,10 +14,10 @@ module ActionController
               { source: { pointer: '/data/attributes/id' }, detail: 'must be a uuid' }
             ]
           }.to_json
-          assert_equal json_reponse_body.to_json, expected_errors_object
+          assert_equal json_response_body.to_json, expected_errors_object
         end
 
-        def json_reponse_body
+        def json_response_body
           JSON.load(@response.body)
         end
 

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -456,7 +456,7 @@ module ActionController
         end
       end
 
-      def test_render_event_is_emmited
+      def test_render_event_is_emitted
         subscriber = ::ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |name|
           @name = name
         end

--- a/test/active_model_serializers/json_pointer_test.rb
+++ b/test/active_model_serializers/json_pointer_test.rb
@@ -13,7 +13,7 @@ module ActiveModelSerializers
       assert_equal '/data', pointer
     end
 
-    def test_unkown_data_pointer
+    def test_unknown_data_pointer
       assert_raises(TypeError) do
         ActiveModelSerializers::JsonPointer.new(:unknown)
       end


### PR DESCRIPTION
```
go get -u github.com/client9/misspell/cmd/misspell
misspell  -w -q -error -source=text {app,config,lib,test}/**/*
```

>   workers   = flag.Int("j", 0, "Number of workers, 0 = number of CPUs")
>   writeit   = flag.Bool("w", false, "Overwrite file with corrections (default is just to display)")
>   quietFlag = flag.Bool("q", false, "Do not emit misspelling output")
>   outFlag   = flag.String("o", "stdout", "output file or [stderr|stdout|]")
>   format    = flag.String("f", "", "'csv', 'sqlite3' or custom Golang template for output")
>   ignores   = flag.String("i", "", "ignore the following corrections, comma separated")
>   locale    = flag.String("locale", "", "Correct spellings using locale perferances for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'")
>   mode      = flag.String("source", "auto", "Source mode: auto=guess, go=golang source, text=plain or markdown-like text")
>   debugFlag = flag.Bool("debug", false, "Debug matching, very slow")
>   exitError = flag.Bool("error", false, "Exit with 2 if misspelling found")