### PR TITLE
Fix 0.10.6 Guides link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please see below for the documentation relevant to you.
 - [0.10 (0-10-stable) Documentation](https://github.com/rails-api/active_model_serializers/tree/0-10-stable)
 - [0.10.6 (latest release) Documentation](https://github.com/rails-api/active_model_serializers/tree/v0.10.6)
   - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/gems/active_model_serializers/0.10.6)
-  - [Guides](docs)
+  - [Guides](https://github.com/rails-api/active_model_serializers/tree/v0.10.6/docs)
 - [0.9 (0-9-stable) Documentation](https://github.com/rails-api/active_model_serializers/tree/0-9-stable)
   - [![API Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/github/rails-api/active_model_serializers/0-9-stable)
 - [0.8 (0-8-stable) Documentation](https://github.com/rails-api/active_model_serializers/tree/0-8-stable)


### PR DESCRIPTION
The link was currently pointing to /docs in master which is currently empty

