### PR TITLE
Fix doc about meta_key example

### DIFF
--- a/docs/general/rendering.md
+++ b/docs/general/rendering.md
@@ -95,7 +95,7 @@ render json: @post, meta: { total: 10 }
 The key can be customized using `meta_key` option.
 
 ```ruby
-render json: @post, meta: { total: 10 }, meta_key: "custom_meta"
+render json: @post, custom_meta: { total: 10 }, meta_key: :custom_meta
 ```
 
 `meta` will only be included in your response if you are using an Adapter that


### PR DESCRIPTION
#### Purpose
In the documentation, the example for changing the meta key seems incorrect. The example has a string, but only a symbol will work, and only the 'custom_meta'  works well rather than 'meta'. The version 0.9 had already fixed this little mistake.

#### Related GitHub issues
[#1868](https://github.com/rails-api/active_model_serializers/issues/1868)
[#1328](https://github.com/rails-api/active_model_serializers/issues/1328)


