### PR TITLE
Configure `ActionDispatch::Response#content_type` behavior on Rails 6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ ruby_supported_versions:
 
 jruby_supported_versions:
   - &jruby_9_1 jruby-9.1.17.0
-  - &jruby_9_2 jruby-9.2.7.0
+  - &jruby_9_2 jruby-9.2.8.0
   - &jruby_head jruby-head
 
 jdk_supported_versions:

--- a/test/support/rails_app.rb
+++ b/test/support/rails_app.rb
@@ -9,6 +9,10 @@ module ActiveModelSerializers
       config.action_controller.perform_caching = true
       config.action_controller.cache_store = :memory_store
 
+      if Rails::VERSION::MAJOR >= 6
+        config.action_dispatch.return_only_media_type_on_content_type = true
+      end
+
       config.filter_parameters += [:password]
     end
 


### PR DESCRIPTION
#### Purpose

This PR will affect all `#content_type` calls in the following files:

https://github.com/rails-api/active_model_serializers/blob/55a6b23cd84395029aa92605f8aae73f37f57c4a/test/action_controller/serialization_test.rb#L158

https://github.com/rails-api/active_model_serializers/blob/55a6b23cd84395029aa92605f8aae73f37f57c4a/test/action_controller/explicit_serializer_test.rb#L74

#### Background

Rails 6 changes the default behavior of `ActionDispatch::Response#content_type`, which now returns the **Content-Type header as it is**.

To retain old behavior, i.e. retrieve the mime type only, we can either set the following configuration in application settings:
```rb
config.action_dispatch.return_only_media_type_on_content_type = true
```

or set it inline as:
```rb
ActionDispatch::Response.return_only_media_type_on_content_type = true
```

or call `#media_type` instead of `#content_type`.

#### Additional helpful information

Rails 6.0 ACTIONPACK release notes: 
https://github.com/rails/rails/blob/6-0-stable/actionpack/CHANGELOG.md

https://github.com/rails/rails/pull/36490
https://github.com/rails/rails/pull/36946
