### PR TITLE
Fail if collection type cannot be inferred with json adapter (#2210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Fixes:
 
 - [#2022](https://github.com/rails-api/active_model_serializers/pull/2022) Mutation of ActiveModelSerializers::Model now changes the attributes. Originally in [#1984](https://github.com/rails-api/active_model_serializers/pull/1984). (@bf4)
 - [#2200](https://github.com/rails-api/active_model_serializers/pull/2200) Fix deserialization of polymorphic relationships. (@dennis95stumm)
+- [#2214](https://github.com/rails-api/active_model_serializers/pull/2214) Fail if unable to infer collection type with json adapter. (@jmeredith16)
 
 Misc:
 

--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -46,7 +46,10 @@ module ActiveModel
         # 3. get from collection name, if a named collection
         key ||= object.respond_to?(:name) ? object.name && object.name.underscore : nil
         # 4. key may be nil for empty collection and no serializer option
-        key && key.pluralize
+        key &&= key.pluralize
+        # 5. fail if the key cannot be determined
+        key || fail(ArgumentError, 'Cannot infer root key from collection type. Please
+                 specify the root or each_serializer option, or render a JSON String')
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -93,12 +93,16 @@ module ActiveModel
         resource = []
         resource.define_singleton_method(:name) { nil }
         serializer = collection_serializer.new(resource)
-        assert_nil serializer.json_key
+        assert_raise ArgumentError do
+          serializer.json_key
+        end
       end
 
       def test_json_key_with_resource_without_name_and_no_serializers
         serializer = collection_serializer.new([])
-        assert_nil serializer.json_key
+        assert_raise ArgumentError do
+          serializer.json_key
+        end
       end
 
       def test_json_key_with_empty_resources_with_serializer


### PR DESCRIPTION
#### Purpose
This issue was found while rendering an empty array while using the `:json` adapter in https://github.com/rails-api/active_model_serializers/issues/2210.  Without a known ActiveModel object, the root element cannot be determined, so what should have been `{ my_obj: [] }` was being represented by `{ "": [] }`.

#### Changes

- Returns an ArgumentError if the `json_key` method cannot determine the root key.  Previously, this method would just return `nil`.
- Updates two tests to verify the ArgumentError is returned instead of `nil`.

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/2210
https://github.com/rails-api/active_model_serializers/issues/1745

