### PR TITLE
[0.9] Removing `instrumentation_keys` in order to fix the payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### [0-9-stable](https://github.com/rails-api/active_model_serializers/compare/v0.9.5...0-9-stable)
 
+- [#2080](https://github.com/rails-api/active_model_serializers/pull/2080) remove `{ payload: nil }` from `!serialize.active_model_serializers` ActiveSupport::Notification. `payload` never had a value.  Changes, for example `{ serializer: 'ActiveModel::DefaultSerializer', payload: nil }` to be `{ serializer: 'ActiveModel::DefaultSerializer' }` (@yosiat)
+
 ### [v0.9.6 (2017-01-10)](https://github.com/rails-api/active_model_serializers/compare/v0.9.5...v0.9.6)
 
 - [#2008](https://github.com/rails-api/active_model_serializers/pull/2008) Fix warning on Thor. (@kirs)

--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -64,10 +64,5 @@ module ActiveModel
       end
     end
 
-    private
-
-    def instrumentation_keys
-      [:object, :scope, :root, :meta_key, :meta, :each_serializer, :resource_name, :key_format, :context]
-    end
   end
 end

--- a/lib/active_model/default_serializer.rb
+++ b/lib/active_model/default_serializer.rb
@@ -15,7 +15,7 @@ module ActiveModel
     end
 
     def as_json(options={})
-      instrument('!serialize') do
+      instrument do
         return [] if @object.nil? && @wrap_in_array
         hash = @object.as_json
         @wrap_in_array ? [hash] : hash

--- a/lib/active_model/default_serializer.rb
+++ b/lib/active_model/default_serializer.rb
@@ -21,12 +21,8 @@ module ActiveModel
         @wrap_in_array ? [hash] : hash
       end
     end
+
     alias serializable_hash as_json
     alias serializable_object as_json
-
-    private
-    def instrumentation_keys
-      [:object, :wrap_in_array]
-    end
   end
 end

--- a/lib/active_model/serializable.rb
+++ b/lib/active_model/serializable.rb
@@ -52,15 +52,8 @@ module ActiveModel
     end
 
     def instrument(action, &block)
-      payload = instrumentation_keys.inject({ serializer: self.class.name }) do |payload, key|
-        payload[:payload] = self.instance_variable_get(:"@#{key}")
-        payload
-      end
+      payload = { serializer: self.class.name }
       ActiveSupport::Notifications.instrument("#{action}.active_model_serializers", payload, &block)
-    end
-
-    def instrumentation_keys
-      [:object, :scope, :root, :meta_key, :meta, :wrap_in_array, :only, :except, :key_format]
     end
   end
 end

--- a/lib/active_model/serializable.rb
+++ b/lib/active_model/serializable.rb
@@ -2,7 +2,7 @@ require 'active_model/serializable/utils'
 
 module ActiveModel
   module Serializable
-    INSTRUMENTATION_KEY = "!serialize.active_model_serializers".freeze
+    INSTRUMENTATION_KEY = '!serialize.active_model_serializers'.freeze
 
     def self.included(base)
       base.extend Utils

--- a/test/unit/active_model/serilizable_test.rb
+++ b/test/unit/active_model/serilizable_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+module ActiveModel
+  class SerializableTest
+    class InstrumentationTest < Minitest::Test
+      def setup
+        @events = []
+
+        @subscriber = ActiveSupport::Notifications.subscribe('!serialize.active_model_serializers') do |name, start, finish, id, payload|
+          @events << { name: name, serializer: payload[:serializer] }
+        end
+      end
+
+      def teardown
+        ActiveSupport::Notifications.unsubscribe(@subscriber) if defined?(@subscriber)
+      end
+
+      def test_instruments_default_serializer
+        DefaultSerializer.new(1).as_json
+
+        assert_equal [{ name: '!serialize.active_model_serializers', serializer: 'ActiveModel::DefaultSerializer' }], @events
+      end
+
+      def test_instruments_serializer
+        profile = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
+        serializer = ProfileSerializer.new(profile)
+
+        serializer.as_json
+
+        assert_equal [{ name: '!serialize.active_model_serializers', serializer: 'ProfileSerializer' }], @events
+      end
+
+      def test_instruments_array_serializer
+        profiles = [
+          Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1'),
+          Profile.new(name: 'Name 2', description: 'Description 2', comments: 'Comments 2')
+        ]
+        serializer = ArraySerializer.new(profiles)
+
+        serializer.as_json
+
+        assert_equal [
+          { name: '!serialize.active_model_serializers', serializer: 'ProfileSerializer' },
+          { name: '!serialize.active_model_serializers', serializer: 'ProfileSerializer' },
+          { name: '!serialize.active_model_serializers', serializer: 'ActiveModel::ArraySerializer' }
+        ], @events
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes - https://github.com/rails-api/active_model_serializers/issues/2067

By the way, if the instrumentation is always the same - `!serialize.active_model_serializers`,
I think a nice change would be to create a const for `INSTRUMENTATION_KEY` that will have `!serialize.active_model_serializers` as a frozen string value.
This improves performance & reduces allocations by a ton.

I can do that if the author wants that.