### PR TITLE
Fix readme in 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ it exists, use it to serialize the `Post`.
 
 This also works with `respond_with`, which uses `to_json` under the hood. Also
 note that any options passed to `render :json` will be passed to your
-serializer and available as `@options` inside.
+serializer and available as `@serialization_options` inside.
 
 To specify a custom serializer for an object, you can specify the
 serializer when you render the object:


### PR DESCRIPTION
There is no `@options` in 0.9, but `@serialization_options` instead. Changed readme to stop confusing people.

#### Changes
 `@options` => `@serialization_options`