### PR TITLE
Fixes bug in Test::Schema when using filter_parameters

### DIFF
--- a/lib/active_model_serializers/test/schema.rb
+++ b/lib/active_model_serializers/test/schema.rb
@@ -60,11 +60,11 @@ module ActiveModelSerializers
         attr_reader :document_store
 
         def controller_path
-          request.filtered_parameters[:controller]
+          request.filtered_parameters.with_indifferent_access[:controller]
         end
 
         def action
-          request.filtered_parameters[:action]
+          request.filtered_parameters.with_indifferent_access[:action]
         end
 
         def schema_directory

--- a/test/active_model_serializers/test/schema_test.rb
+++ b/test/active_model_serializers/test/schema_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+Rails.application.config.filter_parameters += [:password]
+
 module ActiveModelSerializers
   module Test
     class SchemaTest < ActionController::TestCase

--- a/test/active_model_serializers/test/schema_test.rb
+++ b/test/active_model_serializers/test/schema_test.rb
@@ -1,7 +1,5 @@
 require 'test_helper'
 
-Rails.application.config.filter_parameters += [:password]
-
 module ActiveModelSerializers
   module Test
     class SchemaTest < ActionController::TestCase

--- a/test/support/rails_app.rb
+++ b/test/support/rails_app.rb
@@ -6,6 +6,8 @@ module ActiveModelSerializers
       config.active_support.test_order = :random
       config.action_controller.perform_caching = true
       config.action_controller.cache_store = :memory_store
+
+      config.filter_parameters += [:password]
     end
 
     app.routes.default_url_options = { host: 'example.com' }


### PR DESCRIPTION
By default all Rails apps are created with an initializer called _filter_parameter_logging.rb_ and its default contents are:

```ruby
Rails.application.config.filter_parameters += [:password]
```

If this line is executed, as it is on this PR, the class of `request.filtered_parameters` changes from `ActiveSupport::HashWithIndifferentAccess` to `Hash`. This causes `Schema::Test` not to be able to find schemas by controller path and action:

```
     ActiveModelSerializers::Test::Schema::MissingSchema:
       No Schema file at spec/support/schemas//.json
```

Not properly "mocking" the Rails app properly caused the bug to be hidden in this and [leonelgalan/rspec-active_model_serializers](https://github.com/leonelgalan/rspec-active_model_serializers) test suite.

This bug was first reported by me in another in https://github.com/rails-api/active_model_serializers/pull/1947#pullrequestreview-5497390, but at the time I couldn't produce failing tests. 

