### PR TITLE
Performance and memory usage fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Fixes:
 - [#2307](https://github.com/rails-api/active_model_serializers/pull/2307) Falsey attribute values should not be reevaluated.
 
 Misc:
+- [#2309](https://github.com/rails-api/active_model_serializers/pull/2309) Performance and memory usage fixes
 
 ### [v0.10.8 (2018-11-01)](https://github.com/rails-api/active_model_serializers/compare/v0.10.7...v0.10.8)
 

--- a/lib/active_model/serializer/lazy_association.rb
+++ b/lib/active_model/serializer/lazy_association.rb
@@ -9,7 +9,7 @@ module ActiveModel
       delegate :collection?, to: :reflection
 
       def reflection_options
-        @reflection_options ||= reflection.options.dup.reject { |k, _| !REFLECTION_OPTIONS.include?(k) }
+        @reflection_options ||= reflection.options.select { |k, _| REFLECTION_OPTIONS.include?(k) }
       end
 
       def object

--- a/lib/active_model_serializers/adapter.rb
+++ b/lib/active_model_serializers/adapter.rb
@@ -37,7 +37,7 @@ module ActiveModelSerializers
 
       # @return [Array<Symbol>] list of adapter names
       def adapters
-        adapter_map.keys.sort
+        adapter_map.keys.sort!
       end
 
       # Adds an adapter 'klass' with 'name' to the 'adapter_map'

--- a/lib/active_model_serializers/serializable_resource.rb
+++ b/lib/active_model_serializers/serializable_resource.rb
@@ -16,8 +16,8 @@ module ActiveModelSerializers
     # @return the serializable_resource, ready for #as_json/#to_json/#serializable_hash.
     def initialize(resource, options = {})
       @resource = resource
-      @adapter_opts, @serializer_opts =
-        options.partition { |k, _| ADAPTER_OPTION_KEYS.include? k }.map { |h| Hash[h] }
+      @adapter_opts = options.select { |k, _| ADAPTER_OPTION_KEYS.include? k }
+      @serializer_opts = options.reject { |k, _| ADAPTER_OPTION_KEYS.include? k }
     end
 
     def serialization_scope=(scope)


### PR DESCRIPTION
#### Purpose
Performance and memory usage fixes.

#### Changes
1. `{}.select {}` is faster than `{}.dup.reject` because it doesn't duplicate nor create another hash.
2. `{}.keys` is always a new array so we can use `sort!` and save some memory.
3. 2x `{}.select {}` with different blocks are faster than one `{}.partition { }.map { |h| Hash[h] }`

```ruby
require 'benchmark/ips'
require 'benchmark/memory'
require 'set'

hsh = { include: 1, fields: 2, meta: 3, links: 4, e: 5 }.freeze
ADAPTER_OPTION_KEYS = Set.new([:include, :fields, :adapter, :meta, :meta_key, :links, :serialization_context, :key_transform]).freeze

[:ips, :memory].each do |type|
  Benchmark.public_send(type) do |x|
    x.report('map') { adapter_options, serializer_options = hsh.partition { |k, _| ADAPTER_OPTION_KEYS.include? k }.map { |h| Hash[h] } }
    x.report('select') do
      adapter_options = hsh.select { |k, _| ADAPTER_OPTION_KEYS.include? k }
      serializer_options = hsh.reject { |k, _| ADAPTER_OPTION_KEYS.include? k }
    end

    x.compare!
  end

  [].sort
end


Warming up --------------------------------------
                 map    34.293k i/100ms
              select    47.284k i/100ms
Calculating -------------------------------------
                 map    415.582k (± 2.4%) i/s -      2.092M in   5.036739s
              select    529.549k (± 5.0%) i/s -      2.695M in   5.107481s

Comparison:
              select:   529548.5 i/s
                 map:   415581.6 i/s - 1.27x  slower

Calculating -------------------------------------
                 map   904.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
              select   384.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
              select:        384 allocated
                 map:        904 allocated - 2.35x more
```
