### PR TITLE
Support options/conditions for multiple attributes

### DIFF
--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -22,6 +22,18 @@ Serialization of the resource `title` and `body`
 | `attributes :title, :body`  | `{ title: 'Some Title', body: 'Some Body' }`
 | `attributes :title, :body`<br>`def body "Special #{object.body}" end` | `{ title: 'Some Title', body: 'Special Some Body' }`
 
+An `if` or `unless` option can make attributes conditional. It takes a symbol of a method name on the serializer, or a lambda literal.
+
+e.g.
+
+```ruby
+attributes :private_data, :another_private_data, if: :is_current_user?
+attributes :title, :body, if: -> { scope.admin? }
+
+def is_current_user?
+  object.id == current_user.id
+end
+```
 
 #### ::attribute
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -199,10 +199,11 @@ module ActiveModel
     #   class AdminAuthorSerializer < ActiveModel::Serializer
     #     attributes :id, :name, :recent_edits
     def self.attributes(*attrs)
+      options = attrs.last.class == Hash ? attrs.pop : {}
       attrs = attrs.first if attrs.first.class == Array
 
       attrs.each do |attr|
-        attribute(attr)
+        attribute(attr, options)
       end
     end
 


### PR DESCRIPTION
#### Purpose
Support options/conditions on `attributes`
```
attributes :foo, :bar, if: -> { current_user.admin? }
```

#### Changes
serializer.rb#attributes

#### Caveats


#### Related GitHub issues
We needed this so I built it. While reading contributing.md I started searching for issues and found this PR which is pretty much exactly the same thing : https://github.com/rails-api/active_model_serializers/pull/1714

Since this is +1 year ago and OP didn't respond I thought I would still open a new PR. Feel free to close it if I was wrong in doing so 🙂

#### Additional helpful information
