### PR TITLE
fix empty belongs_to with polymorphic serialization error

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/relationship.rb
+++ b/lib/active_model_serializers/adapter/json_api/relationship.rb
@@ -51,6 +51,7 @@ module ActiveModelSerializers
               if association.polymorphic?
                 # We can't infer resource type for polymorphic relationships from the serializer.
                 # We can ONLY know a polymorphic resource type by inspecting each resource.
+                return unless association.lazy_association.serializer
                 association.lazy_association.serializer.json_key
               else
                 association.reflection.type.to_s


### PR DESCRIPTION
#### Purpose

Fixes the error, when `jsonapi_use_foreign_key_on_belongs_to_relationship=true` and `belongs_to` relationship is polymorphic and empty.
