### PR TITLE
Fix JRuby build on CI, with a suggestion from Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ rvm:
 jdk:
   - oraclejdk8
 
+before_install:
+  - gem update --system
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v 1.13.7
 install: bundle install --path=vendor/bundle --retry=3 --jobs=3
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - ruby-head
-  - jruby-9.0.4.0
+  - jruby-9.1.5.0 # is precompiled per http://rubies.travis-ci.org/
   - jruby-head
 
 jdk:
@@ -39,13 +39,13 @@ matrix:
   exclude:
   - rvm: 2.1
     env: RAILS_VERSION=master
-  - rvm: jruby-9.0.4.0
+  - rvm: jruby-9.1.5.0
     env: RAILS_VERSION=master
   - rvm: jruby-head
     env: RAILS_VERSION=master
   - rvm: 2.1
     env: RAILS_VERSION=5.0
-  - rvm: jruby-9.0.4.0
+  - rvm: jruby-9.1.5.0
     env: RAILS_VERSION=5.0
   - rvm: jruby-head
     env: RAILS_VERSION=5.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,9 @@ cache:
 
 install:
   - SET PATH=C:\%ruby_version%\bin;%PATH%
-  - gem install bundler
+  - gem update --system
+  - gem uninstall bundler -a -x
+  - gem install bundler -v 1.13.7
   - bundle env
   - bundle install --path=vendor/bundle --retry=3 --jobs=3
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,10 @@ cache:
 
 install:
   # conditionally install jruby version, per https://github.com/shoes/shoes4/blob/428a09b4a4d884342a1bcecd541a172064396fb3/appveyor.yml
+  # And see http://stackoverflow.com/a/16373842
   - |
