### PR TITLE
Fix example code in `doc/general/getting_started.md`

### DIFF
--- a/docs/general/getting_started.md
+++ b/docs/general/getting_started.md
@@ -37,7 +37,7 @@ and
 class CommentSerializer < ActiveModel::Serializer
   attributes :name, :body
 
-  belongs_to :post_id
+  belongs_to :post
 end
 ```
 


### PR DESCRIPTION
The `belongs_to` method should take relation name, not a foreign_key property.
