### PR TITLE
Implement setting for including belongs_to relationship resource iden…

### DIFF
--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -7,7 +7,7 @@ module ActiveModel
     # @api private
     Association = Struct.new(:reflection, :association_options) do
       attr_reader :lazy_association
-      delegate :object, :include_data?, :virtual_value, :collection?, to: :lazy_association
+      delegate :object, :include_data?, :include_resource_identifier?, :virtual_value, :collection?, to: :lazy_association
 
       def initialize(*)
         super

--- a/lib/active_model/serializer/belongs_to_reflection.rb
+++ b/lib/active_model/serializer/belongs_to_reflection.rb
@@ -6,6 +6,10 @@ module ActiveModel
       def foreign_key_on
         :self
       end
+
+      def include_resource_identifier?
+        ActiveModelSerializers.config.include_belongs_to_resource_identifier == true
+      end
     end
   end
 end

--- a/lib/active_model/serializer/lazy_association.rb
+++ b/lib/active_model/serializer/lazy_association.rb
@@ -25,6 +25,10 @@ module ActiveModel
         )
       end
 
+      def include_resource_identifier?
+        include_data? || reflection.include_resource_identifier?
+      end
+
       # @return [ActiveModel::Serializer, nil]
       def serializer
         return @serializer if defined?(@serializer)

--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -147,6 +147,10 @@ module ActiveModel
         end
       end
 
+      def include_resource_identifier?
+        false
+      end
+
       # @param serializer [ActiveModel::Serializer]
       # @yield [ActiveModel::Serializer]
       # @return [:nil, associated resource or resource collection]

--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -15,7 +15,7 @@ module ActiveModelSerializers
         def as_json
           hash = {}
 
-          hash[:data] = data_for(association) if association.include_data?
+          hash[:data] = data_for(association) if association.include_resource_identifier?
 
           links = links_for(association)
           hash[:links] = links if links.any?

--- a/test/adapter/json_api/relationship_test.rb
+++ b/test/adapter/json_api/relationship_test.rb
@@ -374,6 +374,24 @@ module ActiveModelSerializers
           assert_equal(expected, actual)
         end
 
+        def test_include_belongs_to_relationships
+          ActiveModelSerializers.config.include_belongs_to_resource_identifier = true
+
+          expected = {
+            data: { id: '1337', type: 'authors' }
+          }
+
+          model_attributes = { author: Author.new(id: 1337), author_id: 1337 }
+          relationship_name = :author
+          model = new_model(model_attributes)
+          actual = build_serializer_and_serialize_relationship(model, relationship_name) do
+            belongs_to :author do
+              include_data false
+            end
+          end
+          assert_equal(expected, actual)
+        end
+
         private
 
         def build_serializer_and_serialize_relationship(model, relationship_name, &block)


### PR DESCRIPTION
#### Purpose
I want to use `ActiveModelSerializers.config.include_data_default = :if_sideloaded` option, but I also want to take advantage of "Smarter association id lookup - #1857"

#### Changes
- new setting: `ActiveModelSerializers.config.include_belongs_to_resource_identifier`

#### Caveats
- Documentation and tests are missing for now, I'll add.

#### Related GitHub issues
- #1857

#### Additional helpful information

