### PR TITLE
Update gem requirement to allow Rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,14 @@ jobs:
       matrix:
         include:
           # Recent Rubies and Rails
+          - ruby-version: '3.2'
+            rails-version: '7.1'
           - ruby-version: '3.1'
-            rails-version: '7.0'
+            rails-version: '7.1'
           - ruby-version: '3.0'
-            rails-version: '7.0'
+            rails-version: '7.1'
           - ruby-version: '2.7'
-            rails-version: '7.0'
+            rails-version: '7.1'
           - ruby-version: '2.6'
             rails-version: '6.1'
           - ruby-version: '2.6'

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  rails_versions = ['>= 4.1', '< 7.1']
+  rails_versions = ['>= 4.1', '< 7.2']
   spec.add_runtime_dependency 'activemodel', rails_versions
   # 'activesupport', rails_versions
   # 'builder'


### PR DESCRIPTION
#### Purpose

Update allowed version of Rails to `< 7.2.0` as they have now released [7.1.0](https://github.com/rails/rails/releases/tag/v7.1.0).

#### Changes

* Updates `rails_versions` in Gemspec to `< 7.2`
* Updates CI `rails-version` to `7.1`
* Added `ruby-version: '3.2'` to CI tests

#### Related GitHub issues

Based changes on https://github.com/rails-api/active_model_serializers/pull/2428 which updated from `< 7.0` to `< 7.1`.


