### PR TITLE
Remove typo from upgrade from 0.8 to 0.10 docs

### DIFF
--- a/docs/howto/upgrade_from_0_8_to_0_10.md
+++ b/docs/howto/upgrade_from_0_8_to_0_10.md
@@ -107,7 +107,7 @@ end
 
 ```
 Add this class to your app however you see fit. This is the class that your existing serializers
-that inherit from `ActiveMode::Serializer` should inherit from.
+that inherit from `ActiveModel::Serializer` should inherit from.
 
 ### 3. Add `ActiveModel::V08::CollectionSerializer`
 ```ruby


### PR DESCRIPTION
#### Purpose
Remove typo

#### Changes
Update docs/howto/upgrade_from_0_8_to_0_10.md
Typo `ActiveMode::Serializer` was changed to `ActiveModel::Serializer`