### PR TITLE
Add support for rails 6.1

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  rails_versions = ['>= 4.1', '< 6.1']
+  rails_versions = ['>= 4.1', '< 6.2']
   spec.add_runtime_dependency 'activemodel', rails_versions
   # 'activesupport', rails_versions
   # 'builder'

--- a/lib/active_model/serializer/version.rb
+++ b/lib/active_model/serializer/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveModel
   class Serializer
-    VERSION = '0.10.11'.freeze
+    VERSION = '0.10.11'
   end
 end


### PR DESCRIPTION
With Rails 6.1 RC out, it's only a matter of time that 6.1 is released as well. People working on the edge version might face difficulties updating their gems.