### PR TITLE
Support association nested fields without json api

### DIFF
--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -47,13 +47,13 @@ module ActiveModel
       end
 
       # @api private
-      def serializable_hash(adapter_options, adapter_instance)
+      def serializable_hash(adapter_options, options, adapter_instance)
         association_serializer = lazy_association.serializer
         return virtual_value if virtual_value
         association_object = association_serializer && association_serializer.object
         return unless association_object
 
-        serialization = association_serializer.serializable_hash(adapter_options, {}, adapter_instance)
+        serialization = association_serializer.serializable_hash(adapter_options, options, adapter_instance)
 
         if polymorphic? && serialization
           polymorphic_type = association_object.class.name.underscore

--- a/test/adapter/json/collection_test.rb
+++ b/test/adapter/json/collection_test.rb
@@ -98,6 +98,26 @@ module ActiveModelSerializers
 
           assert_equal(expected, actual)
         end
+
+        def test_fields_with_associations_include_option
+          actual = ActiveModelSerializers::SerializableResource.new(
+            [@first_post, @second_post], adapter: :json, fields: [:id, { author: [:name] }], include: ['author']
+          ).as_json
+
+          expected = { posts: [{
+            id: 1,
+            author: {
+              name: 'Steve K.'
+            }
+          }, {
+            id: 2,
+            author: {
+              name: 'Steve K.'
+            }
+          }] }
+
+          assert_equal(expected, actual)
+        end
       end
     end
   end


### PR DESCRIPTION
#### Purpose
We currently don't use JSON API and we need to support `fields` for root resource _and_ nested associations. I implemented it so it reads like strong_parameters : `fields: { [:attribute, { relation: [:nested_attribute] }] }`. This is different from how it currently works in JSON API : https://github.com/rails-api/active_model_serializers/blob/0-10-stable/docs/general/adapters.md#json-api
I am not sure how do you whitelist root object AND nested associations using the JSON API adapter? I'll be happy to change this PR so it works the same way once I get it.

#### Changes
We need to pass options around to associations.

#### Caveats

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/1849

#### Additional helpful information
I read the whole discussion but didn't find any consensus, maybe this is a bad idea for some reason I am not aware. Since we need this, I thought it might be useful for some other people too. 🙂  I didn't include any documentation changes because I'd like to know if this is something you would like to see merged beforehand.