### PR TITLE
Use underscore before calling classify in case of polymorphic relation deserialization

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -189,7 +189,7 @@ module ActiveModelSerializers
 
           polymorphic = (options[:polymorphic] || []).include?(assoc_name.to_sym)
           if polymorphic
-            hash["#{prefix_key}_type".to_sym] = assoc_data.present? ? assoc_data['type'].classify : nil
+            hash["#{prefix_key}_type".to_sym] = assoc_data.present? ? assoc_data['type'].underscore.classify : nil
           end
 
           hash


### PR DESCRIPTION
Classify does not work for strings with '-', so calling
underscore on those string will make classify work on them.

#### Purpose


#### Changes


#### Caveats


#### Related GitHub issues


#### Additional helpful information


