### PR TITLE
Make the gem compatible with `--enable-frozen-string-literal`

### DIFF
--- a/lib/action_controller/serialization.rb
+++ b/lib/action_controller/serialization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/class/attribute'
 
 module ActionController

--- a/lib/action_controller/serialization_test_case.rb
+++ b/lib/action_controller/serialization_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionController
   module SerializationAssertions
     extend ActiveSupport::Concern

--- a/lib/active_model/array_serializer.rb
+++ b/lib/active_model/array_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_model/default_serializer'
 require 'active_model/serializable'
 

--- a/lib/active_model/default_serializer.rb
+++ b/lib/active_model/default_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_model/serializable'
 
 module ActiveModel

--- a/lib/active_model/serializable.rb
+++ b/lib/active_model/serializable.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'active_model/serializable/utils'
 
 module ActiveModel
   module Serializable
-    INSTRUMENTATION_KEY = '!serialize.active_model_serializers'.freeze
+    INSTRUMENTATION_KEY = '!serialize.active_model_serializers'
 
     def self.included(base)
       base.extend Utils

--- a/lib/active_model/serializable/utils.rb
+++ b/lib/active_model/serializable/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveModel
   module Serializable
     module Utils

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_model/array_serializer'
 require 'active_model/serializable'
 require 'active_model/serializer/association'
@@ -130,14 +132,13 @@ end
       end
 
       def build_serializer_class(resource, options)
-        "".tap do |klass_name|
-          klass_name << "#{options[:namespace]}::" if options[:namespace]
-          klass_name << options[:prefix].to_s.classify if options[:prefix]
-          if resource.is_a?(String)
-            klass_name << "#{resource}Serializer"
-          else
-            klass_name << "#{resource.class.name}Serializer"
-          end
+        klass_name = +""
+        klass_name << "#{options[:namespace]}::" if options[:namespace]
+        klass_name << options[:prefix].to_s.classify if options[:prefix]
+        if resource.is_a?(String)
+          klass_name << "#{resource}Serializer"
+        else
+          klass_name << "#{resource.class.name}Serializer"
         end
       end
 

--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_model/default_serializer'
 require 'active_model/serializer/association/has_one'
 require 'active_model/serializer/association/has_many'

--- a/lib/active_model/serializer/association/has_many.rb
+++ b/lib/active_model/serializer/association/has_many.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveModel
   class Serializer
     class Association

--- a/lib/active_model/serializer/association/has_one.rb
+++ b/lib/active_model/serializer/association/has_one.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveModel
   class Serializer
     class Association

--- a/lib/active_model/serializer/config.rb
+++ b/lib/active_model/serializer/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveModel
   class Serializer
     class Config

--- a/lib/active_model/serializer/generators/resource_override.rb
+++ b/lib/active_model/serializer/generators/resource_override.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators'
 require 'rails/generators/rails/resource/resource_generator'
 

--- a/lib/active_model/serializer/generators/serializer/scaffold_controller_generator.rb
+++ b/lib/active_model/serializer/generators/serializer/scaffold_controller_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators'
 require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
 

--- a/lib/active_model/serializer/generators/serializer/serializer_generator.rb
+++ b/lib/active_model/serializer/generators/serializer/serializer_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class SerializerGenerator < NamedBase

--- a/lib/active_model/serializer/railtie.rb
+++ b/lib/active_model/serializer/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveModel
   class Railtie < Rails::Railtie
     initializer 'generators' do |app|

--- a/lib/active_model/serializer/version.rb
+++ b/lib/active_model/serializer/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module ActiveModel
   class Serializer
-    VERSION = '0.9.9'.freeze
+    VERSION = '0.9.9'
   end
 end

--- a/lib/active_model/serializer_support.rb
+++ b/lib/active_model/serializer_support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveModel
   module SerializerSupport
     alias read_attribute_for_serialization send

--- a/lib/active_model_serializers.rb
+++ b/lib/active_model_serializers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_model'
 require 'active_model/serializer'
 require 'active_model/serializer_support'


### PR DESCRIPTION
This will become the default in a future Ruby version.

Extracted from: https://github.com/rails-api/active_model_serializers/pull/2461

cc @bf4 