### PR TITLE
Silence Grape warnings

### DIFF
--- a/test/grape_test.rb
+++ b/test/grape_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
-require 'grape'
+TestHelper.silence_warnings do
+  require 'grape'
+end
 require 'grape/active_model_serializers'
 require 'kaminari'
 require 'kaminari/hooks'
@@ -53,7 +55,15 @@ module ActiveModelSerializers
 
     class GrapeTest < Grape::API
       format :json
-      include Grape::ActiveModelSerializers
+      TestHelper.silence_warnings do
+        include Grape::ActiveModelSerializers
+      end
+
+      def self.resources(*)
+        TestHelper.silence_warnings do
+          super
+        end
+      end
 
       resources :grape do
         get '/render' do
@@ -91,6 +101,14 @@ module ActiveModelSerializers
 
     def app
       Grape::Middleware::Globals.new(GrapeTest.new)
+    end
+
+    extend Minitest::Assertions
+    def self.run_one_method(*)
+      _, stderr = capture_io do
+        super
+      end
+      fail Minitest::Assertion, stderr if stderr !~ /grape/
     end
 
     def test_formatter_returns_json

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,6 +40,18 @@ require 'minitest'
 require 'minitest/autorun'
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
+module TestHelper
+  module_function
+
+  def silence_warnings
+    original_verbose = $VERBOSE
+    $VERBOSE = nil
+    yield
+  ensure
+    $VERBOSE = original_verbose
+  end
+end
+
 require 'support/rails_app'
 
 # require "rails/test_help"


### PR DESCRIPTION
Extracted from https://github.com/rails-api/active_model_serializers/pull/2017

Is just test noise until fixed in grape, but there's a lot of warnings otherwise and are pretty distracting