### PR TITLE
prioritize serializer's cache key over ActiveRecord's cache key

### DIFF
--- a/lib/active_model/serializer/concerns/caching.rb
+++ b/lib/active_model/serializer/concerns/caching.rb
@@ -286,12 +286,12 @@ module ActiveModel
       def object_cache_key
         if object.respond_to?(:cache_key_with_version)
           object.cache_key_with_version
-        elsif object.respond_to?(:cache_key)
-          object.cache_key
         elsif (serializer_cache_key = (serializer_class._cache_key || serializer_class._cache_options[:key]))
           object_time_safe = object.updated_at
           object_time_safe = object_time_safe.strftime('%Y%m%d%H%M%S%9N') if object_time_safe.respond_to?(:strftime)
           "#{serializer_cache_key}/#{object.id}-#{object_time_safe}"
+        elsif object.respond_to?(:cache_key)
+          object.cache_key
         else
           fail UndefinedCacheKey, "#{object.class} must define #cache_key, or the 'key:' option must be passed into '#{serializer_class}.cache'"
         end


### PR DESCRIPTION
#### Purpose
Allow serializers to override cache key by adding
```
class CompactUserSerializer
  cache key: 'compact-user'
end

class UserSerializer
  cache key: 'user'
end
```

Our Rails application has different version of serializers for a model like `CompactUserSerializer` and `UserSerializer`.
Since our `User` model has a cache key, active model serializer does not use our custom cache key names...

#### Changes

Prioritize Serializer's cache key attribute over Active Model's `cache_key` method.


#### Caveats


#### Related GitHub issues


#### Additional helpful information


