### PR TITLE
Docs: Update changelog for 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Misc:
 
 ### [v0.10.3 (2016-11-21)](https://github.com/rails-api/active_model_serializers/compare/v0.10.2...v0.10.3)
 
+Known Issues:
+
+- [#2048](https://github.com/rails-api/active_model_serializers/pull/2048)
+  The output of `render json: MyModel.new` has changed when no serializer
+  is found for `MyModel`. Now, we just call `as_json` on anything that doesn't
+  have a serializer.
+
 Fixes:
 
 - [#1973](https://github.com/rails-api/active_model_serializers/pull/1973) Fix namespace lookup for collections and has_many relationships (@groyoh)

--- a/docs/howto/upgrade_from_0_8_to_0_10.md
+++ b/docs/howto/upgrade_from_0_8_to_0_10.md
@@ -56,6 +56,7 @@ ActiveModel::ArraySerializer.new(resources, root: "resources")
 ```
 
 - No default serializer when serializer doesn't exist
+  - We just call `as_json` on anything that doesn't have a serializer.
 - `@options` changed to `instance_options`
 - Nested relationships are no longer walked by default. Use the `:include` option at **controller `render`** level to specify what relationships to walk. E.g. `render json: @post, include: {comments: :author}` if you want the `author` relationship walked, otherwise the json would only include the post with comments. See: https://github.com/rails-api/active_model_serializers/pull/1127
 - To emulate `0.8`'s walking of arbitrarily deep relationships use: `include: '**'`. E.g. `render json: @post, include: '**'`


### PR DESCRIPTION
I hope this will help someone else to upgrade.

# Demonstration of breaking change

```ruby
class Banana < ApplicationRecord
end
# There is no BananaSerializer
```

## 0.10.2

```ruby
render json: @banana # => {"id":1,"name":"a banana"}
```

## 0.10.3

```ruby
render json: @banana # => {}
```
