### PR TITLE
Bump Ruby versions on Travis: 2.4.9/2.5.7/2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ ruby_supported_versions:
   - &ruby_2_1 2.1.10
   - &ruby_2_2 2.2.10
   - &ruby_2_3 2.3.8
-  - &ruby_2_4 2.4.7
-  - &ruby_2_5 2.5.6
-  - &ruby_2_6 2.6.4
+  - &ruby_2_4 2.4.9
+  - &ruby_2_5 2.5.7
+  - &ruby_2_6 2.6.5
   - &ruby_head ruby-head
 
 jruby_supported_versions:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/10/01/webrick-regexp-digestauth-dos-cve-2019-16201/