### PR TITLE
Prevent loading has_one relation with block, if it is not included

### DIFF
--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -154,8 +154,9 @@ module ActiveModel
         @object = serializer.object
         @scope = serializer.scope
 
-        block_value = instance_exec(serializer, &block) if block
         return unless include_data?(include_slice)
+
+        block_value = instance_exec(serializer, &block) if block
 
         if block && block_value != :nil
           block_value


### PR DESCRIPTION
Before this PR; when setting a has_one relation with block, it loads content of it even if the relation is not included