### PR TITLE
Update 0.9-stable release to work with ruby 2.6 & 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-version = ENV["RAILS_VERSION"] || "4.2"
+default_rails_version = RUBY_VERSION > '2.5' ? '5.2' : '4.2'
+version = ENV['RAILS_VERSION'] || default_rails_version
 
 if version == 'master'
   gem 'rack', github: 'rack/rack'
@@ -27,6 +28,7 @@ else
   gem 'activemodel', gem_version
   gem 'actionpack', gem_version
   gem 'activerecord', gem_version, group: :test
+  gem 'rails-controller-testing' if version > '4.2'
 end
 
 if RUBY_VERSION < '2'

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -66,10 +66,14 @@ end
             ArraySerializer
           end
         else
-          klass_name = build_serializer_class(resource, options)
-          Serializer.serializers_cache.fetch_or_store(klass_name) do
-            _const_get(klass_name)
-          end
+          search_list = build_serializer_class_list(resource, options)
+          result = search_list.map do |klass_name|
+                     Serializer.serializers_cache.fetch_or_store(klass_name) do
+                       _const_get(klass_name)
+                     end
+                   end
+
+          result.find { |serializer| !serializer.nil? }
         end
       end
 
@@ -116,6 +120,12 @@ end
         attr = attr.to_s.gsub(/\?\Z/, '')
         attr = attr.to_sym if symbolized
         attr
+      end
+
+      def build_serializer_class_list(resource, options)
+        list = []
+        list << build_serializer_class(resource, options)
+        list << build_serializer_class(resource.class.name.demodulize, {})
       end
 
       def build_serializer_class(resource, options)

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -122,7 +122,11 @@ end
         "".tap do |klass_name|
           klass_name << "#{options[:namespace]}::" if options[:namespace]
           klass_name << options[:prefix].to_s.classify if options[:prefix]
-          klass_name << "#{resource.class.name}Serializer"
+          if resource.is_a?(String)
+            klass_name << "#{resource}Serializer"
+          else
+            klass_name << "#{resource.class.name}Serializer"
+          end
         end
       end
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -125,6 +125,7 @@ end
       def build_serializer_class_list(resource, options)
         list = []
         list << build_serializer_class(resource, options)
+        list << build_serializer_class(resource, {})
         list << build_serializer_class(resource.class.name.demodulize, {})
       end
 

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -18,6 +18,19 @@ end
 ###
 ## Models
 ###
+
+module TestNamespace2
+  class Test < Model
+    attr_writer :sub_test
+
+    def sub_test
+      @sub_test ||= TestNamespace2::SubTest.new(name: 'N1', description: 'D1')
+    end
+  end
+
+  class SubTest < Model; end
+end
+
 class User < Model
   def profile
     @profile ||= Profile.new(name: 'N1', description: 'D1')
@@ -101,6 +114,24 @@ end
 ###
 ## Serializers
 ###
+
+module TestNamespace2
+  class TestSerializer < ActiveModel::Serializer
+    attributes :name, :email
+
+    has_one :sub_test
+  end
+
+  class SubTestSerializer < ActiveModel::Serializer
+    def description
+      description = object.read_attribute_for_serialization(:description)
+      scope ? "#{description} - #{scope}" : description
+    end
+
+    attributes :name, :description
+  end
+end
+
 class UserSerializer < ActiveModel::Serializer
   attributes :name, :email
 

--- a/test/integration/action_controller/serialization_test_case_test.rb
+++ b/test/integration/action_controller/serialization_test_case_test.rb
@@ -9,7 +9,7 @@ module ActionController
         end
 
         def render_text
-          render text: 'ok'
+          render plain: 'ok'
         end
 
         def render_template

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@ require 'bundler/setup'
 require 'minitest/autorun'
 require 'active_model_serializers'
 require 'fixtures/poro'
+require 'rails-controller-testing'
+Rails::Controller::Testing.install
 
 # Ensure backward compatibility with Minitest 4
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)

--- a/test/unit/active_model/array_serializer/serialization_test.rb
+++ b/test/unit/active_model/array_serializer/serialization_test.rb
@@ -49,6 +49,7 @@ module ActiveModel
         def object.serializer_class; CustomSerializer; end
 
         assert_equal CustomSerializer, Serializer.serializer_for(object)
+        assert_equal CustomSerializer, Serializer.serializer_for('Custom')
       end
     end
 

--- a/test/unit/active_model/array_serializer/serialization_test.rb
+++ b/test/unit/active_model/array_serializer/serialization_test.rb
@@ -53,6 +53,28 @@ module ActiveModel
       end
     end
 
+    class ModelSerializationNamespaceTest < Minitest::Test
+      def test_namespace
+        test1 = TestNamespace2::Test.new(name: 'Test 1', email: 'test1@test.com', gender: 'M')
+        test2 = TestNamespace2::Test.new(name: 'Test 2', email: 'test2@test.com', gender: 'M')
+        sub_test1 = TestNamespace2::SubTest.new(name: 'Name 1', description: 'Description 1', comments: 'Comments 1')
+        sub_test2 = TestNamespace2::SubTest.new(name: 'Name 2', description: 'Description 2', comments: 'Comments 2')
+        test1.sub_test = sub_test1
+        test2.sub_test = sub_test2
+
+        array = [test1, test2]
+        serializer = ArraySerializer.new(array)
+
+        expected = [
+          { name: 'Test 1', email: 'test1@test.com', sub_test: { name: 'Name 1', description: 'Description 1' }},
+          { name: 'Test 1', email: 'test2@test.com', sub_test: { name: 'Name 2', description: 'Description 2' }}
+        ]
+
+        assert_equal expected, serializer.serializable_array
+        assert_equal expected, serializer.as_json
+      end
+    end
+
     class ModelSerializationTest < Minitest::Test
       def test_array_serializer_serializes_models
         array = [Profile.new({ name: 'Name 1', description: 'Description 1', comments: 'Comments 1' }),

--- a/test/unit/active_model/serializer/has_many_polymorphic_test.rb
+++ b/test/unit/active_model/serializer/has_many_polymorphic_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class HasManyPolymorphicTest < ActiveModel::TestCase
+    class HasManyPolymorphicTest < Minitest::Test
       def setup
         @association = MailSerializer._associations[:attachments]
         @old_association = @association.dup

--- a/test/unit/active_model/serializer/has_one_polymorphic_test.rb
+++ b/test/unit/active_model/serializer/has_one_polymorphic_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ActiveModel
   class Serializer
-    class HasOnePolymorphicTest < ActiveModel::TestCase
+    class HasOnePolymorphicTest < Minitest::Test
       def setup
         @association = InterviewSerializer._associations[:attachment]
         @old_association = @association.dup


### PR DESCRIPTION
#### Purpose
0.9-stable version as of now does not work with ruby 2.6 and above ( excluding ruby 3 ) due to how const_get has become stricter in terms searching for constants.

Examples mentioned in this issue: #2443 

#### Changes
- Update Gemfile to handle higher rails version if ruby is > 2.5
- Patch serializer_for method to search serializers based on a list of potential naming conventions

Note: this is my first rare attempt at making a PR, pardon my newbie-ness and appreciate any feedback.


