### PR TITLE
Patch Enumerator.new ArgumentError.

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -337,7 +337,7 @@ module ActiveModel
     # @return [Enumerator<Association>]
     def associations(include_directive = ActiveModelSerializers.default_include_directive, include_slice = nil)
       include_slice ||= include_directive
-      return Enumerator.new unless object
+      return Enumerator.new { } unless object
 
       Enumerator.new do |y|
         self.class._reflections.each do |key, reflection|


### PR DESCRIPTION
Addresses https://github.com/rails-api/active_model_serializers/issues/2173
```
irb(main):001:0> Enumerator.new
ArgumentError: wrong number of arguments (given 0, expected 1+)
        from (irb):1:in `initialize'
        from (irb):1:in `new'
        from (irb):1
        from /Users/darrencheng/.rbenv/versions/2.3.0/bin/irb:11:in `<main>'
irb(main):002:0> Enumerator.new { }
=> #<Enumerator: #<Enumerator::Generator:0x007fdc64b55a20>:each>
```