### PR TITLE
Bump Ruby versions on Travis: 2.4.7/2.5.6/2.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ ruby_supported_versions:
   - &ruby_2_1 2.1.10
   - &ruby_2_2 2.2.10
   - &ruby_2_3 2.3.8
-  - &ruby_2_4 2.4.6
-  - &ruby_2_5 2.5.5
-  - &ruby_2_6 2.6.3
+  - &ruby_2_4 2.4.7
+  - &ruby_2_5 2.5.6
+  - &ruby_2_6 2.6.4
   - &ruby_head ruby-head
 
 jruby_supported_versions:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/