### PR TITLE
Modifying gemspec to use grape v0.19.1

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'simplecov', '~> 0.11'
   spec.add_development_dependency 'timecop', '~> 0.7'
-  spec.add_development_dependency 'grape', ['>= 0.13', '< 1.0']
+  spec.add_development_dependency 'grape', ['>= 0.13', '< 0.19.1']
   spec.add_development_dependency 'json_schema'
   spec.add_development_dependency 'rake', ['>= 10.0', '< 12.0']
 end


### PR DESCRIPTION
#### Purpose

Resolves issues where tests would fail because Grape v0.19.2 uses mustermann 1.0, which has dropped support for Ruby 2.1

#### Changes

Modifies gemspec to use grape v0.19.1

#### Caveats


#### Related GitHub issues

Resolves #2109

#### Additional helpful information
