### PR TITLE
Fix warning on Thor

### DIFF
--- a/lib/active_model/serializer/generators/serializer/scaffold_controller_generator.rb
+++ b/lib/active_model/serializer/generators/serializer/scaffold_controller_generator.rb
@@ -7,7 +7,7 @@ module Rails
       if Rails::VERSION::MAJOR >= 4
         source_root File.expand_path('../templates', __FILE__)
 
-        hook_for :serializer, default: true
+        hook_for :serializer, default: true, type: :boolean
       end
     end
   end


### PR DESCRIPTION
The default argument type for Thor is `string`. Unless it's specified that we pass `boolean`, we get the warning:

`Expected string default value for '--serializer'; got true (boolean)`

Details: https://github.com/erikhuda/thor/commit/605897b5a02f10a4687237667cafa8dda6ae2016

@bf4 