### PR TITLE
Add support for Rails 6.0.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rails_supported_versions:
   - &rails_5_0 RAILS_VERSION=5.0
   - &rails_5_1 RAILS_VERSION=5.1
   - &rails_5_2 RAILS_VERSION=5.2
-  - &rails_6_0_0_rc1 RAILS_VERSION=6.0.0.rc1
+  - &rails_6_0 RAILS_VERSION=6.0.0.rc2
   - &rails_master RAILS_VERSION=master
 
 cache:
@@ -40,7 +40,7 @@ env:
     - *rails_5_0
     - *rails_5_1
     - *rails_5_2
-    - *rails_6_0_0_rc1
+    - *rails_6_0
     - *rails_master
 
 rvm:
@@ -68,10 +68,10 @@ matrix:
     - { rvm: *ruby_2_1,  env: *rails_5_1 }
     - { rvm: *ruby_2_1,  env: *rails_5_2 }
 
-    - { rvm: *ruby_2_1,  env: *rails_6_0_0_rc1 }
-    - { rvm: *ruby_2_2,  env: *rails_6_0_0_rc1 }
-    - { rvm: *ruby_2_3,  env: *rails_6_0_0_rc1 }
-    - { rvm: *ruby_2_4,  env: *rails_6_0_0_rc1 }
+    - { rvm: *ruby_2_1,  env: *rails_6_0 }
+    - { rvm: *ruby_2_2,  env: *rails_6_0 }
+    - { rvm: *ruby_2_3,  env: *rails_6_0 }
+    - { rvm: *ruby_2_4,  env: *rails_6_0 }
 
     - { rvm: *ruby_2_1,  env: *rails_master }
     - { rvm: *ruby_2_2,  env: *rails_master }
@@ -95,7 +95,7 @@ matrix:
     # - { rvm: *ruby_head, env: *rails_5_0 }
     # - { rvm: *ruby_head, env: *rails_5_1 }
     # - { rvm: *ruby_head, env: *rails_5_2 }
-    # - { rvm: *ruby_head, env: *rails_6_0_0_rc1 }
+    # - { rvm: *ruby_head, env: *rails_6_0 }
     # - { rvm: *ruby_head, env: *rails_master }
 
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,11 @@ matrix:
     - { rvm: *jruby_head, jdk: *jdk_8, env: *rails_master_jruby }
 
   exclude:
+    - { rvm: *ruby_2_4,  env: *rails_4_1 }
+    - { rvm: *ruby_2_5,  env: *rails_4_1 }
+    - { rvm: *ruby_2_6,  env: *rails_4_1 }
+    - { rvm: *ruby_head, env: *rails_4_1 }
+
     - { rvm: *ruby_2_1,  env: *rails_5_0 }
     - { rvm: *ruby_2_1,  env: *rails_5_1 }
     - { rvm: *ruby_2_1,  env: *rails_5_2 }
@@ -108,10 +113,6 @@ matrix:
     - { rvm: *ruby_2_4,  env: *rails_master }
 
   allow_failures:
-    - { rvm: *ruby_2_4,  env: *rails_4_1 }
-    - { rvm: *ruby_2_5,  env: *rails_4_1 }
-    - { rvm: *ruby_2_6,  env: *rails_4_1 }
-
     - { rvm: *ruby_2_5,  env: *rails_master }
     - { rvm: *ruby_2_6,  env: *rails_master }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ rails_supported_versions:
   - &rails_5_1_jruby RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
   - &rails_5_2 RAILS_VERSION=5.2
   - &rails_5_2_jruby RAILS_VERSION=5.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
-  - &rails_6_0 RAILS_VERSION=6.0.0.rc2
-  - &rails_6_0_jruby RAILS_VERSION=6.0.0.rc2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
+  - &rails_6_0 RAILS_VERSION=6.0
+  - &rails_6_0_jruby RAILS_VERSION=6.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
   - &rails_master RAILS_VERSION=master
   - &rails_master_jruby RAILS_VERSION=master JRUBY_OPTS='--dev -J-Xmx1024M --debug'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,19 @@ jdk_supported_versions:
 
 rails_supported_versions:
   - &rails_4_1 RAILS_VERSION=4.1
+  - &rails_4_1_jruby RAILS_VERSION=4.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
   - &rails_4_2 RAILS_VERSION=4.2
+  - &rails_4_2_jruby RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
   - &rails_5_0 RAILS_VERSION=5.0
+  - &rails_5_0_jruby RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
   - &rails_5_1 RAILS_VERSION=5.1
+  - &rails_5_1_jruby RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
   - &rails_5_2 RAILS_VERSION=5.2
+  - &rails_5_2_jruby RAILS_VERSION=5.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
   - &rails_6_0 RAILS_VERSION=6.0.0.rc2
+  - &rails_6_0_jruby RAILS_VERSION=6.0.0.rc2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'
   - &rails_master RAILS_VERSION=master
+  - &rails_master_jruby RAILS_VERSION=master JRUBY_OPTS='--dev -J-Xmx1024M --debug'
 
 cache:
   directories:
@@ -65,25 +72,26 @@ branches:
 
 matrix:
   include:
-    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=4.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=5.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: *rails_4_1_jruby }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: *rails_4_2_jruby }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: *rails_5_0_jruby }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: *rails_5_1_jruby }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: *rails_5_2_jruby }
 
-    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=5.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=6.0.0.rc2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=master JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: *rails_4_2_jruby }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: *rails_5_0_jruby }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: *rails_5_1_jruby }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: *rails_5_2_jruby }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: *rails_6_0_jruby }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: *rails_master_jruby }
 
