### PR TITLE
Upgrade to Ubuntu 22.04 on Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ on: [push, pull_request]
 jobs:
   test:
     name: "Testing"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         include:
           # Recent Rubies and Rails
+          - ruby-version: '3.2'
+            rails-version: '7.0'
           - ruby-version: '3.1'
             rails-version: '7.0'
           - ruby-version: '3.0'

--- a/.rubocop_v0.yml
+++ b/.rubocop_v0.yml
@@ -1,0 +1,109 @@
+AllCops:
+  TargetRubyVersion: 2.1
+  Exclude:
+    - !ruby/regexp /(vendor|bundle|bin|db|tmp)\/.*/
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  # https://github.com/bbatsov/rubocop/blob/master/manual/caching.md
+  # https://github.com/bbatsov/rubocop/blob/e8680418b351491e111a18cf5b453fc07a3c5239/config/default.yml#L60-L77
+  UseCache: true
+  CacheRootDirectory: tmp
+
+Rails:
+  Enabled: true
+
+Lint/NestedMethodDefinition:
+  Enabled: false
+  Exclude:
+    - test/action_controller/serialization_test.rb
+
+Style/Alias:
+  EnforcedStyle: prefer_alias
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Metrics/AbcSize:
+  Max: 35 # TODO: Lower to 15
+
+Metrics/ClassLength:
+  Max: 261 # TODO: Lower to 100
+  Exclude:
+    - test/**/*.rb
+
+Metrics/CyclomaticComplexity:
+  Max: 7 # TODO: Lower to 6
+
+Metrics/LineLength:
+  Max: 251 # TODO: Lower to 80
+
+Metrics/MethodLength:
+  Max: 106 # TODO: Lower to 10
+
+Metrics/PerceivedComplexity:
+  Max: 9 # TODO: Lower to 7
+
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: nested
+
+Style/Documentation:
+  Enabled: false
+
+Style/MissingElse:
+  Enabled: true
+  EnforcedStyle: case
+
+Style/EmptyElse:
+  EnforcedStyle: empty
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Style/BlockDelimiters:
+  Enabled: true
+  EnforcedStyle: line_count_based
+
+Style/SignalException:
+  EnforcedStyle: semantic
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: no_comma
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/DotPosition:
+  EnforcedStyle: leading
+
+########## test_helper.rb sanity
+Style/EndBlock:
+  Exclude:
+    - test/test_helper.rb
+
+Style/SpecialGlobalVars:
+  Exclude:
+    - test/test_helper.rb
+
+Style/GlobalVars:
+  Exclude:
+    - test/test_helper.rb
+
+Style/AndOr:
+  Exclude:
+    - test/test_helper.rb
+    - 'lib/active_model/serializer/lint.rb'
+
+Style/Not:
+  Exclude:
+    - test/test_helper.rb
+
+Style/ClassCheck:
+  Exclude:
+    - test/test_helper.rb

