### PR TITLE
Fix CI builds for 0-9-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - jruby-9.1.5.0 # is precompiled per http://rubies.travis-ci.org/
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - gem update --system

--- a/Gemfile
+++ b/Gemfile
@@ -50,9 +50,26 @@ group :bench do
 end
 
 group :test do
-  gem 'sqlite3',                          platform: (@windows_platforms + [:ruby])
-  gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-
+  platforms(*(@windows_platforms + [:ruby])) do
+    if version == 'master' || version >= '6'
+      gem 'sqlite3', '~> 1.4'
+    else
+      gem 'sqlite3', '~> 1.3.13'
+    end
+  end
+  platforms :jruby do
+    if version == 'master' || version >= '6.0'
+      gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter'
+    elsif version == '5.2'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 52.0'
+    elsif version == '5.1'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0'
+    elsif version == '5.0'
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 50.0'
+    else
+      gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0'
+    end
+  end
   gem 'simplecov', '~> 0.10', require: false, group: :development
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,11 @@ if RUBY_VERSION < '2'
   gem 'mime-types', [ '>= 2.6.2', '< 3' ]
 end
 
-if RUBY_VERSION < '2.1'
-  gem 'nokogiri', '< 1.7'
+if ENV['CI']
+  if RUBY_VERSION < '2.4'
+    # Windows: An error occurred while installing nokogiri (1.8.0)
+    gem 'nokogiri', '< 1.7', platforms: @windows_platforms
+  end
 end
 
 # https://github.com/bundler/bundler/blob/89a8778c19269561926cea172acdcda241d26d23/lib/bundler/dependency.rb#L30-L54

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler
+  - gem install bundler -v 1.17.3
   - bundler --version
   - bundle platform
   - bundle install --path=vendor/bundle --retry=3 --jobs=3


### PR DESCRIPTION
#### Purpose
Fix Travis and Appveyor on 0-9-stable

#### Changes
Version locks for compatibility and switch to openJDK 

#### Caveats
NA

#### Related GitHub issues
Spun out from #2373 because Travis was showing "Abuse Detected"

#### Additional helpful information


