### PR TITLE
【WIP】Add each_serializer option support to CollectionSerializer

### DIFF
--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -40,7 +40,7 @@ module ActiveModel
         return root if root
         # 1. get from options[:serializer] for empty resource collection
         key = object.empty? &&
-          (explicit_serializer_class = options[:serializer]) &&
+          (explicit_serializer_class = options[:serializer] || options[:each_serializer]) &&
           explicit_serializer_class._type
         # 2. get from first serializer instance in collection
         key ||= (serializer = serializers.first) && serializer.json_key

--- a/test/collection_serializer_test.rb
+++ b/test/collection_serializer_test.rb
@@ -18,8 +18,8 @@ module ActiveModel
           instance_options
         end
       end
-      class MessagesSerializer < ActiveModel::Serializer
-        type 'messages'
+      class MessageSerializer < ActiveModel::Serializer
+        type 'message'
       end
 
       def setup
@@ -109,7 +109,13 @@ module ActiveModel
 
       def test_json_key_with_empty_resources_with_serializer
         resource = []
-        serializer = collection_serializer.new(resource, serializer: MessagesSerializer)
+        serializer = collection_serializer.new(resource, serializer: MessageSerializer)
+        assert_equal 'messages', serializer.json_key
+      end
+
+      def test_json_key_with_empty_resources_with_each_serializer
+        resource = []
+        serializer = collection_serializer.new(resource, each_serializer: MessageSerializer)
         assert_equal 'messages', serializer.json_key
       end
 


### PR DESCRIPTION
#### Purpose
 - Raise ArgumentError  "Cannot infer..." when collection is empty -v 10.0.7
 - issues: https://github.com/rails-api/active_model_serializers/issues/2406
#### Changes
 - lib/active_model/serializer/collection_serializer.rb :43 add check to each_serializer option

#### Related GitHub issues
 - https://github.com/rails-api/active_model_serializers/issues/2406

#### Additional helpful information
 - Our production project has passed all rspec by this patch