### PR TITLE
ActiveModel::Model handles the ActiveModel::Errors API

### DIFF
--- a/lib/active_model_serializers/model.rb
+++ b/lib/active_model_serializers/model.rb
@@ -125,16 +125,5 @@ module ActiveModelSerializers
         "#{id}-#{updated_at.strftime('%Y%m%d%H%M%S%9N')}"
       ].compact)
     end
-
-    # The following methods are needed to be minimally implemented for ActiveModel::Errors
-    # :nocov:
-    def self.human_attribute_name(attr, _options = {})
-      attr
-    end
-
-    def self.lookup_ancestors
-      [self]
-    end
-    # :nocov:
   end
 end


### PR DESCRIPTION
Closes https://github.com/rails-api/active_model_serializers/issues/2049

ActiveModel::Model already extends ActiveModel::Translation which
implements human_attribute_name and lookup_ancestors