### PR TITLE
Remove unnecessary line break from exception message

### DIFF
--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -47,8 +47,7 @@ module ActiveModel
         # 4. key may be nil for empty collection and no serializer option
         key &&= key.pluralize
         # 5. fail if the key cannot be determined
-        key || fail(ArgumentError, 'Cannot infer root key from collection type. Please
-                 specify the root or each_serializer option, or render a JSON String')
+        key || fail(ArgumentError, 'Cannot infer root key from collection type. Please specify the root or each_serializer option, or render a JSON String')
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 


### PR DESCRIPTION
This removes the unnecessary line break from the exception message. Example:

```
Cannot infer root key from collection type. Please\n
specify the root or each_serializer option, or render a JSON String
```
