### PR TITLE
Removes null links from pagination

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/pagination_links.rb
+++ b/lib/active_model_serializers/adapter/json_api/pagination_links.rb
@@ -26,7 +26,7 @@ module ActiveModelSerializers
             prev:  prev_page_url,
             next:  next_page_url,
             last:  last_page_url
-          }
+          }.compact
         end
 
         protected

--- a/test/action_controller/json_api/pagination_test.rb
+++ b/test/action_controller/json_api/pagination_test.rb
@@ -61,7 +61,6 @@ module ActionController
         def test_render_only_first_last_and_next_pagination_links
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
                              'first' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
-                             'prev' => nil,
                              'next' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2",
                              'last' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2" }
           get :render_pagination_using_will_paginate, params: { page: { number: 1, size: 2 } }
@@ -84,7 +83,6 @@ module ActionController
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1",
                              'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1",
-                             'next' => nil,
                              'last' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1" }
           get :render_pagination_using_kaminari, params: { page: { number: 3, size: 1 } }
           response = JSON.parse(@response.body)
@@ -94,7 +92,6 @@ module ActionController
         def test_render_only_first_last_and_next_pagination_links_with_additional_params
           expected_links = { 'self' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2&teste=additional",
                              'first' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2&teste=additional",
-                             'prev' => nil,
                              'next' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2&teste=additional",
                              'last' => "#{WILL_PAGINATE_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2&teste=additional" }
           get :render_pagination_using_will_paginate, params: { page: { number: 1, size: 2 }, teste: 'additional' }
@@ -106,7 +103,6 @@ module ActionController
           expected_links = { 'self' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1&teste=additional",
                              'first' => "#{KAMINARI_URI}?page%5Bnumber%5D=1&page%5Bsize%5D=1&teste=additional",
                              'prev' => "#{KAMINARI_URI}?page%5Bnumber%5D=2&page%5Bsize%5D=1&teste=additional",
-                             'next' => nil,
                              'last' => "#{KAMINARI_URI}?page%5Bnumber%5D=3&page%5Bsize%5D=1&teste=additional" }
           get :render_pagination_using_kaminari, params: { page: { number: 3, size: 1 }, teste: 'additional' }
           response = JSON.parse(@response.body)

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -58,8 +58,6 @@ module ActiveModelSerializers
           {
             self: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
             first: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
-            prev: nil,
-            next: nil,
             last: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2"
           }
         end
@@ -82,7 +80,6 @@ module ActiveModelSerializers
               self: "#{URI}?page%5Bnumber%5D=3&page%5Bsize%5D=2",
               first: "#{URI}?page%5Bnumber%5D=1&page%5Bsize%5D=2",
               prev: "#{URI}?page%5Bnumber%5D=2&page%5Bsize%5D=2",
-              next: nil,
               last: "#{URI}?page%5Bnumber%5D=3&page%5Bsize%5D=2"
             }
           }


### PR DESCRIPTION
#### Purpose

Become (more) compliant with JSON-API.

#### Changes

Remove null links from pagination.

#### Caveats

None.

#### Related GitHub issues

None.


#### Additional helpful information

I ran the pagination links generated by active_model_serializers against the [JSON-API spec](https://jsonapi.org/format/#document-links), and it turns out links must not be null. See also the [schema](https://github.com/json-api/json-api/blob/gh-pages/schema#L176). Only strings and objects are allowed.
