### PR TITLE
Fix checking of method defined or not

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ namespace :test do
       end or fail 'Failures' # rubocop:disable Style/AndOr
     end
     bundler_method =
-      if Bundler.method_defined?(:with_unbundled_env)
+      if Bundler.respond_to?(:with_unbundled_env)
         :with_unbundled_env
       else
         :with_clean_env


### PR DESCRIPTION
The `Module#method_defined?` works for an instance method. But `with_unbundled_env` defines as a class method. Therefore, the current check doesn't work as expected.

```ruby
require "bundler"

puts Bundler.method_defined?(:with_unbundled_env) # => false
puts Bundler.respond_to?(:with_unbundled_env)     # => true
```

This fixes the following message that shows when running a test.

```
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /home/y-yagi/src/github.com/rails-api/active_model_serializers/Rakefile:68)
```