### PR TITLE
Include namespace when looking up serializer for parent class if one …

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -91,7 +91,7 @@ module ActiveModel
         if serializer_class
           serializer_class
         elsif klass.superclass
-          get_serializer_for(klass.superclass)
+          get_serializer_for(klass.superclass, namespace)
         else
           nil # No serializer found
         end

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -37,6 +37,11 @@ module ActiveModel
           end
         end
 
+        module SerializerNamespace
+          class ProfileSerializer < ActiveModel::Serializer
+          end
+        end
+
         class MyProfile < Profile
         end
 
@@ -82,6 +87,11 @@ module ActiveModel
         def test_serializer_inherited_serializer
           serializer = ActiveModel::Serializer.serializer_for(@my_profile)
           assert_equal ProfileSerializer, serializer
+        end
+
+        def test_serializer_inherited_serializer_with_namespace
+          serializer = ActiveModel::Serializer.serializer_for(@my_profile, namespace: SerializerNamespace)
+          assert_equal SerializerNamespace::ProfileSerializer, serializer
         end
 
         def test_serializer_inherited_serializer_with_lookup_disabled


### PR DESCRIPTION
…was passed

#### Purpose
To consider namespace, if one was passed, when looking up serializer for parent of a subclass.

#### Changes
Pass namespace along when looking up serializer for superclass of resource.

#### Caveats


#### Related GitHub issues


#### Additional helpful information


