### PR TITLE
Add support for Ruby 2.6, configure sqlite3 to use ~> 1.4 for rails 6+, patch for Rails 4.2 against Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: ruby
 sudo: false
 
+ruby_supported_versions:
+  - &ruby_2_1 2.1.10
+  - &ruby_2_2 2.2.10
+  - &ruby_2_3 2.3.8
+  - &ruby_2_4 2.4.6
+  - &ruby_2_5 2.5.5
+  - &ruby_2_6 2.6.3
+  - &ruby_head ruby-head
+
 cache:
   directories:
     - vendor/bundle
@@ -25,38 +34,39 @@ env:
     - "RAILS_VERSION=master"
 
 rvm:
-  - 2.1.10
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
-  - 2.5.3
-  - ruby-head
+  - *ruby_2_1
+  - *ruby_2_2
+  - *ruby_2_3
+  - *ruby_2_4
+  - *ruby_2_5
+  - *ruby_2_6
+  - *ruby_head
 
 branches:
-  only:
-  - 0-10-stable
+  only: 0-10-stable
 
 matrix:
   include:
-  - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=4.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-  - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-  - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-  # See JRuby currently failing on Rails 5+ https://github.com/jruby/activerecord-jdbc-adapter/issues/708
-  # - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-  # - { rvm: jruby-head,     jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=4.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    # See JRuby currently failing on Rails 5+ https://github.com/jruby/activerecord-jdbc-adapter/issues/708
+    # - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    # - { rvm: jruby-head,     jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
   exclude:
-  - { rvm: 2.1.10,        env: RAILS_VERSION=master }
-  - { rvm: 2.2.8,        env: RAILS_VERSION=master }
-  - { rvm: 2.3.5,        env: RAILS_VERSION=master }
-  - { rvm: 2.4.2,        env: RAILS_VERSION=master }
-  - { rvm: 2.1.10,        env: RAILS_VERSION=5.0 }
-  - { rvm: 2.1.10,        env: RAILS_VERSION=5.1 }
-  - { rvm: 2.1.10,        env: RAILS_VERSION=5.2 }
-  - { rvm: 2.4.2,         env: RAILS_VERSION=4.1 }
-  - { rvm: 2.5.3,         env: RAILS_VERSION=4.1 }
-  - { rvm: ruby-head,     env: RAILS_VERSION=4.1 }
+    - { rvm: *ruby_2_4,  env: RAILS_VERSION=master }
+    - { rvm: *ruby_2_3,  env: RAILS_VERSION=master }
+    - { rvm: *ruby_2_2,  env: RAILS_VERSION=master }
+    - { rvm: *ruby_2_1,  env: RAILS_VERSION=master }
+    - { rvm: *ruby_2_1,  env: RAILS_VERSION=5.2 }
+    - { rvm: *ruby_2_1,  env: RAILS_VERSION=5.1 }
+    - { rvm: *ruby_2_1,  env: RAILS_VERSION=5.0 }
+    - { rvm: *ruby_head, env: RAILS_VERSION=4.1 }
+    - { rvm: *ruby_2_6,  env: RAILS_VERSION=4.1 }
+    - { rvm: *ruby_2_5,  env: RAILS_VERSION=4.1 }
+    - { rvm: *ruby_2_4,  env: RAILS_VERSION=4.1 }
   allow_failures:
-    - rvm: ruby-head
+    - rvm: *ruby_head
     - rvm: jruby-head
     # See JRuby currently failing on Rails 5+ https://github.com/jruby/activerecord-jdbc-adapter/issues/708
     - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :bench do
 end
 
 group :test do
-  platforms *(@windows_platforms + [:ruby]) do
+  platforms(*(@windows_platforms + [:ruby])) do
     if version == 'master' || version >= '6'
       gem 'sqlite3', '~> 1.4'
     else
@@ -71,7 +71,7 @@ group :test do
   gem 'm', '~> 1.5'
   gem 'pry', '>= 0.10'
   gem 'byebug', '~> 8.2' if RUBY_VERSION < '2.2'
-  gem 'pry-byebug', platform: :ruby
+  gem 'pry-byebug', platforms: :ruby
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,13 @@ group :bench do
 end
 
 group :test do
-  gem 'sqlite3', '~> 1.3.13', platform: (@windows_platforms + [:ruby])
+  platforms *(@windows_platforms + [:ruby]) do
+    if version == 'master' || version >= '6'
+      gem 'sqlite3', '~> 1.4'
+    else
+      gem 'sqlite3', '~> 1.3.13'
+    end
+  end
   platforms :jruby do
     if version == 'master' || version >= '5'
       gem 'activerecord-jdbcsqlite3-adapter', '~> 50'

--- a/test/benchmark/config.ru
+++ b/test/benchmark/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(['..', 'app'].join(File::SEPARATOR), __FILE__)
 
 run Rails.application

--- a/test/support/ruby_2_6_rails_4_2_patch.rb
+++ b/test/support/ruby_2_6_rails_4_2_patch.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+if RUBY_VERSION >= '2.6.0'
+  if Rails::VERSION::MAJOR < 5
+    class ActionController::TestResponse < ActionDispatch::TestResponse
+      def recycle!
+        # hack to avoid MonitorMixin double-initialize error:
+        @mon_mutex_owner_object_id = nil
+        @mon_mutex = nil
+        initialize
+      end
+    end
+  else
+    puts "Monkeypatch for ActionController::TestResponse no longer needed"
+  end
+end

--- a/test/support/ruby_2_6_rails_4_2_patch.rb
+++ b/test/support/ruby_2_6_rails_4_2_patch.rb
@@ -2,15 +2,17 @@
 
 if RUBY_VERSION >= '2.6.0'
   if Rails::VERSION::MAJOR < 5
-    class ActionController::TestResponse < ActionDispatch::TestResponse
-      def recycle!
-        # hack to avoid MonitorMixin double-initialize error:
-        @mon_mutex_owner_object_id = nil
-        @mon_mutex = nil
-        initialize
+    module ActionController
+      class TestResponse < ActionDispatch::TestResponse
+        def recycle!
+          # HACK: to avoid MonitorMixin double-initialize error:
+          @mon_mutex_owner_object_id = nil
+          @mon_mutex = nil
+          initialize
+        end
       end
     end
   else
-    puts "Monkeypatch for ActionController::TestResponse no longer needed"
+    puts 'Monkeypatch for ActionController::TestResponse no longer needed'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,8 @@ end
 
 require 'support/rails_app'
 
+require 'support/ruby_2_6_rails_4_2_patch'
+
 # require "rails/test_help"
 
 require 'support/serialization_testing'


### PR DESCRIPTION
#### Purpose
1) Add support for Ruby 2.6
2) Make Rails 4.2 tests pass against Ruby 2.6
3) Make Rails `master` tests pass against Ruby 2.5+
4) Bump Ruby versions for currently supported 2.x series

#### Changes
1) Add ruby-2.6 to `.travis.yml`
2) Monkey patch from https://github.com/rails/rails/issues/34790
3) Configure `sqlite3` gem to use `~> 1.4` for Rails 6+

#### Caveats


#### Related GitHub issues


#### Additional helpful information
- sqlite3 version update for Rails 6+: https://github.com/rails/rails/pull/35844
- https://github.com/doorkeeper-gem/doorkeeper/commit/e7903fc4b0c430d4dee6e2d8f4b50555276bcf66
