### PR TITLE
prevent ActiveModel::Serializer::Fieldset.fields_for crashing in case…

### DIFF
--- a/lib/active_model/serializer/fieldset.rb
+++ b/lib/active_model/serializer/fieldset.rb
@@ -12,7 +12,7 @@ module ActiveModel
       end
 
       def fields_for(type)
-        fields[type.singularize.to_sym] || fields[type.pluralize.to_sym]
+        fields[type.to_s.singularize.to_sym] || fields[type.to_s.pluralize.to_sym]
       end
 
       protected


### PR DESCRIPTION
#### Purpose
Current AMS implementation allows things like this:

`render json: users, each_serializer: UserSerializer, root: :users`

but the new fieldset class don't accept anything else than string for `#fields_for`

#### Changes

Allow `#fields_for` to receive a symbol and parse it to string before any manipulation

value is coming from `#json_key` method

#### Caveats


#### Related GitHub issues


#### Additional helpful information


