### PR TITLE
Add Blueprinter to alternatives in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ See [PR 2121](https://github.com/rails-api/active_model_serializers/pull/2121) w
 - [jsonapi-rb](http://jsonapi-rb.org/) is a [highly performant](https://gist.github.com/NullVoxPopuli/748e89ddc1732b42fdf42435d773734a) and modular JSON:API-only implementation.  There's a vibrant community around it that has produced projects such as [JSON:API Suite](https://jsonapi-suite.github.io/jsonapi_suite/).
 - [fast_jsonapi](https://github.com/Netflix/fast_jsonapi) is a lightning fast JSON:API serializer for Ruby Objects from the team of Netflix.
 - [jsonapi-resources](https://github.com/cerebris/jsonapi-resources) is a popular resource-focused framework for implementing JSON:API servers.
+- [blueprinter](https://github.com/procore/blueprinter) is a fast, declarative, and API spec agnostic serializer that uses composable views to reduce duplication. From your friends at Procore.
 
 
 For benchmarks against alternatives, see https://github.com/rails-api/active_model_serializers/tree/benchmarks


### PR DESCRIPTION
#### Purpose
Blueprinter is a simple, fast, and declarative serialization gem. It uses composable views to reduce duplication. I think it's a good alternative that should be on this readme.

#### Changes
This just updates the readme under the alternatives section

#### Caveats
n/a

#### Related GitHub issues
n/a

#### Additional helpful information
Blueprinter's github https://github.com/procore/blueprinter
