### PR TITLE
Add another strategy for finding Serializers

### DIFF
--- a/lib/active_model_serializers/lookup_chain.rb
+++ b/lib/active_model_serializers/lookup_chain.rb
@@ -36,6 +36,7 @@ module ActiveModelSerializers
     #  Api::V3::AuthorsController => [Api::AuthorSerializer]
     #  Api::V3::Frontend::AuthorsController => [Api::V3::AuthorSerializer, Api::AuthorSerializer]
     BY_NESTING_NAMESPACES = lambda do |_resource_class, _serializer_class, namespace|
+      return nil unless namespace
       nesting_namespaces(namespace.name).map do |container|
         BY_NAMESPACE.call(_resource_class, _serializer_class, container)
       end


### PR DESCRIPTION
This strategy looks at the nesting modules of the current namespace.
For example:

    Api::V3::Frontend::AuthorsController => [
      Api::V3::AuthorSerializer, Api::AuthorSerializer]

As the example shows, this strategy will return ALL the module names
that surround the current namespace providing a straightforward way
to...

- use different serializers for specialized cases (for when you have
  similar controllers for the same resource but for different user
  roles);
- use a specialized serializer in certain controllers and a generic
  one in all the rest;
- a combination of the above.

#### Purpose

Allow having multiple specialized serializers while also allowing to reuse generic serializers. 

#### Changes

Added another loopup proc that returns an array of all the namespaces that surround the current one.

#### Caveats

You have to remember to change the lookup-setting in the config.

#### Related GitHub issues


#### Additional helpful information

I'm sorry for not writing any tests for this. I don't really understand the format of the current lookup-chain test. All help is welcome. 😄 
