### PR TITLE
For nil return DefaultSerializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -59,6 +59,8 @@ end
       def serializer_for(resource, options = {})
         if resource.respond_to?(:serializer_class)
           resource.serializer_class
+        elsif resource.nil?
+          DefaultSerializer
         elsif resource.respond_to?(:to_ary)
           if Object.constants.include?(:ArraySerializer)
             ::ArraySerializer


### PR DESCRIPTION
There is no need to check the serializer for nil serializer,
since it should be DefaultSerializer.

