### PR TITLE
Include namespace when looking up superclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixes:
 - [#2223](https://github.com/rails-api/active_model_serializers/pull/2223) Support Fieldset in Attributes/JSON adapters documented in [docs/general/fields.md](https://github.com/rails-api/active_model_serializers/blob/0-10-stable/docs/general/fields.md) that worked partially before (@bf4)
 - [#2337](https://github.com/rails-api/active_model_serializers/pull/2337) fix incorrect belongs_to serialization when foreign_key on object and belongs_to is blank (@InteNs)
     - Fixes incorrect json-api generation when `jsonapi_use_foreign_key_on_belongs_to_relationship` is `true` and the relationship is blank
+- [#2172](https://github.com/rails-api/active_model_serializers/pull/2172) Preserve the namespace when falling back to a superclass serializer
 
 Misc:
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -94,7 +94,7 @@ module ActiveModel
         if serializer_class
           serializer_class
         elsif klass.superclass
-          get_serializer_for(klass.superclass)
+          get_serializer_for(klass.superclass, namespace)
         else
           nil # No serializer found
         end

--- a/test/serializers/serializer_for_with_namespace_test.rb
+++ b/test/serializers/serializer_for_with_namespace_test.rb
@@ -9,6 +9,7 @@ module ActiveModel
         attributes :title, :author_name
         associations :publisher, :pages
       end
+      class Ebook < Book; end
       class Page < ::Model; attributes :number, :text end
       class Publisher < ::Model; attributes :name end
 
@@ -84,6 +85,11 @@ module ActiveModel
           }
         }
         assert_equal expected, result
+      end
+
+      test 'follows inheritance with a namespace' do
+        serializer = ActiveModel::Serializer.serializer_for(Ebook.new, namespace: Api::V3)
+        assert_equal Api::V3::BookSerializer, serializer
       end
     end
   end


### PR DESCRIPTION
#### Purpose
When falling back to the superclass for finding a serializer, the namespace was getting dropped.

#### Changes
Pass the namespace through when finding a serializer for the superclass.
