### PR TITLE
Add missing api_controller that Rails 5 generator expects

### DIFF
--- a/lib/active_model/serializer/generators/serializer/templates/api_controller.rb
+++ b/lib/active_model/serializer/generators/serializer/templates/api_controller.rb
@@ -1,0 +1,93 @@
+<% if namespaced? -%>
+require_dependency "<%= namespaced_file_path %>/application_controller"
+
+<% end -%>
+<% module_namespacing do -%>
+class <%= controller_class_name %>Controller < ApplicationController
+  before_action :set_<%= singular_table_name %>, only: [:show, :edit, :update, :destroy]
+
+  # GET <%= route_url %>
+  # GET <%= route_url %>.json
+  def index
+    @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
+
+    respond_to do |format|
+      format.html # index.html.erb
+      format.json { render json: <%= "@#{plural_table_name}" %> }
+    end
+  end
+
+  # GET <%= route_url %>/1
+  # GET <%= route_url %>/1.json
+  def show
+    respond_to do |format|
+      format.html # show.html.erb
+      format.json { render json: <%= "@#{singular_table_name}" %> }
+    end
+  end
+
+  # GET <%= route_url %>/new
+  def new
+    @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
+  end
+
+  # GET <%= route_url %>/1/edit
+  def edit
+  end
+
+  # POST <%= route_url %>
+  # POST <%= route_url %>.json
+  def create
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
+
+    respond_to do |format|
+      if @<%= orm_instance.save %>
+        format.html { redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully created.'" %> }
+        format.json { render json: <%= "@#{singular_table_name}" %>, status: :created }
+      else
+        format.html { render action: 'new' }
+        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT <%= route_url %>/1
+  # PATCH/PUT <%= route_url %>/1.json
+  def update
+    respond_to do |format|
+      if @<%= orm_instance.update("#{singular_table_name}_params") %>
+        format.html { redirect_to @<%= singular_table_name %>, notice: <%= "'#{human_name} was successfully updated.'" %> }
+        format.json { head :no_content }
+      else
+        format.html { render action: 'edit' }
+        format.json { render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE <%= route_url %>/1
+  # DELETE <%= route_url %>/1.json
+  def destroy
+    @<%= orm_instance.destroy %>
+    respond_to do |format|
+      format.html { redirect_to <%= index_helper %>_url }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_<%= singular_table_name %>
+      @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def <%= "#{singular_table_name}_params" %>
+      <%- if attributes_names.empty? -%>
+      params[<%= ":#{singular_table_name}" %>]
+      <%- else -%>
+      params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+      <%- end -%>
+    end
+end
+<% end -%>


### PR DESCRIPTION
#### Purpose
This allows AMS 0.9x to be used with Rails 5, without any errors.

#### Changes
Added an `api_controller.rb` template that the Rails 5 Generator expects.

#### Caveats
This fixes the main issue that I was facing in #1923 but as I experiment more, there might be more issues getting Rails 5, AMS 0.9x to play well.

#### Related GitHub issues
#1923 

#### Additional helpful information
Thanks @bf4 @remear for your help debugging this issue.

