### PR TITLE
Value is not always a ActiveModel::Serializer::Link

### DIFF
--- a/lib/active_model_serializers/adapter/json_api.rb
+++ b/lib/active_model_serializers/adapter/json_api.rb
@@ -484,8 +484,11 @@ module ActiveModelSerializers
       #   }.reject! {|_,v| v.nil? }
       def links_for(serializer)
         serializer._links.each_with_object({}) do |(name, value), hash|
-          next if value.excluded?(serializer)
-          result = Link.new(serializer, value.block).as_json
+          if value.is_a?(ActiveModel::Serializer::Link)
+            next if value.excluded?(serializer)
+            value = value.block
+          end
+          result = Link.new(serializer, value).as_json
           hash[name] = result if result
         end
       end


### PR DESCRIPTION
#### Purpose
This PR will fix an issue I was having ``NoMethodError: undefined method `excluded?' for "/nodes/746868371":String`` in ``active_model_serializers-0.10.10/lib/active_model_serializers/adapter/json_api.rb:487:in `block in links_for'``

The PR link below does have a comment that states 'value' is now always a Link, but this doesn't seem to be the case as the error above shows. 

I am new to the project, so this might not be an appropriate fix for the problem I am having.

#### Changes
Revert commit 572f11b7e0592eb0781006b9c364d8bd13474831.

#### Related
#2279 


