### PR TITLE
[0.10] add docs for include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Fixes:
 
 Misc:
 
+- [#2081](https://github.com/rails-api/active_model_serializers/pull/2081) Documentation for `include` option in adapters. (@charlie-wasp)
+
 ### [v0.10.5 (2017-03-07)](https://github.com/rails-api/active_model_serializers/compare/v0.10.4...v0.10.5)
 
 Breaking changes:

--- a/docs/general/adapters.md
+++ b/docs/general/adapters.md
@@ -141,17 +141,19 @@ This adapter follows **version 1.0** of the [format specified](../jsonapi/schema
 }
 ```
 
-#### Included
+### Include option
 
-It will include the associated resources in the `"included"` member
-when the resource names are included in the `include` option.
-Including nested associated resources is also supported.
+All built-in adapters allow to include the associated resources. Nested associated resources is also supported.
+Use `include` option for this:
 
 ```ruby
   render json: @posts, include: ['author', 'comments', 'comments.author']
   # or
   render json: @posts, include: 'author,comments,comments.author'
 ```
+**Note:** Serializer classes must declare associations explicitly, using `belongs_to` and `has_many` and etc., for `include` option to work.
+
+For JSON API adapter associated resources will be gathered in the `"included"` member.
 
 In addition, two types of wildcards may be used:
 

--- a/docs/general/adapters.md
+++ b/docs/general/adapters.md
@@ -143,17 +143,22 @@ This adapter follows **version 1.0** of the [format specified](../jsonapi/schema
 
 ### Include option
 
-All built-in adapters allow to include the associated resources. Nested associated resources is also supported.
-Use `include` option for this:
+Which [serializer associations](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/serializers.md#associations) are rendered can be specified using the `include` option. The option usage is consistent with [the include option in the JSON API spec](http://jsonapi.org/format/#fetching-includes), but is available in all adapters.
 
+Example of the usage:
 ```ruby
   render json: @posts, include: ['author', 'comments', 'comments.author']
   # or
   render json: @posts, include: 'author,comments,comments.author'
 ```
-**Note:** Serializer classes must declare associations explicitly, using `belongs_to` and `has_many` and etc., for `include` option to work.
 
-For JSON API adapter associated resources will be gathered in the `"included"` member.
+The format of the `include` option can be either:
+
+- a String composed of a comma-separated list of [relationship paths](http://jsonapi.org/format/#fetching-includes).
+- an Array of Symbols and Hashes.
+- a mix of both.
+
+An empty string or an empty array will prevent rendering of any associations.
 
 In addition, two types of wildcards may be used:
 
@@ -166,11 +171,6 @@ These can be combined with other paths.
   render json: @posts, include: '**' # or '*' for a single layer
 ```
 
-The format of the `include` option can be either:
-
-- a String composed of a comma-separated list of [relationship paths](http://jsonapi.org/format/#fetching-includes).
-- an Array of Symbols and Hashes.
-- a mix of both.
 
 The following would render posts and include:
 
@@ -182,6 +182,20 @@ It could be combined, like above, with other paths in any combination desired.
 
 ```ruby
   render json: @posts, include: 'author.comments.**'
+```
+
+**Note:** Wildcards are AMS-specific, they are not part of the JSON API spec.
+
+The default include for the JSON API adapter is no associations. The default for the JSON and Attributes adapters is all associations.
+
+For the JSON API adapter associated resources will be gathered in the `"included"` member. For the JSON and Attributes
+adapters associated resources will be rendered among the other attributes.
+
+Only for the JSON API adapter you can specify, which attributes of associated resources will be rendered. This feature
+is called [sparse fieldset](http://jsonapi.org/format/#fetching-sparse-fieldsets):
+
+```ruby
+  render json: @posts, include: 'comments', fields: { comments: ['content', 'created_at'] }
 ```
 
 ##### Security Considerations

--- a/docs/general/adapters.md
+++ b/docs/general/adapters.md
@@ -143,7 +143,7 @@ This adapter follows **version 1.0** of the [format specified](../jsonapi/schema
 
 ### Include option
 
-Which [serializer associations](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/serializers.md#associations) are rendered can be specified using the `include` option. The option usage is consistent with [the include option in the JSON API spec](http://jsonapi.org/format/#fetching-includes), but is available in all adapters.
+Which [serializer associations](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/serializers.md#associations) are rendered can be specified using the `include` option. The option usage is consistent with [the include option in the JSON API spec](http://jsonapi.org/format/#fetching-includes), and is available in all adapters.
 
 Example of the usage:
 ```ruby
@@ -184,7 +184,7 @@ It could be combined, like above, with other paths in any combination desired.
   render json: @posts, include: 'author.comments.**'
 ```
 
-**Note:** Wildcards are AMS-specific, they are not part of the JSON API spec.
+**Note:** Wildcards are ActiveModelSerializers-specific, they are not part of the JSON API spec.
 
 The default include for the JSON API adapter is no associations. The default for the JSON and Attributes adapters is all associations.
 


### PR DESCRIPTION
#### Purpose
This PR addresses #1243, adding missing docs about include option for not JSON API adapters.

#### Related GitHub issues
#1243

This is my first documentation PR, and I will be glad to make it better! :)


