### PR TITLE
JSON:API relationship tests no longer show v0.10.5 regression

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -46,7 +46,14 @@ module ActiveModelSerializers
           if association.belongs_to? &&
               parent_serializer.object.respond_to?(association.reflection.foreign_key)
             id = parent_serializer.read_attribute_for_serialization(association.reflection.foreign_key)
-            type = association.reflection.type.to_s
+            if association.polymorphic?
+              # We can't infer resource type for polymorphic relationships from the serializer.
+              # We can ONLY know a polymorphic resource type by inspecting each resource.
+              serializer = association.lazy_association.serializer
+              type = serializer.json_key
+            else
+              type = association.reflection.type.to_s
+            end
             ResourceIdentifier.for_type_with_id(type, id, serializable_resource_options)
           else
             # TODO(BF): Process relationship without evaluating lazy_association

--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -43,17 +43,16 @@ module ActiveModelSerializers
         end
 
         def data_for_one(association)
-          if association.belongs_to? &&
-              parent_serializer.object.respond_to?(association.reflection.foreign_key)
+          if belongs_to_id_on_self?(association)
             id = parent_serializer.read_attribute_for_serialization(association.reflection.foreign_key)
-            if association.polymorphic?
-              # We can't infer resource type for polymorphic relationships from the serializer.
-              # We can ONLY know a polymorphic resource type by inspecting each resource.
-              serializer = association.lazy_association.serializer
-              type = serializer.json_key
-            else
-              type = association.reflection.type.to_s
-            end
+            type =
+              if association.polymorphic?
+                # We can't infer resource type for polymorphic relationships from the serializer.
+                # We can ONLY know a polymorphic resource type by inspecting each resource.
+                association.lazy_association.serializer.json_key
+              else
+                association.reflection.type.to_s
+              end
             ResourceIdentifier.for_type_with_id(type, id, serializable_resource_options)
           else
             # TODO(BF): Process relationship without evaluating lazy_association
@@ -92,6 +91,11 @@ module ActiveModelSerializers
         def meta_for(association)
           meta = association.meta
           meta.respond_to?(:call) ? parent_serializer.instance_eval(&meta) : meta
+        end
+
+        def belongs_to_id_on_self?(association)
+          association.belongs_to? &&
+            parent_serializer.object.respond_to?(association.reflection.foreign_key)
         end
       end
     end

--- a/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
+++ b/lib/active_model_serializers/adapter/json_api/resource_identifier.rb
@@ -9,6 +9,7 @@ module ActiveModelSerializers
 
         def self.for_type_with_id(type, id, options)
           return nil if id.blank?
+          type = inflect_type(type)
           {
             id: id.to_s,
             type: type_for(:no_class_needed, type, options)
@@ -17,13 +18,17 @@ module ActiveModelSerializers
 
         def self.raw_type_from_serializer_object(object)
           class_name = object.class.name # should use model_name
-          serializer_type = class_name.underscore
+          raw_type = class_name.underscore
+          raw_type = inflect_type(raw_type)
+          raw_type
+            .gsub!('/'.freeze, ActiveModelSerializers.config.jsonapi_namespace_separator)
+          raw_type
+        end
+
+        def self.inflect_type(type)
           singularize = ActiveModelSerializers.config.jsonapi_resource_type == :singular
           inflection = singularize ? :singularize : :pluralize
-          serializer_type = ActiveSupport::Inflector.public_send(inflection, serializer_type)
-          serializer_type
-            .gsub!('/'.freeze, ActiveModelSerializers.config.jsonapi_namespace_separator)
-          serializer_type
+          ActiveSupport::Inflector.public_send(inflection, type)
         end
 
         # {http://jsonapi.org/format/#document-resource-identifier-objects Resource Identifier Objects}
@@ -44,7 +49,8 @@ module ActiveModelSerializers
         private
 
         def type_for(serializer, transform_options)
-          self.class.type_for(serializer, serializer._type, transform_options)
+          serializer_type = serializer._type
+          self.class.type_for(serializer, serializer_type, transform_options)
         end
 
         def id_for(serializer)

--- a/test/adapter/polymorphic_test.rb
+++ b/test/adapter/polymorphic_test.rb
@@ -165,6 +165,53 @@ module ActiveModel
 
           assert_equal(expected, serialization(@picture, :json_api))
         end
+
+        def test_json_api_serialization_with_polymorphic_belongs_to
+          expected = {
+            data: {
+              id: '1',
+              type: 'poly-tags',
+              attributes: { phrase: 'foo' },
+              relationships: {
+                :"object-tags" => {
+                  data: [
+                    { id: '1', type: 'object-tags' },
+                    { id: '5', type: 'object-tags' }
+                  ]
+                }
+              }
+            },
+            included: [
+              {
+                id: '1',
+                type: 'object-tags',
+                relationships: {
+                  taggable: {
+                    data: { id: '42', type: 'employees' }
+                  }
+                }
+              },
+              {
+                id: '42',
+                type: 'employees'
+              },
+              {
+                id: '5',
+                type: 'object-tags',
+                relationships: {
+                  taggable: {
+                    data: { id: '1', type: 'pictures' }
+                  }
+                }
+              },
+              {
+                id: '1',
+                type: 'pictures'
+              }
+            ]
+          }
+          assert_equal(expected, tag_serialization(:json_api))
+        end
       end
     end
   end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -89,7 +89,7 @@ class ObjectTag < ActiveRecord::Base
 end
 class PolymorphicObjectTagSerializer < ActiveModel::Serializer
   attributes :id
-  has_many :taggable, serializer: PolymorphicSimpleSerializer, polymorphic: true
+  belongs_to :taggable, serializer: PolymorphicSimpleSerializer, polymorphic: true
 end
 
 class PolyTag < ActiveRecord::Base
@@ -109,5 +109,5 @@ class PolymorphicHasManySerializer < ActiveModel::Serializer
 end
 class PolymorphicBelongsToSerializer < ActiveModel::Serializer
   attributes :id, :title
-  has_one :imageable, serializer: PolymorphicHasManySerializer, polymorphic: true
+  belongs_to :imageable, serializer: PolymorphicHasManySerializer, polymorphic: true
 end


### PR DESCRIPTION
Closes #2160

Closes #2125

- Fix polymorphic belongs_to tests; passes on v0.10.5, fails on v0.10.6
- Fix JSON:API polymorphic type regression from v0.10.5
- Fix JSON:API: for_type_and_id should always inflect_type
    ```
    Should Serializer._type ever be inflected?
    Right now, it won't be, but association.serializer._type will be inflected.

    That's the current behavior.
     ```

Related: https://github.com/rails-api/active_model_serializers/pull/2140
