### PR TITLE
Updates to travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - "RAILS_VERSION=4.2"
     - "RAILS_VERSION=5.0"
     - "RAILS_VERSION=5.1"
+    - "RAILS_VERSION=5.2"
     - "RAILS_VERSION=master"
 
 rvm:
@@ -29,6 +30,10 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
+
+branches:
+  only:
+  - 0-10-stable
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
   - { rvm: 2.3.5,        env: RAILS_VERSION=master }
   - { rvm: 2.1.10,        env: RAILS_VERSION=5.0 }
   - { rvm: 2.1.10,        env: RAILS_VERSION=5.1 }
+  - { rvm: 2.1.10,        env: RAILS_VERSION=5.2 }
   - { rvm: 2.4.2,         env: RAILS_VERSION=4.1 }
   - { rvm: ruby-head,     env: RAILS_VERSION=4.1 }
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ rvm:
   - 2.2.8
   - 2.3.5
   - 2.4.2
+  - 2.5.3
   - ruby-head
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
   - { rvm: 2.1.10,        env: RAILS_VERSION=5.1 }
   - { rvm: 2.1.10,        env: RAILS_VERSION=5.2 }
   - { rvm: 2.4.2,         env: RAILS_VERSION=4.1 }
+  - { rvm: 2.5.3,         env: RAILS_VERSION=4.1 }
   - { rvm: ruby-head,     env: RAILS_VERSION=4.1 }
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
This adds Rails 5.2 and Ruby 2.5.3 in the list of supported versions.
Excludes the test suite to run with ruby < 2.2 versions for Rails 5.2.
It also specifies the branch Travis should deal with to be exclusively 0-10-stable.