### PR TITLE
rename @attributes to @ams_attributes in ActiveModelSerializer::Model

### DIFF
--- a/lib/active_model_serializers/model.rb
+++ b/lib/active_model_serializers/model.rb
@@ -83,12 +83,16 @@ module ActiveModelSerializers
     #
     #   model.attributes[:foo] = :bar
     # @return [Hash]
-    attr_reader :attributes
+    # reader for @ams_attributes
+    def attributes
+      @ams_attributes
+    end
 
     # @param attributes [Hash]
+    # Head underscore in order not to override @attributes in ActiveModel::Attributes
     def initialize(attributes = {})
       attributes ||= {} # protect against nil
-      @attributes = attributes.symbolize_keys.with_indifferent_access
+      @ams_attributes = attributes.symbolize_keys.with_indifferent_access
       @errors = ActiveModel::Errors.new(self)
       super
     end

--- a/test/benchmark/fixtures.rb
+++ b/test/benchmark/fixtures.rb
@@ -172,10 +172,12 @@ else
     include ActiveModel::Model
     include ActiveModel::Serializers::JSON
 
-    attr_reader :attributes
+    def attributes
+      @ams_attributes
+    end
 
     def initialize(attributes = {})
-      @attributes = attributes
+      @ams_attributes = attributes
       super
     end
 


### PR DESCRIPTION
#### Purpose
Hey team,

We tried to use AMS(0-10-stable) and ActiveModel::Attributes(in Rails 5.2.3) together, but they were not compatible because both of them initialize objects with `@attributes` and AMS's `@attributes` overrides that of ActiveModel::Atrributes.

AMS code
https://github.com/rails-api/active_model_serializers/blob/0-10-stable/lib/active_model_serializers/model.rb#L89
ActiveModel::Attributes code
https://github.com/rails/rails/blob/master/activemodel/lib/active_model/attributes.rb#L63

A code to reproduce this problem is below.
```
class FooBar < ActiveModelSerializers::Model
  include ActiveModel::Model
  include ActiveModel::Attributes
  attribute :foo, :string
end
```
Then, execute the following code in Rails console,
```
FooBar.new(foo: 'bar')
```
and the following message appears.
```
NoMethodError: undefined method `write_from_user' for {"foo"=>"bar"}:ActiveSupport::HashWithIndifferentAccess
```

#### Changes
As a solution, I changed `@attributes` to `@ams_attributes` in ActiveModelSerializer::Model and edit reader for `@attributes` as below,
```
def attributes
  @ams_attributes
end
```
Although I believe that we should produce a better design which does not conflict with ActiveModel::Attributes, I would appreciate it if you merge this PR in order to use AMS and Rails5.2 together for the time being