### PR TITLE
Add Transmutation to README alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See [PR 2121](https://github.com/rails-api/active_model_serializers/pull/2121) w
 - [jsonapi-resources](https://github.com/cerebris/jsonapi-resources) is a popular resource-focused framework for implementing JSON:API servers.
 - [blueprinter](https://github.com/procore/blueprinter) is a fast, declarative, and API spec agnostic serializer that uses composable views to reduce duplication. From your friends at Procore.
 - [Alba](https://github.com/okuramasafumi/alba) is fast and spec agnostic serialization solution. It has some unique features such as global or per-resource error handling.
+- [Transmutation](https://github.com/spellbook-technology/transmutation) is fast and lightweight JSON attribute serialization solution. It provides an intuitive serializer lookup, inspired from AMS.
 
 
 For benchmarks against alternatives, see https://github.com/rails-api/active_model_serializers/tree/benchmarks


### PR DESCRIPTION
#### Purpose

I've recently developed an alternative to Active Model Serializers that takes inspiration from much of the DSL AMS 0.10 uses.

#### Changes

- Add [Transmutation](https://github.com/spellbook-technology/transmutation) alternative to README.

#### Caveats

- This alternative does not support JSON:API formats and is a pure JSON attributes serialization solution.

#### Related GitHub issues

\-

#### Additional helpful information

\-