### PR TITLE
Fix to_prepare warning

### DIFF
--- a/lib/active_model/serializer/railtie.rb
+++ b/lib/active_model/serializer/railtie.rb
@@ -12,6 +12,10 @@ module ActiveModel
         include app.routes.url_helpers
       end
     end
+
+    config.to_prepare do
+      ActiveModel::Serializer.serializers_cache.clear
+    end
   end
 end
 

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -14,9 +14,6 @@ begin
       ActionController::Base.send(:include, ::ActionController::Serialization)
       ActionController::TestCase.send(:include, ::ActionController::SerializationAssertions)
     end
-    ActionDispatch::Reloader.to_prepare do
-      ActiveModel::Serializer.serializers_cache.clear
-    end
   end
 rescue LoadError
   # rails not installed, continuing


### PR DESCRIPTION
Fixes

```
DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1 (use ActiveSupport::Reloader.to_prepare instead) (called from block in <main> at
 /Users/kir/Projects/shopify/vendor/bundle/bundler/gems/active_model_serializers-1e04d1128bc7/lib/active_model_serializers.rb:17)
```

review @rafaelfranca 