### PR TITLE
[0.9 stable] Avoid `Object.constants.include?`

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -62,7 +62,7 @@ end
         if resource.respond_to?(:serializer_class)
           resource.serializer_class
         elsif resource.respond_to?(:to_ary)
-          if Object.constants.include?(:ArraySerializer)
+          if defined?(::ArraySerializer)
             ::ArraySerializer
           else
             ArraySerializer


### PR DESCRIPTION
This is an extremely inneficient way to check if a constant is defined.

`Object.constants.size` is `135` in a raw irb session.

On our large app, not even eager loaded it's `4521`. I didn't bother to check in production, but it's probably several times that.

So here we're both allocating a very large array, and doing a `O(n)` search into it.

cc @bf4 