### PR TITLE
Fix Rails 6.0 deprecation on `class.parent`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jdk:
   - openjdk8
 
 before_install:
-  - gem update --system
+  - gem i rubygems-update -v '<3' && update_rubygems
   - rvm @global do gem uninstall bundler -a -x
   - rvm @global do gem install bundler -v 1.13.7
 install: bundle install --path=vendor/bundle --retry=3 --jobs=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ jdk:
   - openjdk8
 
 before_install:
-  - gem i rubygems-update -v '<3' && update_rubygems
+  - env
+  - gem install rubygems-update -v '<3'
+  - if [ "$JRUBY_BUILD" ] ; then gem uninstall rubygems-update -v 3.1.2 ; fi
+  - update_rubygems
   - rvm @global do gem install bundler -v 1.13.7
 install: bundle _1.13.7_ install --path=vendor/bundle --retry=3 --jobs=3
 cache:
@@ -40,6 +43,7 @@ matrix:
       env: RAILS_VERSION=master
     - rvm: jruby-9.1.5.0
       env: RAILS_VERSION=master
+      env: JRUBY_BUILD=true
     - rvm: 1.9.3
       env: RAILS_VERSION=5.0
     - rvm: 2.0.0
@@ -48,6 +52,7 @@ matrix:
       env: RAILS_VERSION=5.0
     - rvm: jruby-9.1.5.0
       env: RAILS_VERSION=5.0
+      env: JRUBY_BUILD=true
   allow_failures:
     - rvm: ruby-head
     - env: "RAILS_VERSION=master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ jdk:
 
 before_install:
   - gem i rubygems-update -v '<3' && update_rubygems
-  - rvm @global do gem uninstall bundler -a -x
   - rvm @global do gem install bundler -v 1.13.7
-install: bundle install --path=vendor/bundle --retry=3 --jobs=3
+install: bundle _1.13.7_ install --path=vendor/bundle --retry=3 --jobs=3
 cache:
   directories:
     - vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ jdk:
   - openjdk8
 
 before_install:
-  - env
   - gem install rubygems-update -v '<3'
-  - if [ "$JRUBY_BUILD" ] ; then gem uninstall rubygems-update -v 3.1.2 ; fi
+  - if [ "$RUBY_VERSION" = "jruby-9.1.5.0" ] ; then gem uninstall rubygems-update -v 3.1.2 ; fi
   - update_rubygems
   - rvm @global do gem install bundler -v 1.13.7
 install: bundle _1.13.7_ install --path=vendor/bundle --retry=3 --jobs=3
@@ -43,7 +42,6 @@ matrix:
       env: RAILS_VERSION=master
     - rvm: jruby-9.1.5.0
       env: RAILS_VERSION=master
-      env: JRUBY_BUILD=true
     - rvm: 1.9.3
       env: RAILS_VERSION=5.0
     - rvm: 2.0.0
@@ -52,7 +50,6 @@ matrix:
       env: RAILS_VERSION=5.0
     - rvm: jruby-9.1.5.0
       env: RAILS_VERSION=5.0
-      env: JRUBY_BUILD=true
   allow_failures:
     - rvm: ruby-head
     - env: "RAILS_VERSION=master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
 
 before_install:
   - gem update --system 2.6.8
-  - update_rubygems
+  - if [ "$RUBY_VERSION" != "jruby-9.1.5.0" ] ; then update_rubygems ; fi 
   - rvm @global do gem install bundler -v 1.13.7
 install: bundle _1.13.7_ install --path=vendor/bundle --retry=3 --jobs=3
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - jruby-9.1.5.0 # is precompiled per http://rubies.travis-ci.org/
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ jdk:
   - openjdk8
 
 before_install:
-  - gem install rubygems-update -v '<3'
-  - if [ "$RUBY_VERSION" = "jruby-9.1.5.0" ] ; then gem uninstall rubygems-update -v 3.1.2 ; fi
+  - gem update --system 2.6.8
   - update_rubygems
   - rvm @global do gem install bundler -v 1.13.7
 install: bundle _1.13.7_ install --path=vendor/bundle --retry=3 --jobs=3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### [0-9-stable](https://github.com/rails-api/active_model_serializers/compare/v0.9.7...0-9-stable)
 
