### PR TITLE
+ Added association field support.

### DIFF
--- a/lib/active_model/serializer/version.rb
+++ b/lib/active_model/serializer/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveModel
   class Serializer
-    VERSION = '0.10.9'.freeze
+    VERSION = '0.10.90'.freeze
   end
 end


### PR DESCRIPTION
#### Purpose
Allow to filter attributes for nested associations

ex.

```
class AssetSerializer < ActiveModel::Serializer
  attributes :id, :name
  has_many :blobs, serializer: BlobSerializer
end

class BlobSerializer < ActiveModel::Serializer
  attributes :id
end

# serialize assets
render json: @assets, serializer: AssetsSerializer, adapter: :json, fields: [:name, { assets: ['id'] }], root: assets

serialize output
{
"assets": [
{"name": "super troopers", "blobs": [{id: 1}]}
]
}

```

#### Changes


#### Caveats


#### Related GitHub issues


#### Additional helpful information


