### PR TITLE
add #cache_key method to serializable resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features:
 - [#2189](https://github.com/rails-api/active_model_serializers/pull/2189)
   Update version constraint for jsonapi-renderer to `['>= 0.1.1.beta1', '< 0.3']`
   (@tagliala)
+- [#2021](https://github.com/rails-api/active_model_serializers/pull/2159) add #cache_key method to serializable resource. (@ledhed2222)
 
 Fixes:
 

--- a/lib/active_model_serializers/serializable_resource.rb
+++ b/lib/active_model_serializers/serializable_resource.rb
@@ -75,6 +75,10 @@ module ActiveModelSerializers
       use_adapter? && !serializer.nil?
     end
 
+    def cache_key
+      serializer_instance.cache_key(adapter)
+    end
+
     protected
 
     attr_reader :resource, :adapter_opts, :serializer_opts

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -39,7 +39,7 @@ module ActiveModelSerializers
       refute SerializableResource.new(@resource, adapter: false).use_adapter?
     end
 
-    def test_cache_cache_value
+    def test_cache_key_value
       resource = SerializableResource.new(@resource)
       expected_value = resource.serializer_instance.cache_key(resource.adapter)
       assert_equal resource.cache_key, expected_value

--- a/test/serializable_resource_test.rb
+++ b/test/serializable_resource_test.rb
@@ -39,6 +39,12 @@ module ActiveModelSerializers
       refute SerializableResource.new(@resource, adapter: false).use_adapter?
     end
 
+    def test_cache_cache_value
+      resource = SerializableResource.new(@resource)
+      expected_value = resource.serializer_instance.cache_key(resource.adapter)
+      assert_equal resource.cache_key, expected_value
+    end
+
     class SerializableResourceErrorsTest < Minitest::Test
       def test_serializable_resource_with_errors
         options = nil


### PR DESCRIPTION
#### Purpose
Adds `#cache_key` method to SerializableResource so that users can more easily introspect the cache key outside of the controller

#### Changes
As above

#### Caveats
None

#### Related GitHub issues
#2157 

#### Additional helpful information
N/A
