### PR TITLE
Fix dead link in docs/general/rendering

### DIFF
--- a/docs/general/rendering.md
+++ b/docs/general/rendering.md
@@ -290,4 +290,4 @@ See [Usage outside of a controller](../howto/outside_controller_use.md#serializi
 
 ## Pagination
 
-See [How to add pagination links](https://github.com/rails-api/active_model_serializers/blob/master/docs/howto/add_pagination_links.md).
+See [How to add pagination links](../howto/add_pagination_links.md).


### PR DESCRIPTION
The add_pageination_links.md is dead in docs/general/rendering on the
0-10-stable branch.

#### Purpose


#### Changes


#### Caveats


#### Related GitHub issues


#### Additional helpful information


