### PR TITLE
[docs] Fix class name documentation

### DIFF
--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -81,6 +81,7 @@ e.g.
 ```ruby
 has_one :bio
 has_one :blog, key: :site
+has_one :blog, class_name: "Blog"
 has_one :maker, virtual_value: { id: 1 }
 
 has_one :blog do |serializer|
@@ -114,6 +115,7 @@ e.g.
 has_many :comments
 has_many :comments, key: :reviews
 has_many :comments, serializer: CommentPreviewSerializer
+has_many :comments, class_name: "Comment"
 has_many :reviews, virtual_value: [{ id: 1 }, { id: 2 }]
 has_many :comments, key: :last_comments do
   last(1)
@@ -127,6 +129,7 @@ e.g.
 ```ruby
 belongs_to :author, serializer: AuthorPreviewSerializer
 belongs_to :author, key: :writer
+belongs_to :author, class_name: "Author"
 belongs_to :post
 belongs_to :blog
 def blog
@@ -294,7 +297,7 @@ end
 Whether you write the method as above or as `object.comments.where(created_by: scope)`
 is a matter of preference (assuming `scope_name` has been set).
 
-Keep in mind that the scope can be set to any available controller reference. This can be utilized to provide access to any other data scopes or presentation helpers. 
+Keep in mind that the scope can be set to any available controller reference. This can be utilized to provide access to any other data scopes or presentation helpers.
 
 ##### Controller Authorization Context
 
@@ -381,7 +384,7 @@ class PostsController < ActionController::Base
   end
 end
 ```
-Note that any controller reference which provides the desired scope is acceptable, such as another controller method for loading a different resource or reference to helpers. For example, `ActionController::API` does not include `ActionView::ViewContext`, and would need a different reference for passing any helpers into a serializer via `serialization_scope`. 
+Note that any controller reference which provides the desired scope is acceptable, such as another controller method for loading a different resource or reference to helpers. For example, `ActionController::API` does not include `ActionView::ViewContext`, and would need a different reference for passing any helpers into a serializer via `serialization_scope`.
 
 #### #read_attribute_for_serialization(key)
 

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -65,7 +65,7 @@ Where:
   - `virtual_value:`
   - `polymorphic:` defines if polymorphic relation type should be nested in serialized association.
   - `type:` the resource type as used by JSON:API, especially on a `belongs_to` relationship.
-  - `class_name:` used to determine `type` when `type` not given. `class_name` option to supply the model name as string.
+  - `class_name:` used to determine `type` when `type` is not given. `class_name` option to supply the model name as string.
   - `foreign_key:` used by JSON:API on a `belongs_to` relationship to avoid unnecessarily loading the association object.
   - `namespace:` used when looking up the serializer and `serializer` is not given.  Falls back to the parent serializer's `:namespace` instance options, which, when present, comes from the render options. See [Rendering#namespace](rendering.md#namespace] for more details.
 - optional: `&block` is a context that returns the association's attributes.

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -65,7 +65,7 @@ Where:
   - `virtual_value:`
   - `polymorphic:` defines if polymorphic relation type should be nested in serialized association.
   - `type:` the resource type as used by JSON:API, especially on a `belongs_to` relationship.
-  - `class_name:` used to determine `type` when `type` is not given. `class_name` option to supply the model name as string.
+  - `class_name:` the (String) model name used to determine `type`, when `type` is not given. e.g. `class_name: "Comment"` would imply the type `comments`
   - `foreign_key:` used by JSON:API on a `belongs_to` relationship to avoid unnecessarily loading the association object.
   - `namespace:` used when looking up the serializer and `serializer` is not given.  Falls back to the parent serializer's `:namespace` instance options, which, when present, comes from the render options. See [Rendering#namespace](rendering.md#namespace] for more details.
 - optional: `&block` is a context that returns the association's attributes.

--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -65,7 +65,7 @@ Where:
   - `virtual_value:`
   - `polymorphic:` defines if polymorphic relation type should be nested in serialized association.
   - `type:` the resource type as used by JSON:API, especially on a `belongs_to` relationship.
-  - `class_name:` used to determine `type` when `type` not given
+  - `class_name:` used to determine `type` when `type` not given. `class_name` option to supply the model name as string.
   - `foreign_key:` used by JSON:API on a `belongs_to` relationship to avoid unnecessarily loading the association object.
   - `namespace:` used when looking up the serializer and `serializer` is not given.  Falls back to the parent serializer's `:namespace` instance options, which, when present, comes from the render options. See [Rendering#namespace](rendering.md#namespace] for more details.
 - optional: `&block` is a context that returns the association's attributes.


### PR DESCRIPTION
#### Purpose
ActiveModel::Serializer breaks if association with class_name options is provided as constant. 

#### Changes
- Updated the `class_name` defination.
- Added examples for serializer with associations having `class_name` as option.

#### Related GitHub issues
#2258 



