### PR TITLE
Fix model attribute accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ Breaking changes:
 
 Features:
 
-- [#2021](https://github.com/rails-api/active_model_serializers/pull/2021) ActiveModelSerializers::Model#attributes. (@bf4)
+- [#2021](https://github.com/rails-api/active_model_serializers/pull/2021) ActiveModelSerializers::Model#attributes. Originally in [#1982](https://github.com/rails-api/active_model_serializers/pull/1982). (@bf4)
 
 Fixes:
+
+- [#2022](https://github.com/rails-api/active_model_serializers/pull/2022) Mutation of ActiveModelSerializers::Model now changes the attributes. Originally in [#1984](https://github.com/rails-api/active_model_serializers/pull/1984). (@bf4)
 
 Misc:
 

--- a/docs/howto/serialize_poro.md
+++ b/docs/howto/serialize_poro.md
@@ -29,7 +29,7 @@ define and validate which methods ActiveModelSerializers expects to be implement
 
 An implementation of the complete spec is included either for use or as reference:
 [`ActiveModelSerializers::Model`](../../lib/active_model_serializers/model.rb).
-You can use in production code that will make your PORO a lot cleaner.  
+You can use in production code that will make your PORO a lot cleaner.
 
 The above code now becomes:
 

--- a/test/action_controller/adapter_selector_test.rb
+++ b/test/action_controller/adapter_selector_test.rb
@@ -3,6 +3,15 @@ require 'test_helper'
 module ActionController
   module Serialization
     class AdapterSelectorTest < ActionController::TestCase
+      class Profile < Model
+        attributes :id, :name, :description
+        associations :comments
+      end
+      class ProfileSerializer < ActiveModel::Serializer
+        type 'profiles'
+        attributes :name, :description
+      end
+
       class AdapterSelectorTestController < ActionController::Base
         def render_using_default_adapter
           @profile = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')

--- a/test/action_controller/namespace_lookup_test.rb
+++ b/test/action_controller/namespace_lookup_test.rb
@@ -4,7 +4,7 @@ module ActionController
   module Serialization
     class NamespaceLookupTest < ActionController::TestCase
       class Book < ::Model
-        attributes :title, :body
+        attributes :id, :title, :body
         associations :writer, :chapters
       end
       class Chapter < ::Model

--- a/test/action_controller/namespace_lookup_test.rb
+++ b/test/action_controller/namespace_lookup_test.rb
@@ -86,7 +86,7 @@ module ActionController
               book = Book.new(title: 'New Post', body: 'Body')
 
               # because this is a string, ruby can't auto-lookup the constant, so otherwise
-              # the looku things we mean ::Api::V2
+              # the lookup thinks we mean ::Api::V2
               render json: book, namespace: 'ActionController::Serialization::NamespaceLookupTest::Api::V2'
             end
 
@@ -94,7 +94,7 @@ module ActionController
               book = Book.new(title: 'New Post', body: 'Body')
 
               # because this is a string, ruby can't auto-lookup the constant, so otherwise
-              # the looku things we mean ::Api::V2
+              # the lookup thinks we mean ::Api::V2
               render json: book, namespace: :'ActionController::Serialization::NamespaceLookupTest::Api::V2'
             end
 

--- a/test/active_model_serializers/model_test.rb
+++ b/test/active_model_serializers/model_test.rb
@@ -49,6 +49,33 @@ module ActiveModelSerializers
       assert_equal 1, instance.read_attribute_for_serialization(:one)
     end
 
+    def test_attributes_can_be_read_for_serialization_with_attributes_accessors_fix
+      klass = Class.new(ActiveModelSerializers::Model) do
+        derive_attributes_from_names_and_fix_accessors
+        attributes :one, :two, :three
+      end
+      original_attributes = { one: 1, two: 2, three: 3 }
+      original_instance = klass.new(original_attributes)
+
+      # Initial value
+      instance = original_instance
+      expected_attributes = { one: 1, two: 2, three: 3 }.with_indifferent_access
+      assert_equal expected_attributes, instance.attributes
+      assert_equal 1, instance.one
+      assert_equal 1, instance.read_attribute_for_serialization(:one)
+
+      expected_attributes = { one: :not_one, two: 2, three: 3 }.with_indifferent_access
+      # Change via accessor
+      instance = original_instance.dup
+      instance.one = :not_one
+      assert_equal expected_attributes, instance.attributes
+      assert_equal :not_one, instance.one
+      assert_equal :not_one, instance.read_attribute_for_serialization(:one)
+
+      # Attributes frozen
+      assert instance.attributes.frozen?
+    end
+
     def test_id_attribute_can_be_read_for_serialization
       klass = Class.new(ActiveModelSerializers::Model) do
         attributes :id, :one, :two, :three
@@ -78,6 +105,36 @@ module ActiveModelSerializers
       assert_equal expected_attributes, instance.attributes
       assert_equal :ego, instance.id
       assert_equal :ego, instance.read_attribute_for_serialization(:id)
+    ensure
+      self.class.send(:remove_const, :SomeTestModel)
+    end
+
+    def test_id_attribute_can_be_read_for_serialization_with_attributes_accessors_fix
+      klass = Class.new(ActiveModelSerializers::Model) do
+        derive_attributes_from_names_and_fix_accessors
+        attributes :id, :one, :two, :three
+      end
+      self.class.const_set(:SomeTestModel, klass)
+      original_attributes = { id: :ego, one: 1, two: 2, three: 3 }
+      original_instance = klass.new(original_attributes)
+
+      # Initial value
+      instance = original_instance.dup
+      expected_attributes = { id: :ego, one: 1, two: 2, three: 3 }.with_indifferent_access
+      assert_equal expected_attributes, instance.attributes
+      assert_equal :ego, instance.id
+      assert_equal :ego, instance.read_attribute_for_serialization(:id)
+
+      expected_attributes = { id: :superego, one: 1, two: 2, three: 3 }.with_indifferent_access
+      # Change via accessor
+      instance = original_instance.dup
+      instance.id = :superego
+      assert_equal expected_attributes, instance.attributes
+      assert_equal :superego, instance.id
+      assert_equal :superego, instance.read_attribute_for_serialization(:id)
+
+      # Attributes frozen
+      assert instance.attributes.frozen?
     ensure
       self.class.send(:remove_const, :SomeTestModel)
     end

--- a/test/adapter/json/has_many_test.rb
+++ b/test/adapter/json/has_many_test.rb
@@ -4,6 +4,10 @@ module ActiveModelSerializers
   module Adapter
     class Json
       class HasManyTestTest < ActiveSupport::TestCase
+        class ModelWithoutSerializer < ::Model
+          attributes :id, :name
+        end
+
         def setup
           ActionController::Base.cache_store.clear
           @author = Author.new(id: 1, name: 'Steve K.')
@@ -16,7 +20,7 @@ module ActiveModelSerializers
           @second_comment.post = @post
           @blog = Blog.new(id: 1, name: 'My Blog!!')
           @post.blog = @blog
-          @tag = Tag.new(id: 1, name: '#hash_tag')
+          @tag = ModelWithoutSerializer.new(id: 1, name: '#hash_tag')
           @post.tags = [@tag]
         end
 
@@ -30,7 +34,11 @@ module ActiveModelSerializers
         end
 
         def test_has_many_with_no_serializer
-          serializer = PostWithTagsSerializer.new(@post)
+          post_serializer_class = Class.new(ActiveModel::Serializer) do
+            attributes :id
+            has_many :tags
+          end
+          serializer = post_serializer_class.new(@post)
           adapter = ActiveModelSerializers::Adapter::Json.new(serializer)
           assert_equal({
             id: 42,

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -4,6 +4,10 @@ module ActiveModelSerializers
   module Adapter
     class JsonApi
       class HasManyTest < ActiveSupport::TestCase
+        class ModelWithoutSerializer < ::Model
+          attributes :id, :name
+        end
+
         def setup
           ActionController::Base.cache_store.clear
           @author = Author.new(id: 1, name: 'Steve K.')
@@ -26,7 +30,7 @@ module ActiveModelSerializers
           @blog.articles = [@post]
           @post.blog = @blog
           @post_without_comments.blog = nil
-          @tag = Tag.new(id: 1, name: '#hash_tag')
+          @tag = ModelWithoutSerializer.new(id: 1, name: '#hash_tag')
           @post.tags = [@tag]
           @serializer = PostSerializer.new(@post)
           @adapter = ActiveModelSerializers::Adapter::JsonApi.new(@serializer)
@@ -129,7 +133,11 @@ module ActiveModelSerializers
         end
 
         def test_has_many_with_no_serializer
-          serializer = PostWithTagsSerializer.new(@post)
+          post_serializer_class = Class.new(ActiveModel::Serializer) do
+            attributes :id
+            has_many :tags
+          end
+          serializer = post_serializer_class.new(@post)
           adapter = ActiveModelSerializers::Adapter::JsonApi.new(serializer)
 
           assert_equal({

--- a/test/adapter/json_api/include_data_if_sideloaded_test.rb
+++ b/test/adapter/json_api/include_data_if_sideloaded_test.rb
@@ -14,9 +14,19 @@ module ActiveModel
               [{ foo: 'bar' }]
             end
           end
+          class Tag < ::Model
+            attributes :id, :name
+          end
 
           class TagSerializer < ActiveModel::Serializer
+            type 'tags'
             attributes :id, :name
+          end
+
+          class PostWithTagsSerializer < ActiveModel::Serializer
+            type 'posts'
+            attributes :id
+            has_many :tags
           end
 
           class IncludeParamAuthorSerializer < ActiveModel::Serializer

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,6 +1,4 @@
 class Model < ActiveModelSerializers::Model
-  FILE_DIGEST = Digest::MD5.hexdigest(File.open(__FILE__).read)
-
   attr_writer :id
 
   # At this time, just for organization of intent
@@ -108,10 +106,6 @@ class PostPreviewSerializer < ActiveModel::Serializer
   has_many :comments, serializer: ::CommentPreviewSerializer
   belongs_to :author, serializer: ::AuthorPreviewSerializer
 end
-class PostWithTagsSerializer < ActiveModel::Serializer
-  attributes :id
-  has_many :tags
-end
 class PostWithCustomKeysSerializer < ActiveModel::Serializer
   attributes :id
   has_many :comments, key: :reviews
@@ -206,10 +200,6 @@ module Spam
     cache only: [:id]
     attributes :id
   end
-end
-
-class Tag < Model
-  attributes :name
 end
 
 class VirtualValue < Model; end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -1,4 +1,6 @@
 class Model < ActiveModelSerializers::Model
+  rand(2).zero? && derive_attributes_from_names_and_fix_accessors
+
   attr_writer :id
 
   # At this time, just for organization of intent

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -2,13 +2,17 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class AssociationsTest < ActiveSupport::TestCase
+      class ModelWithoutSerializer < ::Model
+        attributes :id, :name
+      end
+
       def setup
         @author = Author.new(name: 'Steve K.')
         @author.bio = nil
         @author.roles = []
         @blog = Blog.new(name: 'AMS Blog')
         @post = Post.new(title: 'New Post', body: 'Body')
-        @tag = Tag.new(id: 'tagid', name: '#hashtagged')
+        @tag = ModelWithoutSerializer.new(id: 'tagid', name: '#hashtagged')
         @comment = Comment.new(id: 1, body: 'ZOMG A COMMENT')
         @post.comments = [@comment]
         @post.tags = [@tag]
@@ -46,7 +50,11 @@ module ActiveModel
       end
 
       def test_has_many_with_no_serializer
-        PostWithTagsSerializer.new(@post).associations.each do |association|
+        post_serializer_class = Class.new(ActiveModel::Serializer) do
+          attributes :id
+          has_many :tags
+        end
+        post_serializer_class.new(@post).associations.each do |association|
           key = association.key
           serializer = association.serializer
           options = association.options


### PR DESCRIPTION
#### Purpose

Replaces https://github.com/rails-api/active_model_serializers/pull/1998 and #1984 with an opt-in change, rather that breaking change with backwards compatibility.

#### Changes

Add new opt-in behavior for fixing the attributes change via accessors bug.

#### Caveats

It will still need to be reconciled with master, which I'll take care of once this is reviewed.


