### PR TITLE
jsonapi is deprecated, just use jsonapi-renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Fixes:
 
 Misc:
 
+- [#2055](https://github.com/rails-api/active_model_serializers/pull/2055)
+  Replace deprecated dependency jsonapi with jsonapi-renderer. (@jaredbeck)
 - [#2021](https://github.com/rails-api/active_model_serializers/pull/2021) Make test attributes explicit. Tests have Model#associations. (@bf4)
 - [#1981](https://github.com/rails-api/active_model_serializers/pull/1981) Fix relationship link documentation. (@groyoh)
 - [#2035](https://github.com/rails-api/active_model_serializers/pull/2035) Document how to disable the logger. (@MSathieu)

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -42,7 +42,8 @@ Gem::Specification.new do |spec|
   # 'minitest'
   # 'thread_safe'
 
-  spec.add_runtime_dependency 'jsonapi', '0.1.1.beta6'
+  # TODO: Latest jsonapi-renderer is 0.1.2
+  spec.add_runtime_dependency 'jsonapi-renderer', '0.1.1.beta1'
   spec.add_runtime_dependency 'case_transform', '>= 0.2'
 
   spec.add_development_dependency 'activerecord', rails_versions


### PR DESCRIPTION
From the author of jsonapi:

> .. The jsonapi gem was previously just a bundle of jsonapi-serializer and jsonapi-renderer, and AMS is using only a helper class of jsonapi-renderer (namely JSONAPI::IncludeDirective). The AMS dependency was previously not properly pinned to a specific version, which I saw as a risk for many users, so I avoided updating this gem. Moreover, the name jsonapi being somewhat too generic for what this gem evolved into (namely jsonapi-rb, which bundles jsonapi-renderer and jsonapi-parser, along with serializers and deserializers, with tight integrations with various frameworks), I decided to stay away from it for fairness.
> TL;DR: Yes, people should use jsonapi-parser and jsonapi-renderer directly (or give a try to jsonapi-rb, depending on their needs).
> https://github.com/beauby/jsonapi/issues/54#issuecomment-280537900

We should also update jsonapi-renderer to the latest, currently 0.1.2, but I thought that should be a separate PR.
