### PR TITLE
Fix wrong type for polymorphic association while deserialization

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -189,7 +189,7 @@ module ActiveModelSerializers
 
           polymorphic = (options[:polymorphic] || []).include?(assoc_name.to_sym)
           if polymorphic
-            hash["#{prefix_key}_type".to_sym] = assoc_data.present? ? assoc_data['type'].classify : nil
+            hash["#{prefix_key}_type".to_sym] = assoc_data.present? ? assoc_data['type'].underscore.classify : nil
           end
 
           hash


### PR DESCRIPTION
while deserializing any polymorphic relation, the type of the record was
coming wrong. (e.g, for a relation of type 'BlogPost', the type was
coming out as 'Blog-post'). This was happening because, we were not
converting the hyphenated 'type' to underscore. This PR will do that
before calling classify on the type.

#### Purpose


#### Changes


#### Caveats


#### Related GitHub issues


#### Additional helpful information


