### PR TITLE
Fix deprecation warnings on Rails 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Breaking changes:
 Features:
 
 Fixes:
+- [#2319](https://github.com/rails-api/active_model_serializers/pull/2319) Fixes #2316. (@kylekeesling)
+  - Fix Rails 6.0 deprication warnings
+  - update test fixture schema to use `timestamps` instead of `timestamp`
 
 Misc:
 

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -23,7 +23,15 @@ module ActionController
     end
 
     def namespace_for_serializer
-      @namespace_for_serializer ||= self.class.parent unless self.class.parent == Object
+      @namespace_for_serializer ||= namespace_for_class(self.class) unless namespace_for_class(self.class) == Object
+    end
+
+    def namespace_for_class(klass)
+      if Module.method_defined?(:module_parent)
+        klass.module_parent
+      else
+        klass.parent
+      end
     end
 
     def serialization_scope

--- a/test/action_controller/namespace_lookup_test.rb
+++ b/test/action_controller/namespace_lookup_test.rb
@@ -125,7 +125,12 @@ module ActionController
       tests Api::V3::LookupTestController
 
       setup do
-        @test_namespace = self.class.parent
+        @test_namespace =
+          if Module.method_defined?(:module_parent)
+            self.class.module_parent
+          else
+            self.class.parent
+          end
       end
 
       test 'uses request headers to determine the namespace' do

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -19,28 +19,28 @@ ActiveRecord::Schema.define do
     t.text :contents
     t.references :author
     t.references :post
-    t.timestamp null: false
+    t.timestamps null: false
   end
   create_table :employees, force: true do |t|
     t.string :name
     t.string :email
-    t.timestamp null: false
+    t.timestamps null: false
   end
   create_table :object_tags, force: true do |t|
     t.string :poly_tag_id
     t.string :taggable_type
     t.string :taggable_id
-    t.timestamp null: false
+    t.timestamps null: false
   end
   create_table :poly_tags, force: true do |t|
     t.string :phrase
-    t.timestamp null: false
+    t.timestamps null: false
   end
   create_table :pictures, force: true do |t|
     t.string :title
     t.string :imageable_type
     t.string :imageable_id
-    t.timestamp null: false
+    t.timestamps null: false
   end
 end
 


### PR DESCRIPTION
#### Purpose
Fix depreciation warnings in Rails 6.0.0.beta2

```
DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1.
~/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/active_model_serializers-0.10.9/lib/action_controller/serialization.rb:26:in `namespace_for_serializer'
```
#### Changes
changes `parent` calls to `module_parent`

#### Related GitHub issues
#2316