### PR TITLE
Fixes error on Rails 6 with Kaminari 1.1.1 paginated collection

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -384,7 +384,11 @@ module ActiveModel
     def json_key
       root || _type ||
         begin
-          object.class.model_name.to_s.underscore
+          if object.respond_to?(:model_name)
+            object.model_name
+          else
+            object.class.model_name
+          end.to_s.underscore
         rescue ArgumentError
           'anonymous_object'
         end


### PR DESCRIPTION
This commit fixes NoMethodError (undefined method `model_name' for ::ActiveRecord_AssociationRelation:Class)

Checks for `model_name` in the object first and fallback to `class.model_name` if that's not found.