### PR TITLE
Fix mt6 assert_nil warnings

### DIFF
--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -75,7 +75,10 @@ module SerializationScopeTesting
     end
 
     def test_default_serialization_scope_object
-      assert_equal @controller.current_user, @controller.serialization_scope
+      expected = @controller.current_user
+      actual = @controller.serialization_scope
+      assert_nil expected
+      assert_nil actual
     end
 
     def test_default_scope_non_admin

--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -33,7 +33,8 @@ module SerializationScopeTesting
     end
   end
   class PostTestController < ActionController::Base
-    attr_accessor :current_user
+    attr_writer :current_user
+
     def render_post_by_non_admin
       self.current_user = User.new(id: 3, name: 'Pete', admin: false)
       render json: new_post, serializer: serializer, adapter: :json
@@ -42,6 +43,10 @@ module SerializationScopeTesting
     def render_post_by_admin
       self.current_user = User.new(id: 3, name: 'Pete', admin: true)
       render json: new_post, serializer: serializer, adapter: :json
+    end
+
+    def current_user
+      defined?(@current_user) ? @current_user : :current_user_not_set
     end
 
     private
@@ -75,10 +80,8 @@ module SerializationScopeTesting
     end
 
     def test_default_serialization_scope_object
-      expected = @controller.current_user
-      actual = @controller.serialization_scope
-      assert_nil expected
-      assert_nil actual
+      assert_equal :current_user_not_set, @controller.current_user
+      assert_equal :current_user_not_set, @controller.serialization_scope
     end
 
     def test_default_scope_non_admin
@@ -128,7 +131,7 @@ module SerializationScopeTesting
     end
 
     def test_defined_serialization_scope_object
-      assert_equal @controller.view_context.class, @controller.serialization_scope.class
+      assert_equal @controller.view_context.controller, @controller.serialization_scope.controller
     end
 
     def test_serialization_scope_non_admin

--- a/test/active_model_serializers/railtie_test_isolated.rb
+++ b/test/active_model_serializers/railtie_test_isolated.rb
@@ -4,11 +4,13 @@ require 'support/isolated_unit'
 class RailtieTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation
 
-  class WithRails < RailtieTest
+  class WithRailsRequiredFirst < RailtieTest
     setup do
       require 'rails'
       require 'active_model_serializers'
-      make_basic_app
+      make_basic_app do |app|
+        app.config.action_controller.perform_caching = true
+      end
     end
 
     test 'mixes ActionController::Serialization into ActionController::Base' do
@@ -32,17 +34,17 @@ class RailtieTest < ActiveSupport::TestCase
 
     test 'it is configured for caching' do
       assert_equal ActionController::Base.cache_store, ActiveModelSerializers.config.cache_store
-      expected = Rails.configuration.action_controller.perform_caching
-      actual = ActiveModelSerializers.config.perform_caching
-      assert_nil expected
-      assert_nil actual
+      assert_equal true, Rails.configuration.action_controller.perform_caching
+      assert_equal true, ActiveModelSerializers.config.perform_caching
     end
   end
 
-  class WithoutRails < RailtieTest
+  class WithoutRailsRequiredFirst < RailtieTest
     setup do
       require 'active_model_serializers'
-      make_basic_app
+      make_basic_app do |app|
+        app.config.action_controller.perform_caching = true
+      end
     end
 
     test 'does not mix ActionController::Serialization into ActionController::Base' do
@@ -59,8 +61,8 @@ class RailtieTest < ActiveSupport::TestCase
     test 'it is not configured for caching' do
       refute_nil ActionController::Base.cache_store
       assert_nil ActiveModelSerializers.config.cache_store
-      refute Rails.configuration.action_controller.perform_caching
-      refute ActiveModelSerializers.config.perform_caching
+      assert_equal true, Rails.configuration.action_controller.perform_caching
+      assert_nil ActiveModelSerializers.config.perform_caching
     end
   end
 end

--- a/test/active_model_serializers/railtie_test_isolated.rb
+++ b/test/active_model_serializers/railtie_test_isolated.rb
@@ -32,7 +32,10 @@ class RailtieTest < ActiveSupport::TestCase
 
     test 'it is configured for caching' do
       assert_equal ActionController::Base.cache_store, ActiveModelSerializers.config.cache_store
-      assert_equal Rails.configuration.action_controller.perform_caching, ActiveModelSerializers.config.perform_caching
+      expected = Rails.configuration.action_controller.perform_caching
+      actual = ActiveModelSerializers.config.perform_caching
+      assert_nil expected
+      assert_nil actual
     end
   end
 

