### PR TITLE
Providing caveat in documentation

### DIFF
--- a/docs/integrations/ember-and-json-api.md
+++ b/docs/integrations/ember-and-json-api.md
@@ -75,7 +75,7 @@ end
 ```
 
 #### Note: 
-In Rails 5, the "unsafe" method (the one ending with a !) throws an InvalidDocument exception when the payload does not meet basic criteria for JSON API deserialization.
+In Rails 5, the "unsafe" method ( `jsonapi_parse!` vs the safe `jsonapi_parse`) throws an `InvalidDocument` exception when the payload does not meet basic criteria for JSON API deserialization.
 
 
 ### Adapter Changes

--- a/docs/integrations/ember-and-json-api.md
+++ b/docs/integrations/ember-and-json-api.md
@@ -74,6 +74,9 @@ Then, in your controller you can tell rails you're accepting and rendering the j
 end
 ```
 
+#### Note: 
+In Rails 5, the "unsafe" method (the one ending with a !) throws an InvalidDocument exception when the payload does not meet basic criteria for JSON API deserialization.
+
 
 ### Adapter Changes
 


### PR DESCRIPTION
I think it'd be helpful to mention that `jsonapi_parse!` will throw an InvalidDocument error.

#### Purpose


#### Changes


#### Caveats


#### Related GitHub issues


#### Additional helpful information