+- [#2373](https://github.com/rails-api/active_model_serializers/pull/2373) Fix Rails 6.0 deprecation warnings. (@supremebeing7)
+  
 ### [v0.9.7 (2017-05-01)](https://github.com/rails-api/active_model_serializers/compare/v0.9.6...v0.9.7)
 
 - [#2080](https://github.com/rails-api/active_model_serializers/pull/2080) remove `{ payload: nil }` from `!serialize.active_model_serializers` ActiveSupport::Notification. `payload` never had a value.  Changes, for example `{ serializer: 'ActiveModel::DefaultSerializer', payload: nil }` to be `{ serializer: 'ActiveModel::DefaultSerializer' }` (@yosiat)

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ if ENV['CI']
   if RUBY_VERSION < '2.2'
     # >= 12.3 and < 13 requires ruby >= 2.0, rake >= 13 requires ruby >= 2.2
     gem 'rake', '< 12.3' 
+    # > 5.12 requires ruby >= 2.2
+    gem 'minitest', '< 5.12'
   end
 end
 
@@ -81,7 +83,9 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.34.0', require: false
+  unless ENV['CI']
+    gem 'rubocop', '~> 0.34.0', require: false
+  end
   
   # 0.12 requires ruby 2.4
   if RUBY_VERSION < '2.4'

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,10 @@ if ENV['CI']
     # Windows: An error occurred while installing nokogiri (1.8.0)
     gem 'nokogiri', '< 1.7', platforms: @windows_platforms
   end
+
+  if RUBY_VERSION < '2.2'
+    gem 'rake', '< 13.0'
+  end
 end
 
 # https://github.com/bundler/bundler/blob/89a8778c19269561926cea172acdcda241d26d23/lib/bundler/dependency.rb#L30-L54

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,10 @@ if ENV['CI']
     gem 'rake', '< 12.3' 
     # > 5.12 requires ruby >= 2.2
     gem 'minitest', '< 5.12'
+    # >= 1.0 requires ruby >= 2.0
+    gem 'thor', '< 1.0'
+    # >= 4.0 requires ruby >= 2.5
+    gem 'sprockets', '< 4.0'
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,8 @@ if ENV['CI']
   end
 
   if RUBY_VERSION < '2.2'
-    gem 'rake', '< 13.0'
+    # >= 12.3 and < 13 requires ruby >= 2.0, rake >= 13 requires ruby >= 2.2
+    gem 'rake', '< 12.3' 
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,15 @@ group :test do
       gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'
     end
   end
-  gem 'simplecov', '~> 0.10', require: false, group: :development
 end
 
 group :development, :test do
   gem 'rubocop', '~> 0.34.0', require: false
+  
+  # 0.12 requires ruby 2.4
+  if RUBY_VERSION < '2.4'
+    gem 'simplecov', '< 0.12', require: false
+  else
+    gem 'simplecov', '~> 0.10', require: false
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -50,9 +50,26 @@ group :bench do
 end
 
 group :test do
-  gem 'sqlite3',                          platform: (@windows_platforms + [:ruby])
-  gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-
+  platforms(*(@windows_platforms + [:ruby])) do
+    if version == 'master' || version >= '6'
+      gem 'sqlite3', '~> 1.4'
+    else
+      gem 'sqlite3', '~> 1.3.13'
+    end
+  end
+  platforms :jruby do
+    if version == 'master' || version >= '6.0'
+      gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter'
+    elsif version == '5.2'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0'
+    elsif version == '5.1'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0'
+    elsif version == '5.0'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 50.0'
+    else
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'
+    end
+  end
   gem 'simplecov', '~> 0.10', require: false, group: :development
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,17 +37,17 @@ if ENV['CI']
   if RUBY_VERSION < '2.4'
     # Windows: An error occurred while installing nokogiri (1.8.0)
     gem 'nokogiri', '< 1.7', platforms: @windows_platforms
+    # >= 4.0 requires ruby >= 2.5
+    gem 'sprockets', '< 4.0'
   end
 
-  if RUBY_VERSION < '2.2' || RUBY_VERSION == 'jruby-9.1.5.0'
+  if RUBY_VERSION < '2.2'
     # >= 12.3 and < 13 requires ruby >= 2.0, rake >= 13 requires ruby >= 2.2
     gem 'rake', '< 12.3' 
     # > 5.12 requires ruby >= 2.2
     gem 'minitest', '< 5.12'
     # >= 1.0 requires ruby >= 2.0
     gem 'thor', '< 1.0'
-    # >= 4.0 requires ruby >= 2.5
-    gem 'sprockets', '< 4.0'
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,11 @@ if RUBY_VERSION < '2'
   gem 'mime-types', [ '>= 2.6.2', '< 3' ]
 end
 
-if RUBY_VERSION < '2.1'
-  gem 'nokogiri', '< 1.7'
+if ENV['CI']
+  if RUBY_VERSION < '2.4'
+    # Windows: An error occurred while installing nokogiri (1.8.0)
+    gem 'nokogiri', '< 1.7', platforms: @windows_platforms
+  end
 end
 
 # https://github.com/bundler/bundler/blob/89a8778c19269561926cea172acdcda241d26d23/lib/bundler/dependency.rb#L30-L54

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ if ENV['CI']
     gem 'nokogiri', '< 1.7', platforms: @windows_platforms
   end
 
-  if RUBY_VERSION < '2.2'
+  if RUBY_VERSION < '2.2' || RUBY_VERSION == 'jruby-9.1.5.0'
     # >= 12.3 and < 13 requires ruby >= 2.0, rake >= 13 requires ruby >= 2.2
     gem 'rake', '< 12.3' 
     # > 5.12 requires ruby >= 2.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler
+  - gem install bundler -v 1.17.3
   - bundler --version
   - bundle platform
   - bundle install --path=vendor/bundle --retry=3 --jobs=3

--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -60,7 +60,15 @@ module ActionController
     private
 
     def namespace_for_serializer
-      @namespace_for_serializer ||= self.class.parent unless self.class.parent == Object
+      @namespace_for_serializer ||= namespace_for_class(self.class) unless namespace_for_class(self.class) == Object
+    end
+
+    def namespace_for_class(klass)
+      if Module.method_defined?(:module_parent)
+        klass.module_parent
+      else
+        klass.parent
+      end
     end
 
     def default_serializer(resource)


### PR DESCRIPTION
#### Purpose
Fix depreciation warnings in Rails 6.0.0

DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1.

#### Changes
Changes parent calls to module_parent

#### Related GitHub issues
https://github.com/rails-api/active_model_serializers/pull/2319

#### Additional helpful information
This was already patched in 0-10-stable but is still an issue on 0-9-stable.

