### PR TITLE
Change url of fast-jsonapi to forked version [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ See [PR 2121](https://github.com/rails-api/active_model_serializers/pull/2121) w
 ## Alternatives
 
 - [jsonapi-rb](http://jsonapi-rb.org/) is a [highly performant](https://gist.github.com/NullVoxPopuli/748e89ddc1732b42fdf42435d773734a) and modular JSON:API-only implementation.  There's a vibrant community around it that has produced projects such as [JSON:API Suite](https://jsonapi-suite.github.io/jsonapi_suite/).
-- [fast_jsonapi](https://github.com/Netflix/fast_jsonapi) is a lightning fast JSON:API serializer for Ruby Objects from the team of Netflix.
+- [fast_jsonapi](https://github.com/fast-jsonapi/fast_jsonapi) is a lightning fast JSON:API serializer for Ruby Objects.
 - [jsonapi-resources](https://github.com/cerebris/jsonapi-resources) is a popular resource-focused framework for implementing JSON:API servers.
 - [blueprinter](https://github.com/procore/blueprinter) is a fast, declarative, and API spec agnostic serializer that uses composable views to reduce duplication. From your friends at Procore.
 


### PR DESCRIPTION
#### Purpose

Now the forked version of fast-jsonapi is developed actively and the Netflix version is not active,
it's better to guide readers to the fork.

#### Changes

- URL of `fast-jsonapi` is changed to the forked version
- Remove `from the team of Netflix` from the description