### PR TITLE
WIP - Add ability to pass block to `type` directive

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -295,8 +295,13 @@ module ActiveModel
     # @example
     #   class AdminAuthorSerializer < ActiveModel::Serializer
     #     type 'authors'
-    def self.type(type)
-      self._type = type && type.to_s
+    # @example
+    #   class AdminAuthorSerializer < ActiveModel::Serializer
+    #     type do
+    #       object.type
+    #     end
+    def self.type(type = nil, &block)
+      self._type = (type && type.to_s) || block
     end
 
     # END SERIALIZER MACROS

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -300,8 +300,11 @@ module ActiveModel
     #     type do
     #       object.type
     #     end
-    def self.type(type = nil, &block)
-      self._type = (type && type.to_s) || block
+    # def self.type(type = nil, &block)
+    #   self._type = (type && type.to_s) || block
+    # end
+    def self.type(type)
+      self._type = type && type.to_s
     end
 
     # END SERIALIZER MACROS

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -109,6 +109,21 @@ module ActiveModel
       # @example
       #   has_one :blog do
       #     include_data false
+      #     meta(id: object.blog.id)
+      #     meta liked: object.likes.any?
+      #     link :self do
+      #       href object.blog.id.to_s
+      #       meta(id: object.blog.id)
+      #     end
+      def set_type(value = nil)
+        @type = block_given? ? Proc.new : value
+        :nil
+      end
+
+      # @api public
+      # @example
+      #   has_one :blog do
+      #     include_data false
       #     link :self, 'a link'
       #     link :related, 'another link'
       #   end

--- a/test/adapter/json_api/type_test.rb
+++ b/test/adapter/json_api/type_test.rb
@@ -15,6 +15,20 @@ module ActiveModel
             type :profile
           end
 
+          class BlockTypeSerializer < ActiveModel::Serializer
+            attribute :name
+            type do
+              'wri' + 'ter'
+            end
+          end
+
+          class BlockTypeSerializerWithObject < ActiveModel::Serializer
+            attribute :name
+            type do
+              object.class.to_s.downcase
+            end
+          end
+
           setup do
             @author = Author.new(id: 1, name: 'Steve K.')
           end
@@ -37,6 +51,14 @@ module ActiveModel
 
           def test_explicit_symbol_type_value
             assert_type(@author, 'profile', serializer: SymbolTypeSerializer)
+          end
+
+          def test_explicit_block_type_value_using_object
+            assert_type(@author, 'author', serializer: BlockTypeSerializerWithObject)
+          end
+
+          def test_explicit_block_type_value_using_arbitrary_code
+            assert_type(@author, 'writer', serializer: BlockTypeSerializer)
           end
 
           private


### PR DESCRIPTION
#### Purpose
This will allow you to dynamically set the serialized type of an object, like so:

    class ThingamajigSerializer
      ...
      type do
        object.special_type
      end
      ...
    end

This is especially helpful if you're using a gem like [active_record-acts_as](https://github.com/hzamani/active_record-acts_as) where in order to get the actual type of an object you have to call `object.actable_type`.

#### Changes
Add `&block` param to `type` and handle accordingly.
Add tests.

#### Caveats
WIP - Need some guidance here.  `self._type` doesn't seem to behave quite like `self._meta` or `self._links`.

#### Related GitHub issues


#### Additional helpful information


