### PR TITLE
Update jsonapi runtime dependency to 0.1.1.beta6

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   # 'minitest'
   # 'thread_safe'
 
-  spec.add_runtime_dependency 'jsonapi', '0.1.1.beta2'
+  spec.add_runtime_dependency 'jsonapi', '0.1.1.beta6'
   spec.add_runtime_dependency 'case_transform', '>= 0.2'
 
   spec.add_development_dependency 'activerecord', rails_versions


### PR DESCRIPTION
#### Purpose
Support ruby 2.4

#### Changes
Update jsonapi runtime dependency to 0.1.1.beta6

#### Related GitHub issues
#2004 

Thanks for the review :+1: 