### PR TITLE
[docs] disable logger via /dev/null instead of AS::N.unsubscribe

### DIFF
--- a/docs/general/logging.md
+++ b/docs/general/logging.md
@@ -16,6 +16,5 @@ ActiveModelSerializers.logger = Logger.new(STDOUT)
 You can also disable the logger, just put this in `config/initializers/active_model_serializers.rb`:
 
 ```ruby
-require 'active_model_serializers'
-ActiveSupport::Notifications.unsubscribe(ActiveModelSerializers::Logging::RENDER_EVENT)
+ActiveModelSerializers.logger = Logger.new(IO::NULL)
 ```


### PR DESCRIPTION
#### Purpose

The advice given to unsubscribe from `ActiveSupport::Notifications` is a bit over-eager, as `#unsubscribe` will remove listeners other than the `ActiveModelSerializers::LogSubscriber`. A better solution to disable logging is to redirect the logger to /dev/null.

#### Changes

Alter logger documentation

#### Caveats


#### Related GitHub issues


#### Additional helpful information


