### PR TITLE
Relax dependencies for Rails 7.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         include:
           # Recent Rubies and Rails
+          - ruby-version: '3.0'
+            rails-version: '7.0'
+          - ruby-version: '2.7'
+            rails-version: '7.0'
           - ruby-version: '2.6'
             rails-version: '6.1'
           - ruby-version: '2.6'

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  rails_versions = ['>= 4.1', '< 7.0']
+  rails_versions = ['>= 4.1', '< 7.1']
   spec.add_runtime_dependency 'activemodel', rails_versions
   # 'activesupport', rails_versions
   # 'builder'


### PR DESCRIPTION
#### Purpose
- Allow using active_model_serializers in stable Rails 7.0.x releases.

#### Changes
- Relaxed Rails dependency - changed `< 7.0` to `< 7.1`.

#### Caveats

#### Related GitHub issues

#### Additional helpful information