-    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=5.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=6.0.0.rc2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=master JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: *rails_4_2_jruby }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: *rails_5_0_jruby }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: *rails_5_1_jruby }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: *rails_5_2_jruby }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: *rails_6_0_jruby }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: *rails_master_jruby }
+
   exclude:
     - { rvm: *ruby_2_1,  env: *rails_5_0 }
     - { rvm: *ruby_2_1,  env: *rails_5_1 }
@@ -104,22 +112,13 @@ matrix:
     - { rvm: *ruby_2_5,  env: *rails_4_1 }
     - { rvm: *ruby_2_6,  env: *rails_4_1 }
 
-    # allow RAILS_VERSION=master to fail against ruby 2.5+ until this gem supports RAILS_VERSION
-    # https://github.com/rails/rails/blob/master/RAILS_VERSION
-    # https://github.com/rails-api/active_model_serializers/blob/0-10-stable/active_model_serializers.gemspec#L24
     - { rvm: *ruby_2_5,  env: *rails_master }
     - { rvm: *ruby_2_6,  env: *rails_master }
 
     - rvm: *ruby_head
-    # - { rvm: *ruby_head, env: *rails_4_1 }
-    # - { rvm: *ruby_head, env: *rails_4_2 }
-    # - { rvm: *ruby_head, env: *rails_5_0 }
-    # - { rvm: *ruby_head, env: *rails_5_1 }
-    # - { rvm: *ruby_head, env: *rails_5_2 }
-    # - { rvm: *ruby_head, env: *rails_6_0 }
-    # - { rvm: *ruby_head, env: *rails_master }
 
-    - rvm: *jruby_9_1
-    - rvm: *jruby_9_2
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: *rails_master_jruby }
+
     - rvm: *jruby_head
+
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ ruby_supported_versions:
   - &ruby_2_6 2.6.3
   - &ruby_head ruby-head
 
+jruby_supported_versions:
+  - &jruby_9_1 jruby-9.1.17.0
+  - &jruby_9_2 jruby-9.2.7.0
+  - &jruby_head jruby-head
+
+jdk_supported_versions:
+  - &jdk_8 openjdk8
+
 rails_supported_versions:
   - &rails_4_1 RAILS_VERSION=4.1
   - &rails_4_2 RAILS_VERSION=4.2
@@ -57,12 +65,25 @@ branches:
 
 matrix:
   include:
-    - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=4.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    # See JRuby currently failing on Rails 5+ https://github.com/jruby/activerecord-jdbc-adapter/issues/708
-    # - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
-    # - { rvm: jruby-head,     jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=4.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_1,  jdk: *jdk_8, env: "RAILS_VERSION=5.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=5.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=6.0.0.rc2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_9_2,  jdk: *jdk_8, env: "RAILS_VERSION=master JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+
+    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=4.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=5.0 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=5.2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=6.0.0.rc2 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - { rvm: *jruby_head, jdk: *jdk_8, env: "RAILS_VERSION=master JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
   exclude:
     - { rvm: *ruby_2_1,  env: *rails_5_0 }
     - { rvm: *ruby_2_1,  env: *rails_5_1 }
@@ -98,7 +119,7 @@ matrix:
     # - { rvm: *ruby_head, env: *rails_6_0 }
     # - { rvm: *ruby_head, env: *rails_master }
 
-    - rvm: jruby-head
-    # See JRuby currently failing on Rails 5+ https://github.com/jruby/activerecord-jdbc-adapter/issues/708
-    - { rvm: jruby-9.1.13.0, jdk: oraclejdk8, env: "RAILS_VERSION=5.1 JRUBY_OPTS='--dev -J-Xmx1024M --debug'" }
+    - rvm: *jruby_9_1
+    - rvm: *jruby_9_2
+    - rvm: *jruby_head
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
+  "https://github.com/#{repo_name}.git"
+end
+
 #
 # Add a Gemfile.local to locally bundle gems outside of version control
 local_gemfile = File.join(File.expand_path('..', __FILE__), 'Gemfile.local')

--- a/Gemfile
+++ b/Gemfile
@@ -61,8 +61,14 @@ group :test do
     end
   end
   platforms :jruby do
-    if version == 'master' || version >= '5'
-      gem 'activerecord-jdbcsqlite3-adapter', '~> 50'
+    if version == 'master' || version >= '6.0'
+      gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter'
+    elsif version == '5.2'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0'
+    elsif version == '5.1'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0'
+    elsif version == '5.0'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 50.0'
     else
       gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'
     end

--- a/test/adapter/json/transform_test.rb
+++ b/test/adapter/json/transform_test.rb
@@ -56,9 +56,8 @@ module ActiveModelSerializers
 
         def test_transform_undefined
           mock_request(:blam)
-          result = nil
           assert_raises NoMethodError do
-            result = @adapter.serializable_hash
+            @adapter.serializable_hash
           end
         end
 

--- a/test/support/serialization_testing.rb
+++ b/test/support/serialization_testing.rb
@@ -20,11 +20,11 @@ module SerializationTesting
   end
 
   def with_prepended_lookup(lookup_proc)
-    original_lookup = ActiveModelSerializers.config.serializer_lookup_cahin
+    original_lookup = ActiveModelSerializers.config.serializer_lookup_chain
     ActiveModelSerializers.config.serializer_lookup_chain.unshift lookup_proc
     yield
   ensure
-    ActiveModelSerializers.config.serializer_lookup_cahin = original_lookup
+    ActiveModelSerializers.config.serializer_lookup_chain = original_lookup
   end
 
   # Aliased as :with_configured_adapter to clarify that


### PR DESCRIPTION
https://weblog.rubyonrails.org/2019/7/30/Rails-6-0-rc2-released/