### PR TITLE
Slim down bundled gem by excluding test files and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 Features:
 
 - [#2327](https://github.com/rails-api/active_model_serializers/pull/2327) Add support for Ruby 2.6 on Travis CI (@wasifhossain)
+- [#2304](https://github.com/rails-api/active_model_serializers/pull/2304) Slim down bundled gem by excluding test files and docs (@greysteil)
 
 Fixes:
 

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/rails-api/active_model_serializers'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   spec.require_paths = ['lib']
   spec.executables   = []
 


### PR DESCRIPTION
#### Purpose
Slim down the bundled gem from 436KB to 60KB

#### Changes
- Remove `test_files` from gemspec since it's deprecated (https://github.com/rubygems/guides/issues/90)
- Only include contents on `lib` in `files` in gemspec, since they're all that's required to build the gem

#### Additional helpful information
This is the approach taken by [rails](https://github.com/rails/rails/blob/master/activesupport/activesupport.gemspec).