--- a/.rubocop_v1.yml
+++ b/.rubocop_v1.yml
@@ -1,0 +1,329 @@
+require:
+  - rubocop-rails
+  - rubocop-minitest
+  - rubocop-rake
+
+AllCops:
+  TargetRubyVersion: 3.0
+  Exclude:
+    - !ruby/regexp /(vendor|bundle|bin|db|tmp)\/.*/
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  # https://github.com/bbatsov/rubocop/blob/master/manual/caching.md
+  # https://github.com/bbatsov/rubocop/blob/e8680418b351491e111a18cf5b453fc07a3c5239/config/default.yml#L60-L77
+  UseCache: true
+  CacheRootDirectory: tmp
+
+Bundler/DuplicatedGem:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+Layout/ArgumentAlignment:
+  Enabled: false
+
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+
+Layout/DotPosition:
+  EnforcedStyle: leading
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 251 # TODO: Lower to 80
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+  # EnforcedStyle: indented
+
+Layout/SpaceInLambdaLiteral:
+  Enabled: false
+
+Lint/BooleanSymbol:
+  Enabled: false
+
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+
+Lint/DisjunctiveAssignmentInConstructor:
+  Enabled: false
+
+Lint/MissingCopEnableDirective:
+  Enabled: false
+
+Lint/MissingSuper:
+  Enabled: false
+
+Lint/NestedMethodDefinition:
+  Enabled: false
+  Exclude:
+    - test/action_controller/serialization_test.rb
+
+Lint/OrderedMagicComments:
+  Enabled: false
+
+Lint/RedundantCopDisableDirective:
+  Enabled: false
+
+Lint/SendWithMixinArgument:
+  Enabled: false
+
+Lint/UselessAccessModifier:
+  Enabled: false
+
+Lint/UselessMethodDefinition:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 44 # TODO: Lower to 15
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Max: 261 # TODO: Lower to 100
+  Exclude:
+    - test/**/*.rb
+
+Metrics/CyclomaticComplexity:
+  Max: 8 # TODO: Lower to 6
+
+Metrics/MethodLength:
+  Max: 106 # TODO: Lower to 10
+
+Metrics/PerceivedComplexity:
+  Max: 12 # TODO: Lower to 7
+
+Minitest/AssertEmptyLiteral:
+  Enabled: false
+
+Minitest/AssertIncludes:
+  Enabled: false
+
+Minitest/AssertInstanceOf:
+  Enabled: false
+
+Minitest/AssertRespondTo:
+  Enabled: false
+
+Minitest/AssertTruthy:
+  Enabled: false
+
+Minitest/RefuteFalse:
+  Enabled: false
+
+Minitest/RefuteRespondTo:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
+Rails/ApplicationController:
+  Enabled: false
+
+Rails/ApplicationRecord:
+  Enabled: false
+
+Rails/IndexWith:
+  Enabled: false
+
+Rails/Present:
+  Enabled: false
+
+Rails/RakeEnvironment:
+  Enabled: false
+
+Rails/RedundantReceiverInWithOptions:
+  Enabled: false
+
+Rails/RefuteMethods:
+  Enabled: false
+
+Rake/Desc:
+  Enabled: false
+
+Rake/DuplicateTask:
+  Enabled: false
+
+Security/JSONLoad:
+  Enabled: false
+
+Style/Alias:
+  EnforcedStyle: prefer_alias
+
+#Style/AlignParameters:
+#  EnforcedStyle: with_fixed_indentation
+
+Style/BlockDelimiters:
+  Enabled: true
+  EnforcedStyle: line_count_based
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: nested
+
+Style/ClassEqualityComparison:
+  Enabled: false
+
+Style/CombinableLoops:
+  Enabled: false
+
+Style/CommentAnnotation:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyElse:
+  EnforcedStyle: empty
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/Encoding:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Style/ExplicitBlockArgument:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+Style/GlobalStdStream:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/HashAsLastArrayItem:
+  Enabled: false
+
+Style/HashSyntax:
+  Enabled: false
+
+Style/HashTransformValues:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/MissingElse:
+  Enabled: true
+  EnforcedStyle: case
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/RedundantAssignment:
+  Enabled: false
+
+Style/RedundantBegin:
+  Enabled: false
+
+Style/RedundantCondition:
+  Enabled: false
+
+Style/RedundantFreeze:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Style/SignalException:
+  EnforcedStyle: semantic
+
+Style/SoleNestedConditional:
+  Enabled: false
+
+Style/StderrPuts:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+  # EnforcedStyleForMultiline: no_comma
+
+Style/YodaCondition:
+  Enabled: false
+
+########## test_helper.rb sanity
+Style/EndBlock:
+  Exclude:
+    - test/test_helper.rb
+
+Style/SpecialGlobalVars:
+  Exclude:
+    - test/test_helper.rb
+
+Style/GlobalVars:
+  Exclude:
+    - test/test_helper.rb
+
+Style/AndOr:
+  Exclude:
+    - test/test_helper.rb
+    - 'lib/active_model/serializer/lint.rb'
+
+Style/Not:
+  Exclude:
+    - test/test_helper.rb
+
+Style/ClassCheck:
+  Exclude:
+    - test/test_helper.rb

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ end
 group :test do
   platforms(*(@windows_platforms + [:ruby])) do
     if version == 'master' || version >= '6'
-      gem 'sqlite3', '~> 1.4'
+      gem 'sqlite3', '< 1.6'
     else
       gem 'sqlite3', '~> 1.3.13'
     end
@@ -86,6 +86,17 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rubocop', '~> 0.40.0', require: false
+  if RUBY_VERSION < '3.0'
+    gem 'rubocop', '~> 0.40.0', require: false
+  else
+    gem 'rubocop', '~> 1.56.0', require: false
+    gem 'rubocop-minitest', '~> 0.31.0', require: false
+    gem 'rubocop-rails', '~> 2.20.0', require: false
+    gem 'rubocop-rake', '~> 0.6.0', require: false
+  end
+  if version <= '5.0'
+    gem 'loofah', '< 2.21.0'
+    gem 'rails-html-sanitizer', '< 1.6.0'
+  end
   gem 'yard', require: false
 end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -31,7 +31,12 @@ else
     ]
     desc 'Execute rubocop'
     RuboCop::RakeTask.new(:rubocop) do |task|
-      task.options = ['--rails', '--display-cop-names', '--display-style-guide']
+      task.options = [
+        ('--rails' if Gem::Version.new(RuboCop::Version.version) < Gem::Version.new('0.72.0')),
+        '--display-cop-names',
+        '--display-style-guide',
+        ['--config', RUBY_VERSION < '3.0' ? '.rubocop_v0.yml' : '.rubocop_v1.yml']
+      ].compact
       task.formatters = ['progress']
       task.patterns = patterns
       task.fail_on_error = true


### PR DESCRIPTION
#### Purpose
Check if tests can run on Github Actions. Currently it's failing as we can see here: https://github.com/rails-api/active_model_serializers/actions/runs/5841080668?pr=2450

#### Changes
Upgrade Ubuntu from 18.04 (deprecated) to 22.04 (latest). Also add test matrix for Ruby 3.2 and Rails 7.0

#### Caveats


#### Related GitHub issues
#2450 

#### Additional helpful information

- rubocop upgraded to v1 in order to pass tests
- 2 rubocop files: rubocop_v0 would apply for Ruby < 3. otherwise rubocop_v1
- `.rubocop_v0.yml` is merely holding changes from `.rubocop.yml`.
- rubocop_v1 targets Ruby 3.0
- rubocop_v1.yml is a superset of rubocop_v0.yml. Many new linters have been disabled on v1 in order to keep this PR simple. **Ideally we should bring back those cops along with necessary code adjustments in future PR**