### PR TITLE
Don't force ActionController::TestCase to load

### DIFF
--- a/lib/active_model_serializers/railtie.rb
+++ b/lib/active_model_serializers/railtie.rb
@@ -44,9 +44,19 @@ module ActiveModelSerializers
     end
     # :nocov:
 
+    def extend_action_controller_test_case(&block)
+      if Rails::VERSION::MAJOR >= 6 || Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2
+        ActiveSupport.on_load(:action_controller_test_case, run_once: true, &block)
+      else
+        ActionController::TestCase.instance_eval(&block)
+      end
+    end
+
     if Rails.env.test?
-      ActionController::TestCase.send(:include, ActiveModelSerializers::Test::Schema)
-      ActionController::TestCase.send(:include, ActiveModelSerializers::Test::Serializer)
+      extend_action_controller_test_case do
+        include ActiveModelSerializers::Test::Schema
+        include ActiveModelSerializers::Test::Serializer
+      end
     end
   end
 end


### PR DESCRIPTION
Instead of referencing `ActionController::TestCase` directly during boot, we can use a lazy load hook to apply our mixins if it is loaded later.

Aside from the direct benefit of not evaluating a [rather large Ruby file](https://github.com/rails/rails/blob/v7.1.3/actionpack/lib/action_controller/test_case.rb) until necessary, this will avoid forcing other lazy load hooks to run prematurely (e.g. https://github.com/amatsuda/routes_lazy_routes/pull/14).

The `action_controller_test_case` load hook was added in Rails 5.1, and the `run_once` option was added in Rails 5.2. I've left the behaviour unchanged for older Rails versions where they're not available.