### PR TITLE
Link to 0.10.3 tag instead of `master` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,14 @@ If you'd like to chat, we have a [community slack](http://amserializers.herokuap
 Thanks!
 
 ## Documentation
+
+If you're reading this at https://github.com/rails-api/active_model_serializers you are
+reading documentation for our `master`, which may include features that have not
+been released yet. Please see below for the documentation relevant to you.
+
 - [0.10 (master) Documentation](https://github.com/rails-api/active_model_serializers/tree/master)
-  - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/gems/active_model_serializers/0.10.2)
+- [0.10.3 (latest release) Documentation](https://github.com/rails-api/active_model_serializers/tree/v0.10.3)
+  - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/gems/active_model_serializers/0.10.3)
   - [Guides](docs)
 - [0.9 (0-9-stable) Documentation](https://github.com/rails-api/active_model_serializers/tree/0-9-stable)
   - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/github/rails-api/active_model_serializers/0-9-stable)


### PR DESCRIPTION
#### Purpose
Link to latest tagged release so people can read the latest docs for an available release.

#### Changes
Updated links

#### Caveats
These links have to be updated with every release

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/1988

#### Additional helpful information
It may be less confusing for new users if the docs link them to the current stable release.