### PR TITLE
Update documentation serializers.md

### DIFF
--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -225,10 +225,10 @@ With the `:json` adapter, the previous serializer would be rendered as:
 link :self do
   href "https://example.com/link_author/#{object.id}"
 end
-link :author { link_author_url(object) }
-link :link_authors { link_authors_url }
+link(:author) { link_author_url(object) }
+link(:link_authors) { link_authors_url }
 link :other, 'https://example.com/resource'
-link :posts { link_author_posts_url(object) }
+link(:posts) { link_author_posts_url(object) }
 ```
 
 #### #object


### PR DESCRIPTION
#### Purpose

fix up syntax error

```
syntax error, unexpected '{', expecting keyword_end
syntax error, unexpected '}', expecting keyword_end
```

#### Changes

```
- link :author { link_author_url(object) }
+ link(:author) { link_author_url(object) }
```

#### Caveats


#### Related GitHub issues


#### Additional helpful information


