### PR TITLE
Fix regression introduced in #2223 when a serializer defines an attribute method name root 

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -311,6 +311,7 @@ module ActiveModel
     # END SERIALIZER MACROS
 
     attr_accessor :object, :root, :scope
+    alias _root root # @api private
 
     # `scope_name` is set as :current_user by default in the controller.
     # If the instance does not have a method named `scope_name`, it
@@ -382,7 +383,7 @@ module ActiveModel
 
     # Used by adapter as resource root.
     def json_key
-      root || _type ||
+      _root || _type ||
         begin
           object.class.model_name.to_s.underscore
         rescue ArgumentError

--- a/test/serializers/attribute_test.rb
+++ b/test/serializers/attribute_test.rb
@@ -98,6 +98,23 @@ module ActiveModel
         assert_equal(expected, hash)
       end
 
+      class EmptyPost < ::Model; end
+      class EmptyPostSerializer < ActiveModel::Serializer
+        attributes :root
+
+        def root
+          true
+        end
+      end
+
+      def test_serializer_with_attribute_name_root
+        post = EmptyPost.new
+        hash = serializable(post).serializable_hash
+        expected = { root: true }
+
+        assert_equal(expected, hash)
+      end
+
       # rubocop:disable Metrics/AbcSize
       def test_conditional_associations
         model = Class.new(::Model) do


### PR DESCRIPTION
#### Purpose
After I upgraded AMS to HEAD of `0-10-stable`, our test suite start failing on this cryptic error:

```
     Failure/Error: render json: comment.reload, serializer: CommentWithMetadataSerializer
     
     NoMethodError:
       undefined method `singularize' for true:TrueClass
     # [GEM_HOME]/active_model_serializers-339f99fccc82/lib/active_model/serializer/fieldset.rb:15:in `fields_for'
     # [GEM_HOME]/active_model_serializers-339f99fccc82/lib/active_model/serializer.rb:370:in `serializable_hash'
     # [GEM_HOME]/active_model_serializers-339f99fccc82/lib/active_model_serializers/adapter/attributes.rb:14:in `serializable_hash'
     # [GEM_HOME]/active_model_serializers-339f99fccc82/lib/active_model_serializers/adapter/json.rb:8:in `serializable_hash'
     # [GEM_HOME]/active_model_serializers-339f99fccc82/lib/active_model_serializers/adapter/base.rb:61:in `as_json'
```

After some digging through, it turned out that our `CommentWithMetadataSerializer` code is something like this:

```ruby
class CommentWithMetadataSerializer < ActiveModel::Serializer
  attributes :root

  # Returns true/false to indicate if this comment is a root of a thread
  def root
    object.root?
  end
end
```

After digging through the source code and changes in #2223, I started to notice that serializer now calls `json_key` method ...

https://github.com/rails-api/active_model_serializers/blob/339f99fccc8221ef3338e6e9681fdda2771ba95f/lib/active_model/serializer.rb#L368-L370

... which then calls `root` and short-circuit, returning `true`

https://github.com/rails-api/active_model_serializers/blob/339f99fccc8221ef3338e6e9681fdda2771ba95f/lib/active_model/serializer.rb#L384-L391

Since it was working before in `0.10.9`, I think this is an unintended name-collision regression.

#### Changes
This PR introduces an alias method name `_top` in the `serializer.rb`, and change `json_key` method to use that method instead. This will allow user to have a method name `root` in their serializer, while still be able to override serializer root attribute.

---

I'm not really sure if I put the test for this functionality at the right place, so any feedback is welcomed! Thank you very much.