### PR TITLE
Fix AMS warnings

### DIFF
--- a/lib/generators/rails/resource_override.rb
+++ b/lib/generators/rails/resource_override.rb
@@ -4,7 +4,7 @@ require 'rails/generators/rails/resource/resource_generator'
 module Rails
   module Generators
     class ResourceGenerator
-      hook_for :serializer, default: true, boolean: true
+      hook_for :serializer, default: true, type: :boolean
     end
   end
 end

--- a/test/generators/serializer_generator_test.rb
+++ b/test/generators/serializer_generator_test.rb
@@ -67,6 +67,7 @@ class SerializerGeneratorTest < Rails::Generators::TestCase
     yield
   ensure
     String.class_eval do
+      undef_method :safe_constantize
       alias_method :safe_constantize, :old
       undef_method :old
     end


### PR DESCRIPTION
Extracted from https://github.com/rails-api/active_model_serializers/pull/2017

-  Fix thor warning to set type: :boolean, was setting `{ banner: "" }` ref https://github.com/rails-api/active_model_serializers/pull/2008

   ```ruby
   require "rails/generators/rails/model/model_generator"

   module Rails
    module Generators
      class ResourceGenerator < ModelGenerator # :nodoc:
        include ResourceHelpers

         hook_for :resource_controller, required: true do |controller|
          invoke controller, [ controller_name, options[:actions] ]
        end

         class_option :actions, type: :array, banner: "ACTION ACTION",
   default: [],
                               desc: "Actions for the resource controller"

         hook_for :resource_route, required: true
      end
    end end
   ```

   ```ruby
   #  .bundle/ruby/2.2.0/bundler/gems/rails-4c5f1bc9d45e/railties/lib/rails/generators/base.rb
        # Invoke a generator based on the value supplied by the user to the
        # given option named "name". A class option is created when this
   method
        # is invoked and you can set a hash to customize it.
        #
        # ==== Examples
        #
        #   module Rails::Generators
        #     class ControllerGenerator < Base
        #       hook_for :test_framework, aliases: "-t"
        #     end
        #   end
        #
        # The example above will create a test framework option and will
   invoke
        # a generator based on the user supplied value.
        #
        # For example, if the user invoke the controller generator as:
        #
        #   rails generate controller Account --test-framework=test_unit
        #
        # The controller generator will then try to invoke the following
   generators:
        #
        #   "rails:test_unit", "test_unit:controller", "test_unit"
        #
        # Notice that "rails:generators:test_unit" could be loaded as well,
   what
        # Rails looks for is the first and last parts of the namespace. This
   is what
        # allows any test framework to hook into Rails as long as it provides
   any
        # of the hooks above.
        #
        # ==== Options
        #
        # The first and last part used to find the generator to be invoked are
        # guessed based on class invokes hook_for, as noticed in the example
   above.
        # This can be customized with two options: :in and :as.
        #
        # Let's suppose you are creating a generator that needs to invoke the
        # controller generator from test unit. Your first attempt is:
        #
        #   class AwesomeGenerator < Rails::Generators::Base
        #     hook_for :test_framework
        #   end
        #
        # The lookup in this case for test_unit as input is:
        #
        #   "test_unit:awesome", "test_unit"
        #
        # Which is not the desired lookup. You can change it by providing the
        # :as option:
        #
        #   class AwesomeGenerator < Rails::Generators::Base
        #     hook_for :test_framework, as: :controller
        #   end
        #
        # And now it will look up at:
        #
        #   "test_unit:controller", "test_unit"
        #
        # Similarly, if you want it to also look up in the rails namespace,
   you
        # just need to provide the :in value:
        #
        #   class AwesomeGenerator < Rails::Generators::Base
        #     hook_for :test_framework, in: :rails, as: :controller
        #   end
        #
        # And the lookup is exactly the same as previously:
        #
        #   "rails:test_unit", "test_unit:controller", "test_unit"
        #
        # ==== Switches
        #
        # All hooks come with switches for user interface. If you do not want
        # to use any test framework, you can do:
        #
        #   rails generate controller Account --skip-test-framework
        #
        # Or similarly:
        #
        #   rails generate controller Account --no-test-framework
        #
        # ==== Boolean hooks
        #
        # In some cases, you may want to provide a boolean hook. For example,
   webrat
        # developers might want to have webrat available on controller
   generator.
        # This can be achieved as:
        #
        #   Rails::Generators::ControllerGenerator.hook_for :webrat, type:
   :boolean
        #
        # Then, if you want webrat to be invoked, just supply:
        #
        #   rails generate controller Account --webrat
        #
        # The hooks lookup is similar as above:
        #
        #   "rails:generators:webrat", "webrat:generators:controller",
   "webrat"
        #
        # ==== Custom invocations
        #
        # You can also supply a block to hook_for to customize how the hook is
        # going to be invoked. The block receives two arguments, an instance
        # of the current class and the class to be invoked.
        #
        # For example, in the resource generator, the controller should be
   invoked
        # with a pluralized class name. But by default it is invoked with the
   same
        # name as the resource generator, which is singular. To change this,
   we
        # can give a block to customize how the controller can be invoked.
        #
        #   hook_for :resource_controller do |instance, controller|
        #     instance.invoke controller, [ instance.name.pluralize ]
        #   end
        #
        def self.hook_for(*names, &block)
          options = names.extract_options!
          in_base = options.delete(:in) || base_name
          as_hook = options.delete(:as) || generator_name

           names.each do |name|
            unless class_options.key?(name)
              defaults = if options[:type] == :boolean
                {}
              elsif [true, false].include?(default_value_for_option(name,
   options))
                { banner: "" }
              else
                { desc: "#{name.to_s.humanize} to be invoked", banner: "NAME"
   }
              end

               class_option(name, defaults.merge!(options))
            end

             hooks[name] = [ in_base, as_hook ]
            invoke_from_option(name, options, &block)
          end
        end
   ```

   ```ruby
    # .bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/parser/option.rb:113:in
   `validate!'
      #   parse :foo => true
      #   #=> Option foo with default value true and type boolean
      #
      # The valid types are :boolean, :numeric, :hash, :array and :string. If
   none
      # is given a default type is assumed. This default type accepts
   arguments as
      # string (--foo=value) or booleans (just --foo).
      #
      # By default all options are optional, unless :required is given.
      def validate_default_type!
        default_type = case @default
        when nil
          return
        when TrueClass, FalseClass
          required? ? :string : :boolean
        when Numeric
          :numeric
        when Symbol
          :string
        when Hash, Array, String
          @default.class.name.downcase.to_sym
        end

         # TODO: This should raise an ArgumentError in a future version of
   Thor
        if default_type != @type
          warn "Expected #{@type} default value for '#{switch_name}'; got
   #{@default.inspect} (#{default_type})"
        end
      end
   ```