### PR TITLE
use config.default_includes for JsonApi adapter relationships

### DIFF
--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -344,7 +344,7 @@ module ActiveModelSerializers
         data.tap do |resource_object|
           next if resource_object.nil?
           # NOTE(BF): the attributes are cached above, separately from the relationships, below.
-          requested_associations = fieldset.fields_for(resource_object[:type]) || '*'
+          requested_associations = fieldset.fields_for(resource_object[:type]) || ActiveModelSerializers.config.default_includes
           relationships = relationships_for(serializer, requested_associations, include_slice)
           resource_object[:relationships] = relationships if relationships.any?
         end


### PR DESCRIPTION
#### Purpose

Fix a raw `'*'` assumption which causes unrequested relationships to evaluated and added with only a `meta` member.

#### Changes

Use `config.default_includes` as intended.

#### Caveats

None?

#### Related GitHub issues

Couldn't find any.

#### Additional helpful information


