### PR TITLE
Always include self, first, last pagination links

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -35,19 +35,21 @@ module ActiveModelSerializers
         private
 
         def pages_from
-          return {} if collection.total_pages <= FIRST_PAGE
-
           {}.tap do |pages|
-            pages[:self] = collection.current_page
+            pages[:self]  = collection.current_page
+            pages[:first] = FIRST_PAGE
+            pages[:last]  = collection.total_pages
 
-            unless collection.current_page == FIRST_PAGE
-              pages[:first] = FIRST_PAGE
-              pages[:prev]  = collection.current_page - FIRST_PAGE
-            end
+            if collection.total_pages > 0
+              unless collection.current_page == FIRST_PAGE
+                pages[:prev] = collection.current_page - FIRST_PAGE
+              end
 
-            unless collection.current_page == collection.total_pages
-              pages[:next] = collection.current_page + FIRST_PAGE
-              pages[:last] = collection.total_pages
+              unless collection.current_page == collection.total_pages
+                pages[:next] = collection.current_page + FIRST_PAGE
+              end
+            else
+              pages[:last] = FIRST_PAGE
             end
           end
         end

--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -57,7 +57,7 @@ module ActiveModelSerializers
         end
 
         def next_page_url
-          return nil if (collection.total_pages == 0 || collection.current_page == collection.total_pages)
+          return nil if collection.total_pages == 0 || collection.current_page == collection.total_pages
           url_for_page(collection.next_page)
         end
 

--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -21,11 +21,11 @@ module ActiveModelSerializers
 
         def as_json
           {
-            "self":  location_url,
-            "first": first_page_url,
-            "prev":  prev_page_url,
-            "next":  next_page_url,
-            "last":  last_page_url
+            self:  location_url,
+            first: first_page_url,
+            prev:  prev_page_url,
+            next:  next_page_url,
+            last:  last_page_url
           }
         end
 

--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -15,7 +15,7 @@ module ActiveModelSerializers
  JsonApi::PaginationLinks requires a ActiveModelSerializers::SerializationContext.
  Please pass a ':serialization_context' option or
  override CollectionSerializer#paginated? to return 'false'.
-             EOF
+            EOF
           end
         end
 

--- a/test/action_controller/json_api/pagination_test.rb
+++ b/test/action_controller/json_api/pagination_test.rb
@@ -61,6 +61,7 @@ module ActionController
         def test_render_only_first_last_and_next_pagination_links
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
                              'first' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
+                             'prev' => nil,
                              'next' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2",
                              'last' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2" }
           get :render_pagination_using_will_paginate, params: { page: { number: 1, size: 2 } }
@@ -83,6 +84,7 @@ module ActionController
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1",
                              'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1",
+                             'next' => nil,
                              'last' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1" }
           get :render_pagination_using_kaminari, params: { page: { number: 3, size: 1 } }
           response = JSON.parse(@response.body)
@@ -92,6 +94,7 @@ module ActionController
         def test_render_only_first_last_and_next_pagination_links_with_additional_params
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2&teste=additional",
                              'first' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2&teste=additional",
+                             'prev' => nil,
                              'next' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2&teste=additional",
                              'last' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2&teste=additional" }
           get :render_pagination_using_will_paginate, params: { page: { number: 1, size: 2 }, teste: 'additional' }
@@ -103,6 +106,7 @@ module ActionController
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1&teste=additional",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1&teste=additional",
                              'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1&teste=additional",
+                             'next' => nil,
                              'last' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1&teste=additional" }
           get :render_pagination_using_kaminari, params: { page: { number: 3, size: 1 }, teste: 'additional' }
           response = JSON.parse(@response.body)

--- a/test/action_controller/json_api/pagination_test.rb
+++ b/test/action_controller/json_api/pagination_test.rb
@@ -58,8 +58,9 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_render_only_last_and_next_pagination_links
+        def test_render_only_first_last_and_next_pagination_links
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
+                             'first' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
                              'next' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2",
                              'last' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2" }
           get :render_pagination_using_will_paginate, params: { page: { number: 1, size: 2 } }
@@ -78,17 +79,19 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_render_only_prev_and_first_pagination_links
+        def test_render_only_prev_first_and_last_pagination_links
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1",
-                             'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1" }
+                             'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1",
+                             'last' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1" }
           get :render_pagination_using_kaminari, params: { page: { number: 3, size: 1 } }
           response = JSON.parse(@response.body)
           assert_equal expected_links, response['links']
         end
 
