### PR TITLE
Replace "JSON:API Suite" URL because it was changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See [PR 2121](https://github.com/rails-api/active_model_serializers/pull/2121) w
 
 ## Alternatives
 
-- [jsonapi-rb](http://jsonapi-rb.org/) is a [highly performant](https://gist.github.com/NullVoxPopuli/748e89ddc1732b42fdf42435d773734a) and modular JSON:API-only implementation.  There's a vibrant community around it that has produced projects such as [JSON:API Suite](https://jsonapi-suite.github.io/jsonapi_suite/).
+- [jsonapi-rb](http://jsonapi-rb.org/) is a [highly performant](https://gist.github.com/NullVoxPopuli/748e89ddc1732b42fdf42435d773734a) and modular JSON:API-only implementation.  There's a vibrant community around it that has produced projects such as [JSON:API Suite](https://jsonapi-suite.github.io/jsonapi_suite_deprecated/).
 - [fast_jsonapi](https://github.com/fast-jsonapi/fast_jsonapi) is a lightning fast JSON:API serializer for Ruby Objects.
 - [jsonapi-resources](https://github.com/cerebris/jsonapi-resources) is a popular resource-focused framework for implementing JSON:API servers.
 - [blueprinter](https://github.com/procore/blueprinter) is a fast, declarative, and API spec agnostic serializer that uses composable views to reduce duplication. From your friends at Procore.


### PR DESCRIPTION
#### Purpose
Improved README documentation

#### Changes
![image](https://user-images.githubusercontent.com/21003135/110318985-98d90d80-8051-11eb-8655-a0b52ee058e8.png)

The github.io link for `JSON:API Suite` in the Alternatives-chapter in the README was returning status 404.

https://jsonapi-suite.github.io/jsonapi_suite/

The top page of `JSON:API Suite` was changed to the following one, so change the URL to this one.

https://jsonapi-suite.github.io/jsonapi_suite_deprecated/

#### Caveats
Nothing

#### Related GitHub issues
Nothing

#### Additional helpful information
It might be more appropriate to put the link to the Ruby Docs for the `JSON:API` Suite. 
I was not able to determine that.

https://jsonapi-suite.github.io/jsonapi_suite_deprecated/ruby/