### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 
 sudo: false
-
+arch:
+  - amd64
+  - ppc64le
 cache:
   directories:
     - vendor/bundle


### PR DESCRIPTION
#### Purpose
It supports travis-ci to test ppc64le build as well.

#### Changes
.travis.yml file changes and arch: ppc64le along with amd64

#### Caveats


#### Related GitHub issues


#### Additional helpful information
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/active_model_serializers/builds/199809698 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!

