### PR TITLE
Allow AMS to run on Rails < 6.1

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  rails_versions = ['>= 4.1', '< 6']
+  rails_versions = ['>= 4.1', '< 6.1']
   spec.add_runtime_dependency 'activemodel', rails_versions
   # 'activesupport', rails_versions
   # 'builder'


### PR DESCRIPTION
#### Purpose
Given that Rails 6.0.0.rc1 is out, the stable release of Rails 6.0.0 is coming soon, and that Rails' `master` version [already defining 6.1.0.alpha](https://github.com/rails/rails/blob/master/version.rb), I would like to propose us to remove the upper bound of Rails requirement to be open-ended so AMS can be installed and tested against edge Rails.

#### Changes
This commit <del>removes</del> increase the upper bound of `rails_versions` to `< 6.1.0`, which is being used when defining runtime dependencies.

#### Caveats
Note that this means that there's a chance that AMS will break when using with future unsupported version of Rails. However, by leaving the dependency version to be unbounded like this, I believe this will encourage other contributors to be able to catch the bug early and contribute back to AMS in time before the future version of Rails.

I also believe that there are a few companies that do test against edge Rails, and by doing this we'll allow them to have AMS in their project without having to maintain their separate fork which removes the upper limit of Rails version.

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/pull/2328 (added 6.0.0.rc1 to Travis build matrix)

#### Additional helpful information
None

Thank you very much.