### PR TITLE
Optional relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tags
 Icon?
 ehthumbs.db
 Thumbs.db
+
+# sdk
+.idea

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -343,6 +343,7 @@ module ActiveModel
       Enumerator.new do |y|
         self.class._reflections.each do |key, reflection|
           next if reflection.excluded?(self)
+          next if reflection.options[:optional] && ( instance_options[:included].nil? || !instance_options[:included].include?(key.to_s) )
           next unless include_directive.key?(key)
 
           association = reflection.build_association(self, instance_options, include_slice)


### PR DESCRIPTION
#### Purpose
With models that have many relationships, especially nested relationships, automatically including those relationships by default can make an otherwise fast query take a long time. Allowing an easy way to make relationships optional unless specifically requested through `include` is essential for performance

#### Changes
Only include relationships in the `associations` method if they are not defined as optional OR if they are optional and specified in the include request

There is also a small update to the `.gitignore` for excluding intelliJ project files  

#### Caveats
This has worked perfectly for our existing needs including a number of polymorphic relationshisp, but may need further testing.

#### Related GitHub issues
#1865 

#### Additional helpful information
In the following serializer:

    class PostSerializer < ActiveModel::Serializer
        has_many :comments, :optional => true
        attributes :id, :title, :body
    end

`comments` will not be the response unless asked for

    render  :json => :post, :include  => "comments" # will include comments

    render  :json => :post, # will only include post data

