### PR TITLE
Enable filtering of fields in nested assocation

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -357,6 +357,12 @@ module ActiveModel
     def serializable_hash(adapter_options = nil, options = {}, adapter_instance = self.class.serialization_adapter_instance)
       adapter_options ||= {}
       options[:include_directive] ||= ActiveModel::Serializer.include_directive_from_options(adapter_options)
+
+      # [Note] Add this clause to provide selective fields for associations in json adapter.
+      if !options[:fields] && (h = options[:include_directive].to_hash[:only])
+        options[:fields] = h.keys
+      end
+
       resource = attributes_hash(adapter_options, options, adapter_instance)
       relationships = associations_hash(adapter_options, options, adapter_instance)
       resource.merge(relationships)


### PR DESCRIPTION
#### Purpose
Filtering nested association's fields.

#### Changes
Consider the case in which `User`, `Profile`, `UserSerializer`, `ProfileSerializer` are defined as below.

```ruby
class User < ApplicationRecord
  has_one :profile
end

class Profile < ApplicationRecord
  belongs_to :user
end

class UserSerializer < ActiveModel::Serializer
  attributes :id, :registered

  has_one :profile
end

class ProfileSerializer < ActiveModel::Serializer
  attributes :id, :location, :birthday
end
```

`user` is defined as below.

```ruby
[2] pry(main)> user = User.new(id: 1, registered: true)
=> #<User:0x00007fcaab93df78 id: 1, registered: true>

[3] pry(main)> user.profile = Profile.new(id: 2, location: 'united_states', birthday: Date.today)
=> #<Profile:0x00007fcaac567b78 id: 2, location: "united_states", birthday: Mon, 27 Aug 2018>
```

We compare the result of `ActiveModelSerializers::SerializableResource.new(user, adapter: :json, fields: [:registered], include: { profile: { only: [:birthday] } }).serializable_hash`.

##### Before
We cannot filter fields in nested associations, so all fields of `profile` are returned.

```ruby
[8] pry(main)> ActiveModelSerializers::SerializableResource.new(user, adapter: :json, fields: [:registered], include: { profile: { only: [:birthday] } }).serializable_hash

Rendered UserSerializer with ActiveModelSerializers::Adapter::Json (0.26ms)
=> {:user=>
  {:registered=>true, :profile=>{:id=>2, :location=>"united_states", :birthday=>Mon, 27 Aug 2018}}}
```

##### After
By applying this PR, we can filter fields in nested associations by using `only` keyword as below.

```ruby
[3] pry(main)> ActiveModelSerializers::SerializableResource.new(user, adapter: :json, fields: [:registered], include: { profile: { only: [:birthday] } }).serializable_hash

Rendered UserSerializer with ActiveModelSerializers::Adapter::Json (4.44ms)
=> {:user=>{:registered=>true, :profile=>{:birthday=>Mon, 27 Aug 2018}}}
```

#### Caveats
Nothing

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/issues/1895

#### Additional helpful information
We use this patch in production.

