### PR TITLE
Re-add thread_safe gem as explicit dependency

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -40,7 +40,8 @@ Gem::Specification.new do |spec|
   # 'i18n,
   # 'tzinfo'
   spec.add_development_dependency 'minitest', ['~> 5.0', '< 5.11']
-  # 'thread_safe'
+
+  spec.add_dependency 'thread_safe','~> 0.3', '>= 0.3.4'
 
   spec.add_runtime_dependency 'jsonapi-renderer', ['>= 0.1.1.beta1', '< 0.3']
   spec.add_runtime_dependency 'case_transform', '>= 0.2'


### PR DESCRIPTION
#### Purpose

Rails 7.1 does no longer require the `tread_safe` gem, but AMS relies on it, which leads to error messages.

#### Changes

Re-adding the `thread_safe` gem as explicit dependency.

#### Caveats

None known.

#### Related GitHub issues

* https://github.com/rails-api/active_model_serializers/pull/2395

#### Additional helpful information

I am using the same version requirements AMS used to have. In the Rails 7.1.1 app with AMS 0.10.14 I am maintaining, `thread_safe 0.3.6` has been installed.
