### PR TITLE
Relax gem requirement for Rails 7.0 prerelease

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  rails_versions = ['>= 4.1', '< 6.2']
+  rails_versions = ['>= 4.1', '< 7.0']
   spec.add_runtime_dependency 'activemodel', rails_versions
   # 'activesupport', rails_versions
   # 'builder'


### PR DESCRIPTION
#### Purpose
This commit updates the upper bound of Rails dependency requirement to `< 7.0`, as the next version of Rails will be Rails 7.0.

This will allow developers to use and test `active_model_serializers` against Rails Edge.

#### Changes
Updates `rails_versions` in Gemspec to `< 7.0`.

#### Caveats
Note that we'll need to bump this upper bound again once Rails 7.0 comes out, as this upper bound will block anything >= 7.0.0.

#### Additional helpful information
https://github.com/rails/rails/commit/1b455e2e9d6937d4107e19cb32e2f98aa08886b9

