### PR TITLE
Testing collection serializer is broken ?

### DIFF
--- a/test/active_model_serializers/test/serializer_test.rb
+++ b/test/active_model_serializers/test/serializer_test.rb
@@ -6,6 +6,12 @@ module ActiveModelSerializers
       include ActiveModelSerializers::Test::Serializer
 
       class MyController < ActionController::Base
+        def render_multi_using_serializer
+          render json: [Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1'),
+                        Profile.new(name: 'Name 2', description: 'Description 2', comments: 'Comments 2')],
+                 each_serializer: ProfileSerializer
+        end
+
         def render_using_serializer
           render json: Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
         end
@@ -16,6 +22,11 @@ module ActiveModelSerializers
       end
 
       tests MyController
+
+      def test_supports_specifying_serializers_with_a_multi_serializer_class
+        get :render_multi_using_serializer
+        assert_serializer ProfileSerializer
+      end
 
       def test_supports_specifying_serializers_with_a_serializer_class
         get :render_using_serializer


### PR DESCRIPTION
Hey guys.

This is not a proper pull request, this is more a test to show the issue I am facing right now.

WDYT ?

#### Purpose

Contrary to what is stated here : https://github.com/rails-api/active_model_serializers/blob/a032201a91cbca407211bca0392ba881eef1f7ba/docs/howto/test.md#controller-serializer-usage : `assert_serializer` does not work on collection.

Error of the test implemented : 
```
ActiveModelSerializers::Test::SerializerTest#test_supports_specifying_serializers_with_a_multi_serializer_class [/home/romain/work/ams/test/active_model_serializers/test/serializer_test.rb:28]:
expecting <ProfileSerializer> but rendering with <["ActiveModel::Serializer::CollectionSerializer"]>
```
