### PR TITLE
[0.9 stable] Revert "Allow serializer_for to accept String instead of just class objects"

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -133,11 +133,7 @@ end
         klass_name = +""
         klass_name << "#{options[:namespace]}::" if options[:namespace]
         klass_name << options[:prefix].to_s.classify if options[:prefix]
-        if resource.is_a?(String)
-          klass_name << "#{resource}Serializer"
-        else
-          klass_name << "#{resource.class.name}Serializer"
-        end
+        klass_name << "#{resource.class.name}Serializer"
       end
 
       def associate(klass, *attrs)

--- a/test/unit/active_model/array_serializer/serialization_test.rb
+++ b/test/unit/active_model/array_serializer/serialization_test.rb
@@ -49,7 +49,7 @@ module ActiveModel
         def object.serializer_class; CustomSerializer; end
 
         assert_equal CustomSerializer, Serializer.serializer_for(object)
-        assert_equal CustomSerializer, Serializer.serializer_for('Custom')
+        assert_nil Serializer.serializer_for('Custom')
       end
     end
 


### PR DESCRIPTION
Ref: https://github.com/rails-api/active_model_serializers/pull/2446/commits/460d4c564af5e45661a30ed1a40e797e4bdda6f4

I first thought about making it configurable, but I just can't find a justification for this feature in a very stable gem with such backward compatibility impact.

cc @bf4 

@Physium could you tell me more about your use case? Because this change broke our app quite hard, in a cause we had:

```ruby
render json: "Error"
```

Which caused AMS to look for `ErrorSerializer`, which really we don't want.

Can't you just do: 

```ruby
render json: Custom.new
```

instead of:

```ruby
render json: "Custom"
```

?