-        def test_render_only_last_and_next_pagination_links_with_additional_params
+        def test_render_only_first_last_and_next_pagination_links_with_additional_params
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2&teste=additional",
+                             'first' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2&teste=additional",
                              'next' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2&teste=additional",
                              'last' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2&teste=additional" }
           get :render_pagination_using_will_paginate, params: { page: { number: 1, size: 2 }, teste: 'additional' }
@@ -96,10 +99,11 @@ module ActionController
           assert_equal expected_links, response['links']
         end
 
-        def test_render_only_prev_and_first_pagination_links_with_additional_params
+        def test_render_only_prev_first_and_last_pagination_links_with_additional_params
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1&teste=additional",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1&teste=additional",
-                             'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1&teste=additional" }
+                             'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1&teste=additional",
+                             'last' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1&teste=additional" }
           get :render_pagination_using_kaminari, params: { page: { number: 3, size: 1 }, teste: 'additional' }
           response = JSON.parse(@response.body)
           assert_equal expected_links, response['links']

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -117,7 +117,7 @@ module ActiveModelSerializers
           end
         end
 
-        def expected_response_with_no_data_pagination_links
+        def expected_response_with_empty_collection_pagination_links
           {}.tap do |hash|
             hash[:data] = []
             hash.merge! links: empty_collection_links
@@ -148,7 +148,7 @@ module ActiveModelSerializers
 
           adapter = load_adapter(using_kaminari(1), mock_request)
 
-          assert_equal expected_response_with_no_data_pagination_links, adapter.serializable_hash
+          assert_equal expected_response_with_empty_collection_pagination_links, adapter.serializable_hash
         end
 
         def test_pagination_links_when_zero_results_will_paginate
@@ -156,7 +156,7 @@ module ActiveModelSerializers
 
           adapter = load_adapter(using_will_paginate(1), mock_request)
 
-          assert_equal expected_response_with_no_data_pagination_links, adapter.serializable_hash
+          assert_equal expected_response_with_empty_collection_pagination_links, adapter.serializable_hash
         end
 
         def test_last_page_pagination_links_using_kaminari

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -58,7 +58,9 @@ module ActiveModelSerializers
           {
             self: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
             first: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
-            last: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2"
+            prev: nil,
+            next: nil,
+            last: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
           }
         end
 
@@ -79,8 +81,9 @@ module ActiveModelSerializers
             links: {
               self: "#{URI}?page%5Bnumber%5D=3&page%5Bsize%5D=2",
               first: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
-              last: "#{URI}?page%5Bnumber%5D=3&page%5Bsize%5D=2",
-              prev: "#{URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2"
+              prev: "#{URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2",
+              next: nil,
+              last: "#{URI}?page%5Bnumber%5D=3&page%5Bsize%5D=2"
             }
           }
         end

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -54,6 +54,14 @@ module ActiveModelSerializers
           }
         end
 
+        def empty_collection_links
+          {
+            self: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
+            first: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
+            last: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2"
+          }
+        end
+
         def links
           {
             links: {
@@ -71,6 +79,7 @@ module ActiveModelSerializers
             links: {
               self: "#{URI}?page%5Bnumber%5D=3&page%5Bsize%5D=2",
               first: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
+              last: "#{URI}?page%5Bnumber%5D=3&page%5Bsize%5D=2",
               prev: "#{URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2"
             }
           }
@@ -111,7 +120,7 @@ module ActiveModelSerializers
         def expected_response_with_no_data_pagination_links
           {}.tap do |hash|
             hash[:data] = []
-            hash[:links] = {}
+            hash.merge! links: empty_collection_links
           end
         end
 

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -60,7 +60,7 @@ module ActiveModelSerializers
             first: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
             prev: nil,
             next: nil,
-            last: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
+            last: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2"
           }
         end
 


### PR DESCRIPTION
Found a bug in jsonapi adapter. Basically, when there’s one page, all links are omitted. The specs says

> Keys MUST either be omitted or have a null value to indicate that a *particular link* is *unavailable*.

It doesn’t say “remove pagination entirely”. A book with one page still has a first/current/last page. It doesn’t contain `next` or `prev`.