### PR TITLE
Update version constraint for jsonapi-renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Features:
 
 - [#2021](https://github.com/rails-api/active_model_serializers/pull/2021) ActiveModelSerializers::Model#attributes. Originally in [#1982](https://github.com/rails-api/active_model_serializers/pull/1982). (@bf4)
 - [#2130](https://github.com/rails-api/active_model_serializers/pull/2130) Allow serialized ID to be overwritten for belongs-to relationships. (@greysteil)
+- [#2189](https://github.com/rails-api/active_model_serializers/pull/2189)
+  Update version constraint for jsonapi-renderer to `['>= 0.1.1.beta1', '< 0.3']`
+  (@tagliala)
 
 Fixes:
 

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   # 'minitest'
   # 'thread_safe'
 
-  spec.add_runtime_dependency 'jsonapi-renderer', ['>= 0.1.1.beta1', '< 0.2']
+  spec.add_runtime_dependency 'jsonapi-renderer', ['>= 0.1.1.beta1', '< 0.3']
   spec.add_runtime_dependency 'case_transform', '>= 0.2'
 
   spec.add_development_dependency 'activerecord', rails_versions


### PR DESCRIPTION
#### Purpose
Update 'jsonapi-renderer' dependency to meet last released version

#### Changes
Just the `'jsonapi-renderer'` entry in the gemspec file

#### Caveats


#### Related GitHub issues
#2057

#### Additional helpful information
Tested against Rails: 5.1.4, 5.0.6, 4.2.9, 4.1.16

