### PR TITLE
chore: rename Serializer to ActiveModelSerializers

### DIFF
--- a/lib/active_model/serializer/reflection.rb
+++ b/lib/active_model/serializer/reflection.rb
@@ -55,7 +55,7 @@ module ActiveModel
       def initialize(*)
         super
         options[:links] = {}
-        options[:include_data_setting] = Serializer.config.include_data_default
+        options[:include_data_setting] = ActiveModelSerializers.config.include_data_default
         options[:meta] = nil
         @type = options.fetch(:type) do
           class_name = options.fetch(:class_name, name.to_s.camelize.singularize)

--- a/test/adapter/json_api/pagination_links_test.rb
+++ b/test/adapter/json_api/pagination_links_test.rb
@@ -226,12 +226,12 @@ module ActiveModelSerializers
         end
 
         def test_pagination_links_not_present_when_disabled
-          ActiveModel::Serializer.config.jsonapi_pagination_links_enabled = false
+          ActiveModelSerializers.config.jsonapi_pagination_links_enabled = false
           adapter = load_adapter(using_kaminari, mock_request)
 
           assert_equal expected_response_without_pagination_links, adapter.serializable_hash
         ensure
-          ActiveModel::Serializer.config.jsonapi_pagination_links_enabled = true
+          ActiveModelSerializers.config.jsonapi_pagination_links_enabled = true
         end
       end
     end

--- a/test/serializers/reflection_test.rb
+++ b/test/serializers/reflection_test.rb
@@ -59,7 +59,7 @@ module ActiveModel
 
         # Assert
         assert_nil reflection.block
-        assert_equal Serializer.config.include_data_default, reflection.options.fetch(:include_data_setting)
+        assert_equal ActiveModelSerializers.config.include_data_default, reflection.options.fetch(:include_data_setting)
         assert_equal true, reflection.options.fetch(:include_data_setting)
 
         include_slice = :does_not_matter
@@ -79,7 +79,7 @@ module ActiveModel
 
         # Assert
         assert_respond_to reflection.block, :call
-        assert_equal Serializer.config.include_data_default, reflection.options.fetch(:include_data_setting)
+        assert_equal ActiveModelSerializers.config.include_data_default, reflection.options.fetch(:include_data_setting)
         assert_equal true, reflection.options.fetch(:include_data_setting)
 
         include_slice = :does_not_matter
@@ -100,7 +100,7 @@ module ActiveModel
 
         # Assert
         assert_respond_to reflection.block, :call
-        assert_equal Serializer.config.include_data_default, reflection.options.fetch(:include_data_setting)
+        assert_equal ActiveModelSerializers.config.include_data_default, reflection.options.fetch(:include_data_setting)
         assert_equal true, reflection.options.fetch(:include_data_setting)
 
         include_slice = :does_not_matter


### PR DESCRIPTION
Just renaming the class to follow docs/rfcs/0000-namespace.md