### PR TITLE
Test against latest stable Ruby and Rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,14 @@ env:
     - "RAILS_VERSION=4.1"
     - "RAILS_VERSION=4.2"
     - "RAILS_VERSION=5.0"
+    - "RAILS_VERSION=5.1"
     - "RAILS_VERSION=master"
 
 rvm:
-  - 2.1
-  - 2.2.6
-  - 2.3.3
+  - 2.1.10
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
 
 matrix:
@@ -37,8 +39,11 @@ matrix:
   # - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
   # - { rvm: jruby-head,     jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
   exclude:
-  - { rvm: 2.1,           env: RAILS_VERSION=master }
-  - { rvm: 2.1,           env: RAILS_VERSION=5.0 }
+  - { rvm: 2.1.10,        env: RAILS_VERSION=master }
+  - { rvm: 2.1.10,        env: RAILS_VERSION=5.0 }
+  - { rvm: 2.1.10,        env: RAILS_VERSION=5.1 }
+  - { rvm: 2.4.2,         env: RAILS_VERSION=4.1 }
+  - { rvm: ruby-head,     env: RAILS_VERSION=4.1 }
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head


### PR DESCRIPTION
Also skips Rails 4.1 tests against Ruby 2.4.2 and ruby-head,
because Rails 4.2.8 is the first version of the 4.x series that
officially	support Ruby 2.4.

#### Purpose

Test against latest stable Ruby version: 2.4.2
Also skips tests that are going to fail (Rails 4.1 with Ruby >= 2.4)

#### Changes

Just the Travis CI configuration

#### Caveats


#### Related GitHub issues


#### Additional helpful information
Travis CI tests were previously skipping the latest stable Ruby version (2.4.2), jumping from 2.3 to 2.5.0.dev. Same for Rails, jumping from 5.0.6 to 5.2.0alpha and skipping 5.1.4