--- a/test/adapter/json_api/include_data_if_sideloaded_test.rb
+++ b/test/adapter/json_api/include_data_if_sideloaded_test.rb
@@ -159,7 +159,12 @@ module ActiveModel
 
           def assert_relationship(relationship_name, expected, opts = {})
             hash = result(opts)
-            assert_equal(expected, hash[:data][:relationships][relationship_name])
+            actual = hash[:data][:relationships][relationship_name]
+            if expected.nil?
+              assert_nil(actual)
+            else
+              assert_equal(expected, actual)
+            end
           end
         end
       end

--- a/test/adapter/json_api/include_data_if_sideloaded_test.rb
+++ b/test/adapter/json_api/include_data_if_sideloaded_test.rb
@@ -146,25 +146,25 @@ module ActiveModel
           end
 
           def test_node_not_included_when_no_link
-            expected = nil
-            assert_relationship(:unlinked_tags, expected)
+            expected = { meta: {} }
+            assert_relationship(:unlinked_tags, expected, key_transform: :unaltered)
           end
 
           private
+
+          def assert_relationship(relationship_name, expected, opts = {})
+            actual = relationship_data(relationship_name, opts)
+            assert_equal(expected, actual)
+          end
 
           def result(opts)
             opts = { adapter: :json_api }.merge(opts)
             serializable(@author, opts).serializable_hash
           end
 
-          def assert_relationship(relationship_name, expected, opts = {})
+          def relationship_data(relationship_name, opts = {})
             hash = result(opts)
-            actual = hash[:data][:relationships][relationship_name]
-            if expected.nil?
-              assert_nil(actual)
-            else
-              assert_equal(expected, actual)
-            end
+            hash[:data][:relationships][relationship_name]
           end
         end
       end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -128,7 +128,7 @@ module ActiveModelSerializers
     def test_cache_key_definition
       assert_equal('post', @post_serializer.class._cache_key)
       assert_equal('writer', @author_serializer.class._cache_key)
-      assert_equal(nil, @comment_serializer.class._cache_key)
+      assert_nil(@comment_serializer.class._cache_key)
     end
 
     def test_cache_key_interpolation_with_updated_at_when_cache_key_is_not_defined_on_object
@@ -171,7 +171,7 @@ module ActiveModelSerializers
 
     def test_cache_options_definition
       assert_equal({ expires_in: 0.1, skip_digest: true }, @post_serializer.class._cache_options)
-      assert_equal(nil, @blog_serializer.class._cache_options)
+      assert_nil(@blog_serializer.class._cache_options)
       assert_equal({ expires_in: 1.day, skip_digest: true }, @comment_serializer.class._cache_options)
     end
 
@@ -182,8 +182,8 @@ module ActiveModelSerializers
 
     def test_associations_separately_cache
       cache_store.clear
-      assert_equal(nil, cache_store.fetch(@post.cache_key))
-      assert_equal(nil, cache_store.fetch(@comment.cache_key))
+      assert_nil(cache_store.fetch(@post.cache_key))
+      assert_nil(cache_store.fetch(@comment.cache_key))
 
       Timecop.freeze(Time.current) do
         render_object_with_cache(@post)

--- a/test/serializers/caching_configuration_test_isolated.rb
+++ b/test/serializers/caching_configuration_test_isolated.rb
@@ -69,9 +69,9 @@ class CachingConfigurationTest < ActiveSupport::TestCase
     end
 
     test 'the non-cached serializer cache_store is nil' do
-      assert_equal nil, @non_cached_serializer._cache
-      assert_equal nil, @non_cached_serializer.cache_store
-      assert_equal nil, @non_cached_serializer._cache
+      assert_nil @non_cached_serializer._cache
+      assert_nil @non_cached_serializer.cache_store
+      assert_nil @non_cached_serializer._cache
     end
 
     test 'the non-cached serializer does not have cache_enabled?' do
@@ -136,9 +136,9 @@ class CachingConfigurationTest < ActiveSupport::TestCase
     end
 
     test 'the non-cached serializer cache_store is nil' do
-      assert_equal nil, @non_cached_serializer._cache
-      assert_equal nil, @non_cached_serializer.cache_store
-      assert_equal nil, @non_cached_serializer._cache
+      assert_nil @non_cached_serializer._cache
+      assert_nil @non_cached_serializer.cache_store
+      assert_nil @non_cached_serializer._cache
     end
 
     test 'the non-cached serializer does not have cache_enabled?' do

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -59,7 +59,7 @@ module ActiveModel
 
         def test_serializer_for_non_ams_serializer
           serializer = ActiveModel::Serializer.serializer_for(@tweet)
-          assert_equal nil, serializer
+          assert_nil serializer
         end
 
         def test_serializer_for_existing_serializer
