### PR TITLE
Test was failing due to change in JSON exception message when parsing empty string

### DIFF
--- a/test/active_model_serializers/test/schema_test.rb
+++ b/test/active_model_serializers/test/schema_test.rb
@@ -115,7 +115,8 @@ module ActiveModelSerializers
       end
 
       def test_that_raises_with_a_invalid_json_body
-        message = 'A JSON text must at least contain two octets!'
+        # message changes from JSON gem 2.0.2 to 2.2.0
+        message = /A JSON text must at least contain two octets!|an unexpected token at ''/
 
         get :invalid_json_body
 
@@ -123,7 +124,7 @@ module ActiveModelSerializers
           assert_response_schema('custom/show.json')
         end
 
-        assert_equal(message, error.message)
+        assert_match(message, error.message)
       end
     end
   end


### PR DESCRIPTION
#2005  was failing CI due to a test expectation that changes depending on the version of the JSON gem.

![screen shot 2016-12-23 at 11 08 06 am](https://cloud.githubusercontent.com/assets/142914/21459089/15e3395c-c901-11e6-820e-c48617910137.png)
