### PR TITLE
Removed misleading line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Check how to change the adapter in the sections below.
 `0.10.x` is based on the `0.8.0` code, but with a more flexible
 architecture. We'd love your help. [Learn how you can help here.](CONTRIBUTING.md)
 
-It is generally safe and recommended to use the master branch.
-
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
As mentioned in the `master` branch's README, master will not be release ready for now.
Fixes https://github.com/rails-api/active_model_serializers/issues/2163