@@ -71,12 +71,12 @@ module ActiveModel
           serializer = with_serializer_lookup_disabled do
             ActiveModel::Serializer.serializer_for(@profile)
           end
-          assert_equal nil, serializer
+          assert_nil serializer
         end
 
         def test_serializer_for_not_existing_serializer
           serializer = ActiveModel::Serializer.serializer_for(@model)
-          assert_equal nil, serializer
+          assert_nil serializer
         end
 
         def test_serializer_inherited_serializer
@@ -88,7 +88,7 @@ module ActiveModel
           serializer = with_serializer_lookup_disabled do
             ActiveModel::Serializer.serializer_for(@my_profile)
           end
-          assert_equal nil, serializer
+          assert_nil serializer
         end
 
         def test_serializer_custom_serializer
@@ -114,7 +114,7 @@ module ActiveModel
           serializer = with_serializer_lookup_disabled do
             ActiveModel::Serializer.serializer_for(post)
           end
-          assert_equal nil, serializer
+          assert_nil serializer
         end
 
         def test_serializer_for_nested_resource
@@ -128,7 +128,7 @@ module ActiveModel
           serializer = with_serializer_lookup_disabled do
             ResourceNamespace::PostSerializer.serializer_for(comment)
           end
-          assert_equal nil, serializer
+          assert_nil serializer
         end
       end
     end


### PR DESCRIPTION
- Fix MT6 assert_nil warnings
  - introduced, discussion https://github.com/seattlerb/minitest/pull/626
    - objections and discussion https://github.com/seattlerb/minitest/commit/922bc9151a622cb3ef0b9f170aa09c3bb72c7eb8#commitcomment-20072731
    - good example of how this is a good thing https://github.com/seattlerb/minitest/pull/626#issuecomment-220718424
  - better warning https://github.com/seattlerb/minitest/issues/660


- https://github.com/rails-api/active_model_serializers/pull/1423

```
bundle exec rake test test:isolated 1>/dev/null
$HOME/.rvm/rubies/ruby-2.2.5/bin/ruby -w -I"lib:lib:test" -r./test/test_helper.rb  -w -I".bundle/ruby/2.2.0/gems/rake-11.3.0/lib" ".bundle/ruby/2.2.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb" "test/**/*_test.rb"
Use assert_nil if expecting nil from test/action_controller/serialization_scope_name_test.rb:78:in `test_default_serialization_scope_object'. This will fail in MT6.
Use assert_nil if expecting nil from test/cache_test.rb:174:in `test_cache_options_definition'. This will fail in MT6.
Use assert_nil if expecting nil from test/cache_test.rb:185:in `test_associations_separately_cache'. This will fail in MT6.
Use assert_nil if expecting nil from test/cache_test.rb:186:in `test_associations_separately_cache'. This will fail in MT6.
Use assert_nil if expecting nil from test/cache_test.rb:131:in `test_cache_key_definition'. This will fail in MT6.
Use assert_nil if expecting nil from test/adapter/json_api/include_data_if_sideloaded_test.rb:162:in `assert_relationship'. This will fail in MT6.
Expected string default value for '--test-framework'; got false (boolean)
Expected string default value for '--test-framework'; got false (boolean)
Use assert_nil if expecting nil from test/serializers/serializer_for_test.rb:74:in `test_serializer_for_existing_serializer_with_lookup_disabled'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/serializer_for_test.rb:62:in `test_serializer_for_non_ams_serializer'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/serializer_for_test.rb:131:in `test_serializer_for_nested_resource_with_lookup_disabled'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/serializer_for_test.rb:117:in `test_serializer_for_namespaced_resource_with_lookup_disabled'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/serializer_for_test.rb:79:in `test_serializer_for_not_existing_serializer'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/serializer_for_test.rb:91:in `test_serializer_inherited_serializer_with_lookup_disabled'. This will fail in MT6.
Use assert_nil if expecting nil from test/active_model_serializers/railtie_test_isolated.rb:35:in `block in <class:WithRails>'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/caching_configuration_test_isolated.rb:139:in `block in <class:PerformCachingFalse>'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/caching_configuration_test_isolated.rb:140:in `block in <class:PerformCachingFalse>'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/caching_configuration_test_isolated.rb:141:in `block in <class:PerformCachingFalse>'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/caching_configuration_test_isolated.rb:72:in `block in <class:PerformCachingTrue>'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/caching_configuration_test_isolated.rb:73:in `block in <class:PerformCachingTrue>'. This will fail in MT6.
Use assert_nil if expecting nil from test/serializers/caching_configuration_test_isolated.rb:74:in `block in <class:PerformCachingTrue>'. This will fail in MT6.
```