### PR TITLE
[0.9 stable] Make the test suite pass with Rails 7.1 and Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         include:
           # Recent Rubies and Rails
-          # - ruby-version: '3.1'
-          #   rails-version: '7.0'
+          - ruby-version: '3.3'
+            rails-version: '7.1'
           # - ruby-version: '3.0'
           #   rails-version: '7.0'
           # - ruby-version: '2.7'

--- a/Gemfile
+++ b/Gemfile
@@ -70,10 +70,10 @@ end
 
 group :test do
   platforms(*(@windows_platforms + [:ruby])) do
-    if version == 'master' || version >= '6'
-      gem 'sqlite3', '~> 1.4'
-    else
+    if RUBY_VERSION < '2.5' || version < '6'
       gem 'sqlite3', '~> 1.3.13'
+    else
+      gem 'sqlite3'
     end
   end
   platforms :jruby do

--- a/lib/action_controller/serialization_test_case.rb
+++ b/lib/action_controller/serialization_test_case.rb
@@ -24,6 +24,7 @@ module ActionController
       @serializers = Hash.new(0)
       super
     end
+    ruby2_keywords :process if respond_to?(:ruby2_keywords, true)
 
     # Asserts that the request was rendered with the appropriate serializers.
     #

--- a/test/integration/action_controller/serialization_test.rb
+++ b/test/integration/action_controller/serialization_test.rb
@@ -13,7 +13,7 @@ module ActionController
 
       def test_render_using_implicit_serializer
         get :render_using_implicit_serializer
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"profile":{"name":"Name 1","description":"Description 1"}}', @response.body
       end
     end
@@ -35,7 +35,7 @@ module ActionController
 
       def test_render_using_implicit_serializer_and_scope
         get :render_using_implicit_serializer_and_scope
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"profile":{"name":"Name 1","description":"Description 1 - current_user"}}', @response.body
       end
     end
@@ -65,7 +65,7 @@ module ActionController
 
       def test_render_using_scope_set_in_default_serializer_options
         get :render_using_scope_set_in_default_serializer_options
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"profile":{"name":"Name 1","description":"Description 1 - current_admin"}}', @response.body
       end
     end
@@ -91,7 +91,7 @@ module ActionController
 
       def test_render_using_implicit_serializer_and_explicit_scope
         get :render_using_implicit_serializer_and_explicit_scope
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"profile":{"name":"Name 1","description":"Description 1 - current_admin"}}', @response.body
       end
     end
@@ -117,7 +117,7 @@ module ActionController
 
       def test_render_overriding_serialization_scope
         get :render_overriding_serialization_scope
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"profile":{"name":"Name 1","description":"Description 1 - current_admin"}}', @response.body
       end
     end
@@ -141,7 +141,7 @@ module ActionController
 
       def test_render_calling_serialization_scope
         get :render_calling_serialization_scope
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"profile":{"name":"Name 1","description":"Description 1 - current_user"}}', @response.body
       end
     end
@@ -157,7 +157,7 @@ module ActionController
 
       def test_render_using_json_dump
         get :render_using_json_dump
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"hello":"world"}', @response.body
       end
     end
@@ -173,7 +173,7 @@ module ActionController
 
       def test_render_using_rails_behavior
         get :render_using_rails_behavior
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '[{"attributes":{"name":"Name 1","description":"Description 1","comments":"Comments 1"}}]', @response.body
       end
     end
@@ -189,7 +189,7 @@ module ActionController
 
       def test_render_array
         get :render_array
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"my":[{"name":"Name 1","description":"Description 1"}]}', @response.body
       end
     end
@@ -205,7 +205,7 @@ module ActionController
 
       def test_render_array
         get :render_array
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"webLog":[{"name":"Name 1","displayName":"Display Name 1"},{"name":"Name 2","displayName":"Display Name 2"}]}', @response.body
       end
     end
@@ -223,7 +223,7 @@ module ActionController
 
       def test_render_without_root
         get :render_without_root
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '{"name":"Name 1","displayName":"Display Name 1"}', @response.body
       end
     end
@@ -242,7 +242,7 @@ module ActionController
 
       def test_render_array_without_root
         get :render_array_without_root
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
         assert_equal '[{"name":"Name 1","displayName":"Display Name 1"},{"name":"Name 2","displayName":"Display Name 2"}]', @response.body
       end
     end
@@ -278,7 +278,7 @@ module ActionController
         @association.embed_in_root = true
 
         get :render_array_embeding_in_root
-        assert_equal 'application/json', @response.content_type
+        assert_includes @response.content_type, 'application/json'
 
         assert_equal("{\"my\":[{\"name\":\"Name 1\",\"email\":\"mail@server.com\",\"profile_id\":#{@controller.user.profile.object_id}}],\"profiles\":[{\"name\":\"N1\",\"description\":\"D1\"}]}", @response.body)
       end


### PR DESCRIPTION
Fixes a number of small issues.

Extracted out of https://github.com/rails-api/active_model_serializers/pull/2461, this is the minimal number of changes just so the suite passes (locally at least).

cc @bf4 