### PR TITLE
Add support for Rails 6.0.0.rc1 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,21 @@ ruby_supported_versions:
   - &ruby_2_6 2.6.3
   - &ruby_head ruby-head
 
+rails_supported_versions:
+  - &rails_4_1 RAILS_VERSION=4.1
+  - &rails_4_2 RAILS_VERSION=4.2
+  - &rails_5_0 RAILS_VERSION=5.0
+  - &rails_5_1 RAILS_VERSION=5.1
+  - &rails_5_2 RAILS_VERSION=5.2
+  - &rails_6_0_0_rc1 RAILS_VERSION=6.0.0.rc1
+  - &rails_master RAILS_VERSION=master
+
 cache:
   directories:
     - vendor/bundle
 
 before_install:
-  - "travis_retry gem update --system 2.7.8"
+  - "travis_retry gem update --system 3.0.3"
   - "travis_retry gem install bundler -v '1.17.3'"
 install: BUNDLER_VERSION=1.17.3 bundle install --path=vendor/bundle --retry=3 --jobs=3
 
@@ -26,12 +35,13 @@ after_success:
 
 env:
   matrix:
-    - "RAILS_VERSION=4.1"
-    - "RAILS_VERSION=4.2"
-    - "RAILS_VERSION=5.0"
-    - "RAILS_VERSION=5.1"
-    - "RAILS_VERSION=5.2"
-    - "RAILS_VERSION=master"
+    - *rails_4_1
+    - *rails_4_2
+    - *rails_5_0
+    - *rails_5_1
+    - *rails_5_2
+    - *rails_6_0_0_rc1
+    - *rails_master
 
 rvm:
   - *ruby_2_1
@@ -54,19 +64,40 @@ matrix:
     # - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
     # - { rvm: jruby-head,     jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
   exclude:
-    - { rvm: *ruby_2_4,  env: RAILS_VERSION=master }
-    - { rvm: *ruby_2_3,  env: RAILS_VERSION=master }
-    - { rvm: *ruby_2_2,  env: RAILS_VERSION=master }
-    - { rvm: *ruby_2_1,  env: RAILS_VERSION=master }
-    - { rvm: *ruby_2_1,  env: RAILS_VERSION=5.2 }
-    - { rvm: *ruby_2_1,  env: RAILS_VERSION=5.1 }
-    - { rvm: *ruby_2_1,  env: RAILS_VERSION=5.0 }
-    - { rvm: *ruby_head, env: RAILS_VERSION=4.1 }
-    - { rvm: *ruby_2_6,  env: RAILS_VERSION=4.1 }
-    - { rvm: *ruby_2_5,  env: RAILS_VERSION=4.1 }
-    - { rvm: *ruby_2_4,  env: RAILS_VERSION=4.1 }
+    - { rvm: *ruby_2_1,  env: *rails_5_0 }
+    - { rvm: *ruby_2_1,  env: *rails_5_1 }
+    - { rvm: *ruby_2_1,  env: *rails_5_2 }
+
+    - { rvm: *ruby_2_1,  env: *rails_6_0_0_rc1 }
+    - { rvm: *ruby_2_2,  env: *rails_6_0_0_rc1 }
+    - { rvm: *ruby_2_3,  env: *rails_6_0_0_rc1 }
+    - { rvm: *ruby_2_4,  env: *rails_6_0_0_rc1 }
+
+    - { rvm: *ruby_2_1,  env: *rails_master }
+    - { rvm: *ruby_2_2,  env: *rails_master }
+    - { rvm: *ruby_2_3,  env: *rails_master }
+    - { rvm: *ruby_2_4,  env: *rails_master }
+
   allow_failures:
+    - { rvm: *ruby_2_4,  env: *rails_4_1 }
+    - { rvm: *ruby_2_5,  env: *rails_4_1 }
+    - { rvm: *ruby_2_6,  env: *rails_4_1 }
+
+    # allow RAILS_VERSION=master to fail against ruby 2.5+ until this gem supports RAILS_VERSION
+    # https://github.com/rails/rails/blob/master/RAILS_VERSION
+    # https://github.com/rails-api/active_model_serializers/blob/0-10-stable/active_model_serializers.gemspec#L24
+    - { rvm: *ruby_2_5,  env: *rails_master }
+    - { rvm: *ruby_2_6,  env: *rails_master }
+
     - rvm: *ruby_head
+    # - { rvm: *ruby_head, env: *rails_4_1 }
+    # - { rvm: *ruby_head, env: *rails_4_2 }
+    # - { rvm: *ruby_head, env: *rails_5_0 }
+    # - { rvm: *ruby_head, env: *rails_5_1 }
+    # - { rvm: *ruby_head, env: *rails_5_2 }
+    # - { rvm: *ruby_head, env: *rails_6_0_0_rc1 }
+    # - { rvm: *ruby_head, env: *rails_master }
+
     - rvm: jruby-head
     # See JRuby currently failing on Rails 5+ https://github.com/jruby/activerecord-jdbc-adapter/issues/708
     - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - vendor/bundle
 
 before_install:
-  - "travis_retry gem update --system 3.0.3"
+  - "travis_retry gem update --system 2.7.9"
   - "travis_retry gem install bundler -v '1.17.3'"
 install: BUNDLER_VERSION=1.17.3 bundle install --path=vendor/bundle --retry=3 --jobs=3
 


### PR DESCRIPTION
Configure **Travis** to
- **include** tests for `Rails 6.0.0.rc1` using `Ruby 2.5+`
- **allow failures** for 
   - `Rails 4.1` using `Ruby 2.4+`
   - `Rails master` using `Ruby 2.5+` (until we support Rails 6 in the gemspec that matches Rails master version)
   - `ruby-head` (currently 2.7) against `Rails 4.2+`
- **exclude** tests for
   - `Ruby 2.1` against `Rails 5+` ([Rails 5.0+ supports Ruby 2.2.2+ only](https://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/))
   - `Rails 6+` for `Ruby < 2.5` ([Rails 6+ requires Ruby 2.5+](https://weblog.rubyonrails.org/2018/12/20/timeline-for-the-release-of-Rails-6-0/))
- Install `rubygems 2.7.9` (keep rubygems version < 3.0 until we keep supporting ruby < 2.3)