### PR TITLE
Eagerload on application boot

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -24,8 +24,6 @@ module ActiveModel
       autoload :Attribute
       autoload :Association
       autoload :Reflection
-      autoload :SingularReflection
-      autoload :CollectionReflection
       autoload :BelongsToReflection
       autoload :HasOneReflection
       autoload :HasManyReflection

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -18,16 +18,18 @@ module ActiveModel
     # @see #serializable_hash for more details on these valid keys.
     SERIALIZABLE_HASH_VALID_KEYS = [:only, :except, :methods, :include, :root].freeze
     extend ActiveSupport::Autoload
-    autoload :Adapter
-    autoload :Null
-    autoload :Attribute
-    autoload :Association
-    autoload :Reflection
-    autoload :SingularReflection
-    autoload :CollectionReflection
-    autoload :BelongsToReflection
-    autoload :HasOneReflection
-    autoload :HasManyReflection
+    eager_autoload do
+      autoload :Adapter
+      autoload :Null
+      autoload :Attribute
+      autoload :Association
+      autoload :Reflection
+      autoload :SingularReflection
+      autoload :CollectionReflection
+      autoload :BelongsToReflection
+      autoload :HasOneReflection
+      autoload :HasManyReflection
+    end
     include ActiveSupport::Configurable
     include Caching
 

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -5,16 +5,19 @@ require 'active_support/core_ext/string/inflections'
 require 'active_support/json'
 module ActiveModelSerializers
   extend ActiveSupport::Autoload
-  autoload :Model
-  autoload :Callbacks
-  autoload :Deserialization
-  autoload :SerializableResource
-  autoload :Logging
-  autoload :Test
-  autoload :Adapter
-  autoload :JsonPointer
-  autoload :Deprecate
-  autoload :LookupChain
+  eager_autoload do
+    autoload :Model
+    autoload :Callbacks
+    autoload :SerializableResource
+    autoload :SerializationContext
+    autoload :Logging
+    autoload :Test
+    autoload :Adapter
+    autoload :JsonPointer
+    autoload :Deprecate
+    autoload :LookupChain
+    autoload :Deserialization
+  end
 
   class << self; attr_accessor :logger; end
   self.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
@@ -44,6 +47,11 @@ module ActiveModelSerializers
     yield
   ensure
     $VERBOSE = original_verbose
+  end
+
+  def self.eager_load!
+    super
+    ActiveModel::Serializer.eager_load!
   end
 
   require 'active_model/serializer/version'

--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -22,14 +22,16 @@ module ActiveModelSerializers
   module Adapter
     class JsonApi < Base
       extend ActiveSupport::Autoload
-      autoload :Jsonapi
-      autoload :ResourceIdentifier
-      autoload :Relationship
-      autoload :Link
-      autoload :PaginationLinks
-      autoload :Meta
-      autoload :Error
-      autoload :Deserialization
+      eager_autoload do
+        autoload :Jsonapi
+        autoload :ResourceIdentifier
+        autoload :Link
+        autoload :PaginationLinks
+        autoload :Meta
+        autoload :Error
+        autoload :Deserialization
+        autoload :Relationship
+      end
 
       def self.default_key_transform
         :dash

--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -5,6 +5,8 @@ require 'action_controller/serialization'
 
 module ActiveModelSerializers
   class Railtie < Rails::Railtie
+    config.eager_load_namespaces << ActiveModelSerializers
+
     config.to_prepare do
       ActiveModel::Serializer.serializers_cache.clear
     end


### PR DESCRIPTION
#### Purpose
Load all modules and classes during application boot. This is needed because rails 5 unhooks autoloading (rails/rails@a71350cae0082193ad8c66d65ab62e8bb0b7853b) after the application has booted.

#### Changes
Eagerload dependencies during application boot by using `eager_autoload`.

#### Related GitHub issues
#2255

#### Additional helpful information
Not sure if eagerloading `ActiveModelSerializers::Adapter::JsonApi` should be the default or the user has  to add explicitly `config.eager_load_namespaces << ActiveModelSerializers::Adapter::JsonApi` to reduce memory usage if another adapter is used. 


