### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name:                     "Checkout Code"
-        uses:                     "actions/checkout@v2"
+        uses:                     "actions/checkout@v4"
         timeout-minutes:          5
         with:
           fetch-depth:            0


### PR DESCRIPTION
#### Purpose

Updates [actions/checkout](https://github.com/actions/checkout) to v4, which will remove the "The following actions uses node12 which is deprecated" messages being raised when the GitHub actions run.

`actions/checkout@v2`:

<img width="1658" alt="Screenshot 2023-10-06 at 08 54 24" src="https://github.com/rails-api/active_model_serializers/assets/163900/c0c5890c-7c20-4044-8f85-2940b90acae2">

`actions/checkout@v4`:

<img width="1645" alt="Screenshot 2023-10-06 at 08 58 30" src="https://github.com/rails-api/active_model_serializers/assets/163900/07a4a6bf-1099-4b8f-b7cb-be26dc75f864">

#### Changes

Changed `actions/checkout@v2` to `actions/checkout@v4` in `.github/workflows/ci.yml`


