### PR TITLE
Adds a configuration option belongs_to_uses_id_on_self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
 
 - [#2021](https://github.com/rails-api/active_model_serializers/pull/2021) ActiveModelSerializers::Model#attributes. Originally in [#1982](https://github.com/rails-api/active_model_serializers/pull/1982). (@bf4)
 - [#2130](https://github.com/rails-api/active_model_serializers/pull/2130) Allow serialized ID to be overwritten for belongs-to relationships. (@greysteil)
+- [#2140](https://github.com/rails-api/active_model_serializers/pull/2140) Allow for configuration option that will automatically look up serializers with a `belongs_to` relationship. (@cassidycodes)
 
 Fixes:
 

--- a/docs/general/configuration_options.md
+++ b/docs/general/configuration_options.md
@@ -28,6 +28,31 @@ Possible values:
 
 When `false`, serializers must be explicitly specified.
 
+##### belongs_to_uses_id_on_self
+
+Enable automatic serializer lookup when using a `belongs_to` without `has_many`.
+
+Possible values:
+
+- `true`
+- `false` (default)
+
+When `false`, serializers must be explicitly specified in order to use a custom `type` field in the serializer.
+
+```ruby
+class PostSerializer <  ActiveModel::Serializer
+  belongs_to :blog, type: 'custom-type'
+end
+```
+
+or to explicitly state the serializer:
+
+```ruby
+class PostSerializer <  ActiveModel::Serializer
+  belongs_to :foo, serializer: FooSerializer
+end
+```
+
 ##### key_transform
 
 The [key transform](key_transforms.md) to use.

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -118,6 +118,7 @@ module ActiveModel
     # BEGIN DEFAULT CONFIGURATION
     config.collection_serializer = ActiveModel::Serializer::CollectionSerializer
     config.serializer_lookup_enabled = true
+    config.belongs_to_uses_id_on_self = false
 
     # @deprecated Use {#config.collection_serializer=} instead of this. Is
     #   compatibility layer for ArraySerializer.

--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -43,7 +43,8 @@ module ActiveModelSerializers
         end
 
         def data_for_one(association)
-          if association.belongs_to? &&
+          if !ActiveModelSerializers.config.belongs_to_uses_id_on_self &&
+              association.belongs_to? &&
               parent_serializer.object.respond_to?(association.reflection.foreign_key)
             id = parent_serializer.read_attribute_for_serialization(association.reflection.foreign_key)
             type = association.reflection.type.to_s

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -212,22 +212,20 @@ module ActiveModel
       end
 
       def test_belongs_to_allows_type_overwriting
-        begin
-          ActiveModelSerializers.config.belongs_to_uses_id_on_self = true
+        ActiveModelSerializers.config.belongs_to_uses_id_on_self = true
 
-          attributes = {
-            id: 1,
-            title: 'Belongs to Blog with Custom Type',
-            blog_with_custom_type: BlogWithCustomType.new(id: 1)
-          }
-          post = BelongsToBlogWithCustomTypeModel.new(attributes)
+        attributes = {
+          id: 1,
+          title: 'Belongs to Blog with Custom Type',
+          blog_with_custom_type: BlogWithCustomType.new(id: 1)
+        }
+        post = BelongsToBlogWithCustomTypeModel.new(attributes)
 
-          actual = serializable(post, adapter: :json_api, serializer: BelongsToBlogWithCustomTypeModelSerializer).as_json
-          expected = { data: { id: '1', type: 'posts', relationships: { :'blog-with-custom-type' => { data: { id: '1', type: 'custom-type' } } } } }
-          assert_equal expected, actual
-        ensure
-          ActiveModelSerializers.config.belongs_to_uses_id_on_self = false
-        end
+        actual = serializable(post, adapter: :json_api, serializer: BelongsToBlogWithCustomTypeModelSerializer).as_json
+        expected = { data: { id: '1', type: 'posts', relationships: { :'blog-with-custom-type' => { data: { id: '1', type: 'custom-type' } } } } }
+        assert_equal expected, actual
+      ensure
+        ActiveModelSerializers.config.belongs_to_uses_id_on_self = false
       end
 
       class InlineAssociationTestPostSerializer < ActiveModel::Serializer


### PR DESCRIPTION
#### Purpose

Adds a configuration option `belongs_to_uses_id_on_self ` to allow for automatic serializer lookup. This solves an issue where the custom `type` attribute was not being used as the type was inferred from the associated object.

#### Changes

- Adds `ActiveModelSerializers.config.belongs_to_uses_id_on_self `
- Adds documentation for usage

#### Caveats

- Setting `belongs_to_uses_id_on_self` to true will result in a lookup on the associated object,

#### Related GitHub issues

Closes #2125

#### Additional helpful information


