### PR TITLE
Update version constraint for jsonapi-renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Breaking changes:
 Features:
 
 - [#2021](https://github.com/rails-api/active_model_serializers/pull/2021) ActiveModelSerializers::Model#attributes. Originally in [#1982](https://github.com/rails-api/active_model_serializers/pull/1982). (@bf4)
+- [#2057](https://github.com/rails-api/active_model_serializers/pull/2057)
+  Update version constraint for jsonapi-renderer to `['>= 0.1.1.beta1', '< 0.2']`
+  (@jaredbeck)
 
 Fixes:
 

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -42,8 +42,7 @@ Gem::Specification.new do |spec|
   # 'minitest'
   # 'thread_safe'
 
-  # TODO: Latest jsonapi-renderer is 0.1.2
-  spec.add_runtime_dependency 'jsonapi-renderer', '0.1.1.beta1'
+  spec.add_runtime_dependency 'jsonapi-renderer', ['>= 0.1.1.beta1', '< 0.2']
   spec.add_runtime_dependency 'case_transform', '>= 0.2'
 
   spec.add_development_dependency 'activerecord', rails_versions


### PR DESCRIPTION
Now that we are no longer using the deprecated `jsonapi` (https://github.com/rails-api/active_model_serializers/pull/2055) we can discuss updating the version constraint of `jsonapi-renderer`.

Currently (2017-02-20) the latest version is 0.1.2.

Why not use a version constraint like '~> 0.1.1'? Because we know of no reason why 0.1.1.beta1 cannot still be used. That said, we have done no research looking for such a reason.