### PR TITLE
Add rubocop binstub that respects file patterns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,13 @@
 AllCops:
   TargetRubyVersion: 2.1
   Exclude:
-    - config/initializers/forbidden_yaml.rb
     - !ruby/regexp /(vendor|bundle|bin|db|tmp)\/.*/
   DisplayCopNames: true
   DisplayStyleGuide: true
+  # https://github.com/bbatsov/rubocop/blob/master/manual/caching.md
+  # https://github.com/bbatsov/rubocop/blob/e8680418b351491e111a18cf5b453fc07a3c5239/config/default.yml#L60-L77
+  UseCache: true
+  CacheRootDirectory: tmp
 
 Rails:
   Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ begin
   require 'simplecov'
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
+import('lib/tasks/rubocop.rake')
 
 Bundler::GemHelper.install_tasks
 
@@ -27,36 +28,6 @@ namespace :yard do
     output_file = 'doc/erd.dot'
     sh "bundle exec yard graph --protected --full --dependencies > #{output_file}"
     puts 'open doc/erd.dot if you have graphviz installed'
-  end
-end
-
-begin
-  require 'rubocop'
-  require 'rubocop/rake_task'
-rescue LoadError # rubocop:disable Lint/HandleExceptions
-else
-  Rake::Task[:rubocop].clear if Rake::Task.task_defined?(:rubocop)
-  require 'rbconfig'
-  # https://github.com/bundler/bundler/blob/1b3eb2465a/lib/bundler/constants.rb#L2
-  windows_platforms = /(msdos|mswin|djgpp|mingw)/
-  if RbConfig::CONFIG['host_os'] =~ windows_platforms
-    desc 'No-op rubocop on Windows-- unsupported platform'
-    task :rubocop do
-      puts 'Skipping rubocop on Windows'
-    end
-  elsif defined?(::Rubinius)
-    desc 'No-op rubocop to avoid rbx segfault'
-    task :rubocop do
-      puts 'Skipping rubocop on rbx due to segfault'
-      puts 'https://github.com/rubinius/rubinius/issues/3499'
-    end
-  else
-    Rake::Task[:rubocop].clear if Rake::Task.task_defined?(:rubocop)
-    desc 'Execute rubocop'
-    RuboCop::RakeTask.new(:rubocop) do |task|
-      task.options = ['--rails', '--display-cop-names', '--display-style-guide']
-      task.fail_on_error = true
-    end
   end
 end
 

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Usage:
+#   bin/rubocop [-A|-t|-h]
+#   bin/rubocop [file or path] [cli options]
+#
+# Options:
+#  Autocorrect    -A
+#  AutoGenConfig  -t
+#  Usage          -h,--help,help
+
+set -e
+
+case $1 in
+  -A)
+     echo "Rubocop autocorrect is ON" >&2
+     bundle exec rake -f lib/tasks/rubocop.rake rubocop:auto_correct
+     ;;
+
+  -t)
+     echo "Rubocop is generating a new TODO" >&2
+     bundle exec rake -f lib/tasks/rubocop.rake rubocop:auto_gen_config
+     ;;
+
+  -h|--help|help)
+     sed -ne '/^#/!q;s/.\{1,2\}//;1d;p' < "$0"
+     ;;
+
+  *)
+     # with no args, run vanilla rubocop
+     # else assume we're passing in arbitrary arguments
+     if [ -z "$1" ]; then
+       bundle exec rake -f lib/tasks/rubocop.rake rubocop
+     else
+       bundle exec rubocop "$@"
+     fi
+     ;;
+esac

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,0 +1,53 @@
+begin
+  require 'rubocop'
+  require 'rubocop/rake_task'
+rescue LoadError # rubocop:disable Lint/HandleExceptions
+else
+  require 'rbconfig'
+  # https://github.com/bundler/bundler/blob/1b3eb2465a/lib/bundler/constants.rb#L2
+  windows_platforms = /(msdos|mswin|djgpp|mingw)/
+  if RbConfig::CONFIG['host_os'] =~ windows_platforms
+    desc 'No-op rubocop on Windows-- unsupported platform'
+    task :rubocop do
+      puts 'Skipping rubocop on Windows'
+    end
+  elsif defined?(::Rubinius)
+    desc 'No-op rubocop to avoid rbx segfault'
+    task :rubocop do
+      puts 'Skipping rubocop on rbx due to segfault'
+      puts 'https://github.com/rubinius/rubinius/issues/3499'
+    end
+  else
+    Rake::Task[:rubocop].clear if Rake::Task.task_defined?(:rubocop)
+    patterns = [
+      'Gemfile',
+      'Rakefile',
+      'lib/**/*.{rb,rake}',
+      'config/**/*.rb',
+      'app/**/*.rb',
+      'test/**/*.rb'
+    ]
+    desc 'Execute rubocop'
+    RuboCop::RakeTask.new(:rubocop) do |task|
+      task.options = ['--rails', '--display-cop-names', '--display-style-guide']
+      task.formatters = ['progress']
+      task.patterns = patterns
+      task.fail_on_error = true
+    end
+
+    namespace :rubocop do
+      desc 'Auto-gen rubocop config'
+      task :auto_gen_config do
+        options = ['--auto-gen-config'].concat patterns
+        require 'benchmark'
+        result = 0
+        cli = RuboCop::CLI.new
+        time = Benchmark.realtime do
+          result = cli.run(options)
+        end
+        puts "Finished in #{time} seconds" if cli.options[:debug]
+        abort('RuboCop failed!') if result.nonzero?
+      end
+    end
+  end
+end


### PR DESCRIPTION
Best of both worlds!

(Because you can't override the default rubocop includes)

The binstub basically, lets me safely `rubocop test/foo_test.rb`
instead of `bundle exec rubocop test/foo_test.rb`

```bash
  # ~/.profile
  # https://twitter.com/tpope/status/165631968996900865
  # tl;dr `mkdir .git/safe` to add `bin` to path, e.g. `bin/rails`
  PATH=".git/safe/../../bin:$PATH"
```