### PR TITLE
Fix thread unsafe behavior

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -341,7 +341,7 @@ module ActiveModel
       return Enumerator.new {} unless object
 
       Enumerator.new do |y|
-        self.class._reflections.each do |key, reflection|
+        (@reflections ||= self.class._reflections.deep_dup).each do |key, reflection|
           next if reflection.excluded?(self)
           next unless include_directive.key?(key)
 
@@ -405,6 +405,6 @@ module ActiveModel
 
     protected
 
-    attr_accessor :instance_options
+    attr_accessor :instance_options, :reflections
   end
 end


### PR DESCRIPTION
#### Purpose
There is a critical bug which reported at [issue 2207](https://github.com/rails-api/active_model_serializers/issues/2270). The bugs pose a serious security threat as a resource is capable of accessing another resource that does not belong to it. The consequences may affect to an enormous amount of project using AMS as their json serializer. 

#### Changes
A Small change in class ActiveModel::Serializer create new reflection in instance level instead of using self.class._reflections, which is used cross-request and cause object is override.

#### Caveats
The usage of self.class._reflections.deep_dup method put an amount of process, so that may affect performance

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/2270