-    if "%jruby_version%"=="jruby-9.1.6.0" (
+    cmd /E:on /c "
+    if defined jruby_version (
       cd ..
       appveyor DownloadFile https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.zip
       7z x jruby-bin-9.1.6.0.zip -y
@@ -24,6 +26,7 @@ install:
     else (
       SET PATH=C:\%ruby_version%\bin;%PATH%
     )
+    "
   - gem update --system
   - gem uninstall bundler -a -x
   - gem install bundler -v 1.13.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,15 +7,12 @@ environment:
   matrix:
     - ruby_version: "Ruby21"
     - ruby_version: "Ruby21-x64"
-    - jruby_version: "jruby-9.1.6.0" # no pre-installed versions https://www.appveyor.com/docs/installed-software/#ruby
 
 cache:
   - vendor/bundle
 
 install:
-  # conditionally install jruby version, per https://github.com/shoes/shoes4/blob/428a09b4a4d884342a1bcecd541a172064396fb3/appveyor.yml
-  # And see http://stackoverflow.com/a/16373842
-  - cmd /E:on /c "if defined jruby_version (cd ..; appveyor DownloadFile https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.zip; 7z x jruby-bin-9.1.6.0.zip -y; SET PATH=C:\projects\jruby-9.1.6.0\bin;%PATH% ) else ( SET PATH=C:\%ruby_version%\bin;%PATH% )"
+  - SET PATH=C:\%ruby_version%\bin;%PATH%
   - gem update --system
   - gem uninstall bundler -a -x
   - gem install bundler -v 1.13.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,12 +15,11 @@ cache:
 install:
   # conditionally install jruby version, per https://github.com/shoes/shoes4/blob/428a09b4a4d884342a1bcecd541a172064396fb3/appveyor.yml
   # And see http://stackoverflow.com/a/16373842
-  - |
+  - >
     cmd /E:on /c "
-    if defined jruby_version (
-      cd ..
-      appveyor DownloadFile https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.zip
-      7z x jruby-bin-9.1.6.0.zip -y
+    if defined jruby_version (cd ..;
+      appveyor DownloadFile https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.zip;
+      7z x jruby-bin-9.1.6.0.zip -y;
       SET PATH=C:\projects\jruby-9.1.6.0\bin;%PATH%
     )
     else (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,23 @@ environment:
   matrix:
     - ruby_version: "Ruby21"
     - ruby_version: "Ruby21-x64"
-    - ruby_version: "jruby-9.1.5.0" # no pre-installed versions https://www.appveyor.com/docs/installed-software/#ruby
+    - jruby_version: "jruby-9.1.6.0" # no pre-installed versions https://www.appveyor.com/docs/installed-software/#ruby
 
 cache:
   - vendor/bundle
 
 install:
-  - SET PATH=C:\%ruby_version%\bin;%PATH%
+  # conditionally install jruby version, per https://github.com/shoes/shoes4/blob/428a09b4a4d884342a1bcecd541a172064396fb3/appveyor.yml
+  - |
+    if "%jruby_version%"=="jruby-9.1.6.0" (
+      cd ..
+      appveyor DownloadFile https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.zip
+      7z x jruby-bin-9.1.6.0.zip -y
+      SET PATH=C:\projects\jruby-9.1.6.0\bin;%PATH%
+    )
+    else (
+      SET PATH=C:\%ruby_version%\bin;%PATH%
+    )
   - gem update --system
   - gem uninstall bundler -a -x
   - gem install bundler -v 1.13.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '{build}'
+version: 1.0.{build}-{branch}
 
 skip_tags: true
 
@@ -7,7 +7,7 @@ environment:
   matrix:
     - ruby_version: "Ruby21"
     - ruby_version: "Ruby21-x64"
-    - ruby_version: "jruby-9.0.0.0"
+    - ruby_version: "jruby-9.1.5.0" # no pre-installed versions https://www.appveyor.com/docs/installed-software/#ruby
 
 cache:
   - vendor/bundle
@@ -19,6 +19,11 @@ install:
   - gem install bundler -v 1.13.7
   - bundle env
   - bundle install --path=vendor/bundle --retry=3 --jobs=3
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
 
 test_script:
   - bundle exec rake ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,17 +15,7 @@ cache:
 install:
   # conditionally install jruby version, per https://github.com/shoes/shoes4/blob/428a09b4a4d884342a1bcecd541a172064396fb3/appveyor.yml
   # And see http://stackoverflow.com/a/16373842
-  - >
-    cmd /E:on /c "
-    if defined jruby_version (cd ..;
-      appveyor DownloadFile https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.zip;
-      7z x jruby-bin-9.1.6.0.zip -y;
-      SET PATH=C:\projects\jruby-9.1.6.0\bin;%PATH%
-    )
-    else (
-      SET PATH=C:\%ruby_version%\bin;%PATH%
-    )
-    "
+  - cmd /E:on /c "if defined jruby_version (cd ..; appveyor DownloadFile https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.zip; 7z x jruby-bin-9.1.6.0.zip -y; SET PATH=C:\projects\jruby-9.1.6.0\bin;%PATH% ) else ( SET PATH=C:\%ruby_version%\bin;%PATH% )"
   - gem update --system
   - gem uninstall bundler -a -x
   - gem install bundler -v 1.13.7


### PR DESCRIPTION
per
https://github.com/hanami/helpers/pull/97/commits/13f30e287c315f93141c2da005d4f08dec0d16dc
per https://twitter.com/jodosha/status/823522145745731586

and ref https://github.com/rails/rails/pull/23453

Failures:

- https://travis-ci.org/rails-api/active_model_serializers/jobs/194809110
- https://ci.appveyor.com/project/bf4/active-model-serializers/build/782/job/y4upmix6325a865x

> Bundler could not find compatible versions for gem "json":
In snapshot (Gemfile.lock):
  json (= 1.8.6) java
  In Gemfile:
    simplecov (~> 0.11) java was resolved to 0.12.0, which depends on
    json (< 3, >= 1.8) java
  simplecov (~> 0.11) java was resolved to 0.12.0, which depends on
    json (< 3, >= 1.8)

- https://ci.appveyor.com/project/bf4/active-model-serializers/build/782/job/14mq0r5t0dfr7f1c

> C:/Ruby21/lib/ruby/gems/2.1.0/gems/bundler-1.14.2/lib/bundler/resolver.rb:207:in `rescue in start': Bundler could not find compatible versions for gem "nokogiri": (Bundler::VersionConflict)
In snapshot (Gemfile.lock):
  nokogiri (= 1.7.0.1) x86-mingw32
  In Gemfile:
  active_model_serializers x86-mingw32 was resolved to 0.10.4, which depends on
  actionpack (< 6, >= 4.1) x86-mingw32 was resolved to 4.2.7.1, which depends on
  rails-dom-testing (>= 1.0.5, ~> 1.0) was resolved to 1.0.8, which depends on
  nokogiri (~> 1.6) x86-mingw32
  active_model_serializers x86-mingw32 was resolved to 0.10.4, which depends on
  actionpack (< 6, >= 4.1) x86-mingw32 was resolved to 4.2.7.1, which depends on
  rails-dom-testing (>= 1.0.5, ~> 1.0) was resolved to 1.0.8, which depends on
  nokogiri (~> 1.6)
  Running `bundle update` will rebuild your snapshot from scratch, using only