### PR TITLE
Fix deserialization of polymorphic relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Features:
 Fixes:
 
 - [#2022](https://github.com/rails-api/active_model_serializers/pull/2022) Mutation of ActiveModelSerializers::Model now changes the attributes. Originally in [#1984](https://github.com/rails-api/active_model_serializers/pull/1984). (@bf4)
+- [#2200](https://github.com/rails-api/active_model_serializers/pull/2200) Fix deserialization of polymorphic relationships. (@dennis95stumm)
 
 Misc:
 

--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -189,7 +189,7 @@ module ActiveModelSerializers
 
           polymorphic = (options[:polymorphic] || []).include?(assoc_name.to_sym)
           if polymorphic
-            hash["#{prefix_key}_type".to_sym] = assoc_data.present? ? assoc_data['type'] : nil
+            hash["#{prefix_key}_type".to_sym] = assoc_data.present? ? assoc_data['type'].classify : nil
           end
 
           hash

--- a/test/action_controller/json_api/deserialization_test.rb
+++ b/test/action_controller/json_api/deserialization_test.rb
@@ -45,7 +45,7 @@ module ActionController
           response = JSON.parse(@response.body)
           expected = {
             'restriction_for_id' => '67',
-            'restriction_for_type' => 'discounts',
+            'restriction_for_type' => 'Discount',
             'restricted_to_id' => nil,
             'restricted_to_type' => nil
           }

--- a/test/adapter/json_api/parse_test.rb
+++ b/test/adapter/json_api/parse_test.rb
@@ -125,7 +125,7 @@ module ActiveModelSerializers
               src: 'http://example.com/images/productivity.png',
               author_id: nil,
               photographer_id: '9',
-              photographer_type: 'people',
+              photographer_type: 'Person',
               comment_ids: %w(1 2)
             }
             assert_equal(expected, parsed_hash)


### PR DESCRIPTION
#### Purpose
The type of polymorphic relationships must be classified. Otherwise a `NameError` will be raised by ruby.

#### Changes
The type of polymorphic relationships gets now classified.