### PR TITLE
Allow serialized ID to be overwritten for belongs-to relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 Features:
 
 - [#2021](https://github.com/rails-api/active_model_serializers/pull/2021) ActiveModelSerializers::Model#attributes. Originally in [#1982](https://github.com/rails-api/active_model_serializers/pull/1982). (@bf4)
+- [#2130](https://github.com/rails-api/active_model_serializers/pull/2130) Allow serialized ID to be overwritten for belongs-to relationships. (@greysteil)
 
 Fixes:
 

--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -45,7 +45,7 @@ module ActiveModelSerializers
         def data_for_one(association)
           if association.belongs_to? &&
               parent_serializer.object.respond_to?(association.reflection.foreign_key)
-            id = parent_serializer.object.send(association.reflection.foreign_key)
+            id = parent_serializer.read_attribute_for_serialization(association.reflection.foreign_key)
             type = association.reflection.type.to_s
             ResourceIdentifier.for_type_with_id(type, id, serializable_resource_options)
           else


### PR DESCRIPTION
#### Purpose
If the `id` attribute for a class isn't taken directly from the object when serializing it, it may be desirable for other classes that serialize a relationship with that class to overwrite the relationship IDs they serialize.

For example, suppose we have:

```(ruby)
class Repo < Model
  attributes :id, :github_id, :name
  associations :configs
end

class Config < Model
  attributes :id
  belongs_to :repo
end

class RepoSerializer < ActiveModel::Serializer
  attributes :id, :name

  has_many :update_configs

  def id
    object.github_id
  end
end

class ConfigSerializer < ActiveModel::Serializer
  attributes :id
  belongs_to :repo
end
```

In the above example, serializing a list of `Repo`s will give the `github_id` for each one, but serializing a `Config` will give the `id` for its parent repo.


#### Changes
I've updated the `belongs_to?` path of `Relationship#data_for_one` to use `read_attribute_for_serialization` instead of `object.send` to fetch the serialized foreign key. This allows the serialized relationship ID to be
overwritten using:

```(ruby)
class ConfigSerializer < ActiveModel::Serializer
  ...

  def repo_id
    object.repo.github_id
  end
end
```

#### Caveats
Ideally AMS would inspect the `RepoSerializer` when serializing the `Config`, and realise it can't just output the foreign key. Unfortunately, getting the serialization class for the child repo currently requires loading the record (via evaluating `lazy_assocation`), and loses the performance benefit of the existing `belongs_to?` path.

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/2125. (Not resolved by this, but the ID issue is at least improved, for no performance cost.)

#### Additional helpful information


