### PR TITLE
Return null resource object identifier for blank id

### DIFF
--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -295,20 +295,8 @@ module ActiveModelSerializers
 
       # {http://jsonapi.org/format/#document-resource-objects Document Resource Objects}
       def resource_object_for(serializer, include_slice = {})
-        resource_object = serializer.fetch(self) do
-          resource_object = ResourceIdentifier.new(serializer, instance_options).as_json
+        resource_object = data_for(serializer, include_slice)
 
-          requested_fields = fieldset && fieldset.fields_for(resource_object[:type])
-          attributes = attributes_for(serializer, requested_fields)
-          resource_object[:attributes] = attributes if attributes.any?
-          resource_object
-        end
-
-        requested_associations = fieldset.fields_for(resource_object[:type]) || '*'
-        relationships = relationships_for(serializer, requested_associations, include_slice)
-        resource_object[:relationships] = relationships if relationships.any?
-
-        links = links_for(serializer)
         # toplevel_links
         # definition:
         #   allOf
@@ -322,7 +310,10 @@ module ActiveModelSerializers
         # prs:
         #   https://github.com/rails-api/active_model_serializers/pull/1247
         #   https://github.com/rails-api/active_model_serializers/pull/1018
-        resource_object[:links] = links if links.any?
+        if (links = links_for(serializer)).any?
+          resource_object ||= {}
+          resource_object[:links] = links
+        end
 
         # toplevel_meta
         #   alias meta
@@ -332,10 +323,31 @@ module ActiveModelSerializers
         #   {
         #     :'git-ref' => 'abc123'
         #   }
-        meta = meta_for(serializer)
-        resource_object[:meta] = meta unless meta.blank?
+        if (meta = meta_for(serializer)).present?
+          resource_object ||= {}
+          resource_object[:meta] = meta
+        end
 
         resource_object
+      end
+
+      def data_for(serializer, include_slice)
+        data = serializer.fetch(self) do
+          resource_object = ResourceIdentifier.new(serializer, instance_options).as_json
+          break nil if resource_object.nil?
+
+          requested_fields = fieldset && fieldset.fields_for(resource_object[:type])
+          attributes = attributes_for(serializer, requested_fields)
+          resource_object[:attributes] = attributes if attributes.any?
+          resource_object
+        end
+        data.tap do |resource_object|
+          next if resource_object.nil?
+          # NOTE(BF): the attributes are cached above, separately from the relationships, below.
+          requested_associations = fieldset.fields_for(resource_object[:type]) || '*'
+          relationships = relationships_for(serializer, requested_associations, include_slice)
+          resource_object[:relationships] = relationships if relationships.any?
+        end
       end
 
       # {http://jsonapi.org/format/#document-resource-object-relationships Document Resource Object Relationship}

--- a/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
@@ -23,6 +23,7 @@ module ActiveModelSerializers
         end
 
         def self.for_type_with_id(type, id, options)
+          return nil if id.blank?
           {
             id: id.to_s,
             type: type_for(:no_class_needed, type, options)
@@ -36,6 +37,7 @@ module ActiveModelSerializers
         end
 
         def as_json
+          return nil if id.blank?
           { id: id, type: type }
         end
 

--- a/test/action_controller/adapter_selector_test.rb
+++ b/test/action_controller/adapter_selector_test.rb
@@ -19,7 +19,7 @@ module ActionController
         end
 
         def render_using_adapter_override
-          @profile = Profile.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
+          @profile = Profile.new(id: 'render_using_adapter_override', name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
           render json: @profile, adapter: :json_api
         end
 
@@ -41,7 +41,7 @@ module ActionController
 
         expected = {
           data: {
-            id: @controller.instance_variable_get(:@profile).id.to_s,
+            id: 'render_using_adapter_override',
             type: 'profiles',
             attributes: {
               name: 'Name 1',


### PR DESCRIPTION
Fix regression from 6e4152851554b33d8cdf607fe4e175dd1aafd1c7 where relationships with null data shows up with `:data=>{:id=>"", :type=>"locations"}`

```
       -:data => {:id=>"123", :type=>"places", :attributes=>{:status=>"live"}, :relationships=>{:location=>{:data=>nil}}},
       +:data => {:id=>"123", :type=>"places", :attributes=>{:status=>"live"}, :relationships=>{:location=>{:data=>{:id=>"", :type=>"locations"}}}},
```

Also, fix test where attributes were included when id was ""

```
  1) Failure:
  ActionController::Serialization::AdapterSelectorTest#test_render_using_adapter_override
  [test/action_c$ntroller/adapter_selector_test.rb:53]:
  --- expected
  +++ actual
  @@ -1 +1 @@
  -"{\"data\":{\"id\":\"\",\"type\":\"profiles\",\"attributes\":{\"name\":\"Name 1\",\"description\":\"Description 1\"}}}"
  +"{\"data\":null}"
```