### PR TITLE
Fix Lint links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ to know about, but not part of ActiveModelSerializers.)
 
 - An `ActiveRecord::Base` object.
 - Any Ruby object that passes the
-  [Lint](http://www.rubydoc.info/github/rails-api/active_model_serializers/ActiveModel/Serializer/Lint/Tests)
-  [code](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer/lint.rb).
+  [Lint](https://www.rubydoc.info/gems/active_model_serializers/ActiveModel/Serializer/Lint/Tests)
+  [(code)](lib/active_model/serializer/lint.rb).
 
 ActiveModelSerializers provides a
 [`ActiveModelSerializers::Model`](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model_serializers/model.rb),


### PR DESCRIPTION
#### Purpose
The links to the Lint tests and code are broken in the README.

#### Changes

- Update Tests link to navigate to the gem's Rubydoc instead of Github's.
- Update code link to relative path so it works within the branch
- Add parenthesis around the `code` link to highlight the fact that there are separate links.

