### PR TITLE
FIx the backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ end
 
 You can specify that serializers use the lower-camel key format at the config, class or instance level.
 
-```ruby
+````ruby
 
 ActiveModel::Serializer.setup do |config|
   config.key_format = :lower_camel
@@ -245,13 +245,13 @@ class BlogLowerCamelSerializer < ActiveModel::Serializer
 end
 
 BlogSerializer.new(object, key_format: :lower_camel)
-```
+````
 
 ## Changing the default association key type
 
 You can specify that serializers use unsuffixed names as association keys by default.
 
-`````ruby
+````ruby
 ActiveModel::Serializer.setup do |config|
   config.default_key_type = :name
 end

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ end
 
 You can specify that serializers use the lower-camel key format at the config, class or instance level.
 
-````ruby
+```ruby
 
 ActiveModel::Serializer.setup do |config|
   config.key_format = :lower_camel
@@ -245,17 +245,17 @@ class BlogLowerCamelSerializer < ActiveModel::Serializer
 end
 
 BlogSerializer.new(object, key_format: :lower_camel)
-````
+```
 
 ## Changing the default association key type
 
 You can specify that serializers use unsuffixed names as association keys by default.
 
-````ruby
+```ruby
 ActiveModel::Serializer.setup do |config|
   config.default_key_type = :name
 end
-````
+```
 
 This will build association keys like `comments` or `author` instead of `comment_ids` or `author_id`.
 
@@ -932,7 +932,7 @@ now generates:
 class PostSerializer < ApplicationSerializer
   attributes :id
 end
-````
+```
 
 # Design and Implementation Guidelines
 


### PR DESCRIPTION
The backticks are wrong, and making the remaining part of doc inside code block. Just a simple fix to the README.

#### Purpose
Fixing 0.9 stable branch readme

#### Changes
Added missing / removed extra backticks


