### PR TITLE
Backport caching of the constant lookup

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 1.9.3"
 
   gem.add_dependency "activemodel", ">= 3.2"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_development_dependency "rails", ">= 3.2"
 end

--- a/lib/active_model/serializable.rb
+++ b/lib/active_model/serializable.rb
@@ -33,7 +33,11 @@ module ActiveModel
     end
 
     def namespace
-      get_namespace && Utils._const_get(get_namespace)
+      if module_name = get_namespace
+        Serializer.serializers_cache.fetch_or_store(module_name) do
+          Utils._const_get(module_name)
+        end
+      end
     end
 
     def embedded_in_root_associations

--- a/lib/active_model/serializable/utils.rb
+++ b/lib/active_model/serializable/utils.rb
@@ -4,11 +4,13 @@ module ActiveModel
       extend self
 
       def _const_get(const)
-        begin
-          method = RUBY_VERSION >= '2.0' ? :const_get : :qualified_const_get
-          Object.send method, const
-        rescue NameError
-          const.safe_constantize
+        Serializer.serializers_cache.fetch_or_store(const) do
+          begin
+            method = RUBY_VERSION >= '2.0' ? :const_get : :qualified_const_get
+            Object.send method, const
+          rescue NameError
+            const.safe_constantize
+          end
         end
       end
     end

--- a/lib/active_model/serializable/utils.rb
+++ b/lib/active_model/serializable/utils.rb
@@ -4,13 +4,11 @@ module ActiveModel
       extend self
 
       def _const_get(const)
-        Serializer.serializers_cache.fetch_or_store(const) do
-          begin
-            method = RUBY_VERSION >= '2.0' ? :const_get : :qualified_const_get
-            Object.send method, const
-          rescue NameError
-            const.safe_constantize
-          end
+        begin
+          method = RUBY_VERSION >= '2.0' ? :const_get : :qualified_const_get
+          Object.send method, const
+        rescue NameError
+          const.safe_constantize
         end
       end
     end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -66,7 +66,10 @@ end
             ArraySerializer
           end
         else
-          _const_get build_serializer_class(resource, options)
+          klass_name = build_serializer_class(resource, options)
+          Serializer.serializers_cache.fetch_or_store(klass_name) do
+            _const_get(klass_name)
+          end
         end
       end
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -4,6 +4,7 @@ require 'active_model/serializer/association'
 require 'active_model/serializer/config'
 
 require 'thread'
+require 'concurrent/map'
 
 module ActiveModel
   class Serializer
@@ -98,6 +99,10 @@ end
 
       def has_many(*attrs)
         associate(Association::HasMany, *attrs)
+      end
+
+      def serializers_cache
+        @serializers_cache ||= Concurrent::Map.new
       end
 
       private

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -14,6 +14,9 @@ begin
       ActionController::Base.send(:include, ::ActionController::Serialization)
       ActionController::TestCase.send(:include, ::ActionController::SerializationAssertions)
     end
+    ActionDispatch::Reloader.to_prepare do
+      ActiveModel::Serializer.serializers_cache.clear
+    end
   end
 rescue LoadError
   # rails not installed, continuing


### PR DESCRIPTION
#### Purpose

Backport https://github.com/rails-api/active_model_serializers/pull/833 to the 0-9-stable branch

> Currently, each time a model is serializer is tries to look up the Serializer class using safe_constantize. This can be slow when serializing a large number of models.

#### Changes

> This adds a cache to return the serializer class for each class, which reduced the amount of time looking up the serializer classes.

This difference is that the cache is around `ActiveMode::Serializer::Utils._const_get` and uses Concurrent::Map (the successor to ThreadSafe::Cache) from concurrent-ruby.