### PR TITLE
fix: use Concurrent::Map instead of Ruby `||=` to make thread safe

### DIFF
--- a/lib/active_model/serializer/lazy_association.rb
+++ b/lib/active_model/serializer/lazy_association.rb
@@ -53,7 +53,7 @@ module ActiveModel
       private
 
       def cached_result
-        @cached_result ||= {}
+        @cached_result ||= Concurrent::Map.new
       end
 
       def serialize_object!(object)


### PR DESCRIPTION
#### Purpose

This PR enhances the thread safety of the `cached_result` initialization in the `ActiveModel::Serializer::LazyAssociation` class. By replacing the plain Ruby hash with `Concurrent::Map,` we aim to prevent potential race conditions and ensure thread-safe operations in multi-threaded environments.