### PR TITLE
Allow referencing sideloaded `include` by `key`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Breaking changes:
 
 Features:
+- [#2136](https://github.com/rails-api/active_model_serializers/pull/2136) Enable inclusion of sideloaded relationship objects by `key`. (@caomania)
 
 Fixes:
 

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -140,7 +140,7 @@ module ActiveModel
       def include_data?(include_slice)
         include_data_setting = options[:include_data_setting]
         case include_data_setting
-        when :if_sideloaded then include_slice.key?(name)
+        when :if_sideloaded then include_slice.key?(options.fetch(:key, name))
         when true           then true
         when false          then false
         else fail ArgumentError, "Unknown include_data_setting '#{include_data_setting.inspect}'"

--- a/test/adapter/json_api/include_data_if_sideloaded_test.rb
+++ b/test/adapter/json_api/include_data_if_sideloaded_test.rb
@@ -135,7 +135,6 @@ module ActiveModel
             assert_nil(hash[:included])
           end
 
-
           def test_nested_relationship
             expected = {
               data: [

--- a/test/adapter/json_api/include_data_if_sideloaded_test.rb
+++ b/test/adapter/json_api/include_data_if_sideloaded_test.rb
@@ -6,7 +6,7 @@ module ActiveModel
       class JsonApi
         class IncludeParamTest < ActiveSupport::TestCase
           IncludeParamAuthor = Class.new(::Model) do
-            associations :tags, :posts
+            associations :tags, :posts, :roles
           end
 
           class CustomCommentLoader
@@ -51,14 +51,19 @@ module ActiveModel
               include_data :if_sideloaded
               IncludeParamAuthorSerializer.comment_loader.all
             end
+            has_many :roles, key: :granted_roles do
+              include_data :if_sideloaded
+            end
           end
 
           def setup
             IncludeParamAuthorSerializer.comment_loader = Class.new(CustomCommentLoader).new
             @tag = Tag.new(id: 1337, name: 'mytag')
+            @role = Role.new(id: 1337, name: 'myrole')
             @author = IncludeParamAuthor.new(
               id: 1337,
-              tags: [@tag]
+              tags: [@tag],
+              roles: [@role]
             )
           end
 
@@ -104,6 +109,32 @@ module ActiveModel
             hash = result(include: :tags)
             assert_equal(expected, hash[:included])
           end
+
+          def test_sideloads_included_when_using_key
+            expected = [
+              {
+                id: '1337',
+                type: 'roles',
+                attributes: {
+                  name: 'myrole',
+                  description: nil,
+                  slug: 'myrole-1337'
+                },
+                relationships: {
+                  author: { data: nil }
+                }
+              }
+            ]
+
+            hash = result(include: :granted_roles)
+            assert_equal(expected, hash[:included])
+          end
+
+          def test_sideloads_not_included_when_using_name_when_key_defined
+            hash = result(include: :roles)
+            assert_nil(hash[:included])
+          end
+
 
           def test_nested_relationship
             expected = {


### PR DESCRIPTION
#### Purpose
When an association is set to be `sideloaded` and the association has a `key` defined we should be able to include this association by referencing the `key`.

#### Changes
When checking `include_slice` for associations to include, check the association's `key` option first, then fallback to the association `name`.

#### Additional helpful information
Added tests to demonstrate that attempting to reference an association by `key` when including associations currently fails.  

