### PR TITLE
Improves documentation of belongs_to

### DIFF
--- a/docs/general/serializers.md
+++ b/docs/general/serializers.md
@@ -66,7 +66,7 @@ Where:
   - `polymorphic:` defines if polymorphic relation type should be nested in serialized association.
   - `type:` the resource type as used by JSON:API, especially on a `belongs_to` relationship.
   - `class_name:` the (String) model name used to determine `type`, when `type` is not given. e.g. `class_name: "Comment"` would imply the type `comments`
-  - `foreign_key:` used by JSON:API on a `belongs_to` relationship to avoid unnecessarily loading the association object.
+  - `foreign_key:` used by JSON:API on a `belongs_to` relationship to avoid unnecessarily loading the association object. This can also be used to override the `id` attribute set in the [`relationships` data field](http://jsonapi.org/format/#document-resource-object-relationships) if you are exposing a different value to the outside world. For example, if you are building an API and you want your consumers to access data via UUID instead of your database's ID, specifying the name of the foreign key like `foreign_key: :user_uuid` will cause the `relationships.data.id` to be set to the `#user_uuid` return value.
   - `namespace:` used when looking up the serializer and `serializer` is not given.  Falls back to the parent serializer's `:namespace` instance options, which, when present, comes from the render options. See [Rendering#namespace](rendering.md#namespace] for more details.
 - optional: `&block` is a context that returns the association's attributes.
   - prevents `association_name` method from being called.

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -237,6 +237,16 @@ module ActiveModel
 
     # @param [Symbol] name of the association
     # @param [Hash<Symbol => any>] options for the reflection
+    # @option options [Symbol] :key The name used for the serialized association.
+    # @option options [Symbol] :serializer
+    # @option options [Symbol] :if
+    # @option options [Symbol] :unless
+    # @option options [Symbol] :virtual_value
+    # @option options [Symbol] :polymorphic defines if polymorphic relation type should be nested in serialized association.
+    # @option options [Symbol] :type the resource type as used by JSON:API, especially on a `belongs_to` relationship.
+    # @option options [Symbol] :class_name the (String) model name used to determine `type`, when `type` is not given. e.g. `class_name: "Comment"` would imply the type `comments`
+    # @option options [Symbol] :foreign_key used by JSON:API on a `belongs_to` relationship to avoid unnecessarily loading the association object. This can also be used to override the `id` attribute set in the [`relationships` data field](http://jsonapi.org/format/#document-resource-object-relationships) if you are exposing a different value to the outside world instead of DB IDs
+    # @option options [Symbol] :namespace used when looking up the serializer and `serializer` is not given.  Falls back to the parent serializer's `:namespace` instance options, which, when present, comes from the render options. See [Rendering#namespace](rendering.md#namespace] for more details.
     # @return [void]
     #
     # @example


### PR DESCRIPTION
Full credit to @brucec5 for discovering this functionality.

#### Purpose

`#belongs_to` docs were a little slim, and it took us a long time to realize that we could use this to essentially override the API's "foreign key".

I also bumped the docs slightly to make it clearer that this is a way you can send a different identifier out into the world for the JSON API relationships.

This is especially useful if you want to change the identifier you expose to the outside world instead of DB values. There are many reasons you might want to do this.

* https://softwareengineering.stackexchange.com/questions/346971/should-backend-ids-be-public-or-not-on-a-rest-api
* http://toddfredrich.com/ids-in-rest-api.html
* https://medium.com/lightrail/prevent-business-intelligence-leaks-by-using-uuids-instead-of-database-ids-on-urls-and-in-apis-17f15669fd2e

#### Changes

Pure docs. No code was harmed in the making of this pull request.

#### Caveats

This may not be the best way to change the identifier exposed to the outside world. I don't see any way that this usage would cause a problem, but I welcome feedback.

I'm a little surprised that AMS doesn't call `Model#to_param` to generate the identifier used in the relationships field.