### PR TITLE
Adjusts Deserializer relationship parsing to allow links/meta keys

### DIFF
--- a/test/action_controller/json_api/deserialization_test.rb
+++ b/test/action_controller/json_api/deserialization_test.rb
@@ -106,6 +106,43 @@ module ActionController
 
           assert_equal(expected, response)
         end
+
+        def test_deserialization_with_links_relationship
+          hash = {
+            'data' => {
+              'type' => 'photos',
+              'id' => 'zorglub',
+              'attributes' => {
+                'title' => 'Ember Hamster',
+                'src' => 'http://example.com/images/productivity.png',
+                'image-width' => '200',
+                'imageHeight' => '200',
+                'ImageSize' => '1024'
+              },
+              'relationships' => {
+                'images' => {
+                  'links' => {
+                    'related' => 'https://example.com/images/tomster/related'
+                  }
+                }
+              }
+            }
+          }
+
+          post :render_parsed_payload, params: hash
+
+          response = JSON.parse(@response.body)
+          expected = {
+            'id' => 'zorglub',
+            'title' => 'Ember Hamster',
+            'src' => 'http://example.com/images/productivity.png',
+            'image_width' => '200',
+            'image_height' => '200',
+            'image_size' => '1024'
+          }
+
+          assert_equal(expected, response)
+        end
       end
     end
   end


### PR DESCRIPTION
#### Purpose

The JSON API spec allows for the [relationships key](http://jsonapi.org/format/#document-resource-object-relationships) to include one of `data`, `links` or `meta`.

The current parsing logic for the deserialiser raises an exception unless a `data` key is present (this may have been changed after the code was written 🚄), which means that we're getting an exception on a valid JSON:API document 😭 

#### Changes

* Adjusts the document validation inside the Deserializer to allow for one of `data`, `links`, or `meta` as per the spec.
* Ignores the `links` or `meta` keys when parsing the relationship into something to be used by Rails.

#### Caveats

It may not be the best behaviour to ignore the keys silently - however, I'm not really sure what a useful thing to do here would be. Perhaps print a warning?

#### Related GitHub issues

None 😺 

#### Additional helpful information

Thanks for the 💎, and your time reviewing this folks! 