### PR TITLE
remove explicit require for thread_safe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,6 @@ group :test do
   gem 'm', '~> 1.5'
   gem 'pry', '>= 0.10'
   gem 'byebug', '~> 8.2' if RUBY_VERSION < '2.2'
-  gem 'pry-byebug', platforms: :ruby
 end
 
 group :development, :test do

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'thread_safe'
 require 'jsonapi/include_directive'
 require 'active_model/serializer/collection_serializer'
 require 'active_model/serializer/array_serializer'


### PR DESCRIPTION
In Rails master, [tzinfo has been updated to 2.x](https://github.com/rails/rails/commit/e9425abe33924623b1dce62bd817eace757c2b4e), which no longer depends on the `thread_safe` gem and has moved to `concurrent-ruby` instead. Thereby, unless you're explicitly adding `thread_safe` to your Gemfile, `active_model_serializers` throws up a `cannot require thread_safe`. #2369 has already replaced `ThreadSafe::Cache` with `Concurrent::Map`. This require should no longer be required!(😅)