### PR TITLE
Minitest 5.11 breaks; needs something like ::Minitest::Result.from

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
   # - { rvm: jruby-head,     jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
   exclude:
   - { rvm: 2.1.10,        env: RAILS_VERSION=master }
+  - { rvm: 2.2.8,        env: RAILS_VERSION=master }
+  - { rvm: 2.3.5,        env: RAILS_VERSION=master }
   - { rvm: 2.1.10,        env: RAILS_VERSION=5.0 }
   - { rvm: 2.1.10,        env: RAILS_VERSION=5.1 }
   - { rvm: 2.4.2,         env: RAILS_VERSION=4.1 }

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   # 'activesupport', rails_versions
   # 'i18n,
   # 'tzinfo'
-  # 'minitest'
+  spec.add_development_dependency 'minitest', ['~> 5.0', '< 5.11']
   # 'thread_safe'
 
   spec.add_runtime_dependency 'jsonapi-renderer', ['>= 0.1.1.beta1', '< 0.3']

--- a/test/action_controller/serialization_test.rb
+++ b/test/action_controller/serialization_test.rb
@@ -457,13 +457,19 @@ module ActionController
       end
 
       def test_render_event_is_emitted
-        subscriber = ::ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |name|
-          @name = name
+        subscriber = ::ActiveSupport::Notifications.subscribe('render.active_model_serializers') do |subscribed_event|
+          @subscribed_event = subscribed_event
         end
 
         get :render_using_implicit_serializer
 
-        assert_equal 'render.active_model_serializers', @name
+        subscribed_event_name =
+          if @subscribed_event.is_a?(String)
+            @subscribed_event
+          else
+            @subscribed_event.name # is a ActiveSupport::Notifications::Event
+          end
+        assert_equal 'render.active_model_serializers', subscribed_event_name
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end


### PR DESCRIPTION
per https://github.com/rails-api/active_model_serializers/pull/2289#issuecomment-428078153