### PR TITLE
Fix media type parameter (charset) in JSON:API responses (#2285)

### DIFF
--- a/lib/active_model_serializers/register_jsonapi_renderer.rb
+++ b/lib/active_model_serializers/register_jsonapi_renderer.rb
@@ -43,7 +43,7 @@ module ActiveModelSerializers
       # ref https://github.com/rails/rails/pull/21496
       ActionController::Renderers.add :jsonapi do |json, options|
         json = serialize_jsonapi(json, options).to_json(options) unless json.is_a?(String)
-        self.content_type ||= Mime[:jsonapi]
+        self.headers[ActionDispatch::Response::CONTENT_TYPE] = Mime[:jsonapi].to_s
         self.response_body = json
       end
     end

--- a/test/active_model_serializers/register_jsonapi_renderer_test_isolated.rb
+++ b/test/active_model_serializers/register_jsonapi_renderer_test_isolated.rb
@@ -140,6 +140,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       headers = { 'CONTENT_TYPE' => 'application/vnd.api+json' }
       post '/render_with_jsonapi_renderer', params: payload, headers: headers
       assert_equal expected.to_json, response.body
+      assert_equal "application/vnd.api+json", response.headers["Content-Type"]
     end
 
     def test_jsonapi_parser


### PR DESCRIPTION
#### Purpose
Fixes #2285

#### Changes
The renderer sets the response Content-Type headerstring instead of using the higher-level interface where the media type is passed as a Mime.

#### Caveats
Perhaps the `headers` interface is a bit too low-level?

#### Related GitHub issues
#2285 