### PR TITLE
Add raise_cannot_infer_root_key_error to config

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -146,6 +146,8 @@ module ActiveModel
     config.jsonapi_include_toplevel_object = false
     config.jsonapi_use_foreign_key_on_belongs_to_relationship = false
     config.include_data_default = true
+    # Raise ActiveModel::Serializer::CollectionSerializer::CannotInferRootKeyError when cannot infer root key from collection type
+    config.raise_cannot_infer_root_key_error = true
 
     # For configuring how serializers are found.
     # This should be an array of procs.

--- a/lib/active_model/serializer/collection_serializer.rb
+++ b/lib/active_model/serializer/collection_serializer.rb
@@ -48,8 +48,11 @@ module ActiveModel
         key ||= object.respond_to?(:name) ? object.name && object.name.underscore : nil
         # 4. key may be nil for empty collection and no serializer option
         key &&= key.pluralize
-        # 5. fail if the key cannot be determined
-        key || fail(ArgumentError, 'Cannot infer root key from collection type. Please specify the root or each_serializer option, or render a JSON String')
+        if raise_cannot_infer_root_key_error?
+          # 5. fail if the key cannot be determined
+          key || fail(CannotInferRootKeyError, 'Cannot infer root key from collection type. Please specify the root or each_serializer option, or render a JSON String')
+        end
+        key
       end
       # rubocop:enable Metrics/CyclomaticComplexity
 
@@ -60,11 +63,17 @@ module ActiveModel
           object.respond_to?(:size)
       end
 
+      class CannotInferRootKeyError < StandardError; end
+
       protected
 
       attr_reader :serializers, :options
 
       private
+
+      def raise_cannot_infer_root_key_error?
+        ActiveModelSerializers.config.raise_cannot_infer_root_key_error
+      end
 
       def serializers_from_resources
         serializer_context_class = options.fetch(:serializer_context_class, ActiveModel::Serializer)


### PR DESCRIPTION
#### Purpose
 - Raise error when cannot infer root key by v10.0.7 . I think this is braking change. 
 - Added config that you can upgrade without changing existing code.

#### Changes
 - ArgumentError changes to CannotInferRootKeyError in CollectionSerializer#json_key
    - Custom error helps clarify the problem
 - Add config.raise_cannot_infer_root_key_error
 - Add test when serializer does not have type and collection is empty

#### Related GitHub issues
 - https://github.com/rails-api/active_model_serializers/issues/2406

#### 
Our project has many like this code😢

```
::ActiveModelSerializers::SerializableResource.new(
  collections, # [] empty array
  each_serializer: NonTypeCollectionSerializer,
).serializable_hash || []
※ v0.10.6
```

