### PR TITLE
Add warnings about global adapter config to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Fixes:
 
 Misc:
 
+- #2176 Documentation for global adapter config (@mrpinsky)
+
 ### [v0.10.6 (2017-05-01)](https://github.com/rails-api/active_model_serializers/compare/v0.10.5...v0.10.6)
 
 Fixes:

--- a/docs/general/adapters.md
+++ b/docs/general/adapters.md
@@ -36,6 +36,12 @@ The `Attributes` adapter does not include a root key. It is just the serialized 
 
 Use either the `JSON` or `JSON API` adapters if you want the response document to have a root key.
 
+***IMPORTANT***: Adapter configuration has *no effect* on a serializer instance
+being used directly. That is, `UserSerializer.new(user).as_json` will *always*
+behave as if the adapter were the 'Attributes' adapter. See [Outside Controller
+Usage](../howto/outside_controller_use.md) for more details on recommended
+usage.
+
 ## Built in Adapters
 
 ### Attributes - Default

--- a/docs/howto/add_root_key.md
+++ b/docs/howto/add_root_key.md
@@ -18,6 +18,13 @@ In order to add the root key you need to use the ```JSON``` Adapter, you can cha
 ActiveModelSerializers.config.adapter = :json
 ```
 
+Note that adapter configuration has no effect on a serializer that is called
+directly, e.g. in a serializer unit test. Instead, something like
+`UserSerializer.new(user).as_json` will *always* behave as if the adapter were
+the 'Attributes' adapter. See [Outside Controller
+Usage](../howto/outside_controller_use.md) for more details on recommended
+usage.
+
 You can also specify a class as adapter, as long as it complies with the ActiveModelSerializers adapters interface.
 It will add the root key to all your serialized endpoints.
 


### PR DESCRIPTION
#### Purpose
Clarify effects of global adapter configuration in relation on serializer behavior

#### Changes
Add warnings to docs

#### Caveats
No code changes, just documentation

#### Additional helpful information
This came up for me when trying to test serializer behavior. I wanted to the serialization to include a root key, but despite setting `ActiveModelSerializers.config.adapter = :json` in an initializer, my calls to `serializer.as_json` didn't have the root key. When I tried to repro in a fresh Rails app, I found that calls to `render` in a controller did add a root key, but direct calls to `serializer.as_json` and `serializer.serializable_hash` with no arguments did not. Digging in, I think the problem is in `ActiveModel::Serializer:112-115`:
```ruby
    # @api private
    def self.serialization_adapter_instance
      @serialization_adapter_instance ||= ActiveModelSerializers::Adapter::Attributes
    end
```
that is, `@serialization_adapter_instance` is never set, and so it defaults to the hard-coded `Attributes` adapter if it isn't passed in to `serializable_hash` (which it isn't if you just use `as_json`);
```ruby
    # @return [Hash] containing the attributes and first level
    # associations, similar to how ActiveModel::Serializers::JSON is used
    # in ActiveRecord::Base.
    def serializable_hash(adapter_options = nil, options = {}, adapter_instance = self.class.serialization_adapter_instance)
      adapter_options ||= {}
      options[:include_directive] ||= ActiveModel::Serializer.include_directive_from_options(adapter_options)
      resource = attributes_hash(adapter_options, options, adapter_instance)
      relationships = associations_hash(adapter_options, options, adapter_instance)
      resource.merge(relationships)
    end
    alias to_hash serializable_hash
    alias to_h serializable_hash

    # @see #serializable_hash
    def as_json(adapter_opts = nil)
      serializable_hash(adapter_opts)
    end
```
