### PR TITLE
Improve attribute methods generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### [0-9-stable](https://github.com/rails-api/active_model_serializers/compare/v0.9.12...0-9-stable)
 
+- Perf
+  - [#2471](https://github.com/rails-api/active_model_serializers/pull/2471) Generate better attribute accessors, that also don't trigger warnings when redefined. (@byroot)
+
 ### [v0.9.12 (2024-04-11)](https://github.com/rails-api/active_model_serializers/compare/v0.9.11...v0.9.12)
 
 - Fix

--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,10 @@ group :test do
   platforms(*(@windows_platforms + [:ruby])) do
     if RUBY_VERSION < '2.5' || version < '6'
       gem 'sqlite3', '~> 1.3.13'
+    elsif version >= '8'
+      gem 'sqlite3', '>= 2'
     else
-      gem 'sqlite3'
+      gem 'sqlite3', '< 2'
     end
   end
   platforms :jruby do


### PR DESCRIPTION
I'm currently working through Ruby warnings in our app, and one of the top source is from ActiveModel Serializer sub classes.

Usually they look like:

```ruby
class SomethingSerializer < AMS
  attributes :title, :body

  def title # method redefinition warning
    titleize
  end
end
```

One solution would be to call `attributes` at the end of the method, so that `attributes` skips defining these, but it's quite unatural.

Instead we can use the self alias trick to mark these generated methods as OK to redefine. An alternative would be to define them in an included module like Active Model does, but not sure if it's worth it.

While I was at it, I improved the way these methods are generated.

cc @bf4 