### PR TITLE
Cleanup assertions in isolated jsonapi renderer tests a bit

### DIFF
--- a/test/active_model_serializers/register_jsonapi_renderer_test_isolated.rb
+++ b/test/active_model_serializers/register_jsonapi_renderer_test_isolated.rb
@@ -12,8 +12,16 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
     end
 
     def render_with_jsonapi_renderer
-      unlocked_params = Rails::VERSION::MAJOR >= 5 ? params.to_unsafe_h : params
-      attributes = unlocked_params[:data].present? ? unlocked_params[:data][:attributes] : {}
+      permitted_params = params.permit(data: [:id, :type, attributes: [:name]])
+      permitted_params = permitted_params.to_h.with_indifferent_access
+      attributes =
+        if permitted_params[:data]
+          permitted_params[:data][:attributes].merge(id: permitted_params[:data][:id])
+        else
+          # Rails returns empty params when no mime type can be negotiated.
+          # (Until https://github.com/rails/rails/pull/26632 is reviewed.)
+          permitted_params
+        end
       author = Author.new(attributes)
       render jsonapi: author
     end
@@ -34,6 +42,17 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
     assert_equal(expected, TestController.last_request_parameters)
   end
 
+  def define_author_model_and_serializer
+    TestController.const_set(:Author, Class.new(ActiveModelSerializers::Model) do
+      attributes :name
+    end)
+    TestController.const_set(:AuthorSerializer, Class.new(ActiveModel::Serializer) do
+      type 'users'
+      attribute :id
+      attribute :name
+    end)
+  end
+
   class WithoutRenderer < JsonApiRendererTest
     setup do
       require 'rails'
@@ -49,6 +68,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
           match ':action', to: TestController, via: [:get, :post]
         end
       end
+      define_author_model_and_serializer
     end
 
     def test_jsonapi_parser_not_registered
@@ -61,12 +81,12 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
     end
 
     def test_jsonapi_renderer_not_registered
-      payload = '{"data": {"attributes": {"name": "Johnny Rico"}, "type": "authors"}}'
+      payload = '{"data": {"attributes": {"name": "Johnny Rico"}, "type": "users", "id": "36c9c04e-86b1-4636-a5b0-8616672d1765"}}'
       headers = { 'CONTENT_TYPE' => 'application/vnd.api+json' }
       post '/render_with_jsonapi_renderer', params: payload, headers: headers
-      assert_equal 500, response.status
       assert_equal '', response.body
-      assert response.request.env['action_dispatch.exception'].is_a?(ActionView::MissingTemplate) if response.request.present?
+      assert_equal 500, response.status
+      assert_equal ActionView::MissingTemplate, request.env['action_dispatch.exception'].class
     end
 
     def test_jsonapi_parser
@@ -94,6 +114,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
           match ':action', to: TestController, via: [:get, :post]
         end
       end
+      define_author_model_and_serializer
     end
 
     def test_jsonapi_parser_registered
@@ -109,18 +130,13 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
     def test_jsonapi_renderer_registered
       expected = {
         'data' => {
-          'id' => 'author',
-          'type' => 'authors',
-          'attributes' => { 'name' => 'Johnny Rico' },
-          'relationships' => {
-            'posts' => { 'data' => nil },
-            'roles' => { 'data' => nil },
-            'bio' => { 'data' => nil }
-          }
+          'id' => '36c9c04e-86b1-4636-a5b0-8616672d1765',
+          'type' => 'users',
+          'attributes' => { 'name' => 'Johnny Rico' }
         }
       }
 
-      payload = '{"data": {"attributes": {"name": "Johnny Rico"}, "type": "authors"}}'
+      payload = '{"data": {"attributes": {"name": "Johnny Rico"}, "type": "users", "id": "36c9c04e-86b1-4636-a5b0-8616672d1765"}}'
       headers = { 'CONTENT_TYPE' => 'application/vnd.api+json' }
       post '/render_with_jsonapi_renderer', params: payload, headers: headers
       assert_equal expected.to_json, response.body
@@ -133,10 +149,11 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
             'attributes' => {
               'name' => 'John Doe'
             },
-            'type' => 'users'
+            'type' => 'users',
+            'id' => '36c9c04e-86b1-4636-a5b0-8616672d1765'
           }
         },
-        '{"data": {"attributes": {"name": "John Doe"}, "type": "users"}}',
+        '{"data": {"attributes": {"name": "John Doe"}, "type": "users", "id": "36c9c04e-86b1-4636-a5b0-8616672d1765"}}',
         'CONTENT_TYPE' => 'application/vnd.api+json'
       )
     end

--- a/test/active_model_serializers/test/schema_test.rb
+++ b/test/active_model_serializers/test/schema_test.rb
@@ -116,7 +116,7 @@ module ActiveModelSerializers
 
       def test_that_raises_with_a_invalid_json_body
         # message changes from JSON gem 2.0.2 to 2.2.0
-        message = /A JSON text must at least contain two octets!|an unexpected token at ''/
+        message = /A JSON text must at least contain two octets!|unexpected token at ''/
 
         get :invalid_json_body
 


### PR DESCRIPTION
Follows https://github.com/rails-api/active_model_serializers/pull/2010