### PR TITLE
feat: allow kebab case for deserialization options: only, except

### DIFF
--- a/lib/active_model_serializers/adapter/json_api/deserialization.rb
+++ b/lib/active_model_serializers/adapter/json_api/deserialization.rb
@@ -95,6 +95,9 @@ module ActiveModelSerializers
           attributes['id'] = primary_data['id'] if primary_data['id']
           relationships = primary_data['relationships'] || {}
 
+          attributes = transform_keys(attributes, options)
+          relationships = transform_keys(relationships, options)
+
           filter_fields(attributes, options)
           filter_fields(relationships, options)
 
@@ -143,9 +146,11 @@ module ActiveModelSerializers
 
         # @api private
         def filter_fields(fields, options)
-          if (only = options[:only])
+          only = transform_keys(options[:only], options)
+          except = transform_keys(options[:except], options)
+          if only
             fields.slice!(*Array(only).map(&:to_s))
-          elsif (except = options[:except])
+          elsif except
             fields.except!(*Array(except).map(&:to_s))
           end
         end
@@ -157,7 +162,7 @@ module ActiveModelSerializers
 
         # @api private
         def parse_attributes(attributes, options)
-          transform_keys(attributes, options)
+          attributes
             .map { |(k, v)| { field_key(k, options) => v } }
             .reduce({}, :merge)
         end
@@ -199,15 +204,15 @@ module ActiveModelSerializers
 
         # @api private
         def parse_relationships(relationships, options)
-          transform_keys(relationships, options)
+          relationships
             .map { |(k, v)| parse_relationship(k, v['data'], options) }
             .reduce({}, :merge)
         end
 
         # @api private
-        def transform_keys(hash, options)
+        def transform_keys(hash_or_array, options = {})
           transform = options[:key_transform] || :underscore
-          CaseTransform.send(transform, hash)
+          CaseTransform.send(transform, hash_or_array)
         end
       end
     end

--- a/test/adapter/json_api/parse_test.rb
+++ b/test/adapter/json_api/parse_test.rb
@@ -13,7 +13,8 @@ module ActiveModelSerializers
                 'id' => 'zorglub',
                 'attributes' => {
                   'title' => 'Ember Hamster',
-                  'src' => 'http://example.com/images/productivity.png'
+                  'src' => 'http://example.com/images/productivity.png',
+                  'created-at' => '2000-01-01'
                 },
                 'relationships' => {
                   'author' => {
@@ -38,7 +39,8 @@ module ActiveModelSerializers
               src: 'http://example.com/images/productivity.png',
               author_id: nil,
               photographer_id: '9',
-              comment_ids: %w(1 2)
+              comment_ids: %w(1 2),
+              created_at: '2000-01-01'
             }
 
             @illformed_payloads = [nil,
@@ -87,17 +89,40 @@ module ActiveModelSerializers
           end
 
           def test_filter_fields_only
-            parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, only: [:id, :title, :author])
+            parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, only: [:id, :title, :author, :created_at])
             expected = {
               id: 'zorglub',
               title: 'Ember Hamster',
-              author_id: nil
+              author_id: nil,
+              created_at: '2000-01-01'
+            }
+            assert_equal(expected, parsed_hash)
+          end
+
+          def test_filter_fields_only_from_kebab_case
+            parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, only: [:id, :title, :author, :'created-at'])
+            expected = {
+              id: 'zorglub',
+              title: 'Ember Hamster',
+              author_id: nil,
+              created_at: '2000-01-01'
             }
             assert_equal(expected, parsed_hash)
           end
 
           def test_filter_fields_except
             parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, except: [:id, :title, :author])
+            expected = {
+              src: 'http://example.com/images/productivity.png',
+              photographer_id: '9',
+              comment_ids: %w(1 2),
+              created_at: '2000-01-01'
+            }
+            assert_equal(expected, parsed_hash)
+          end
+
+          def test_filter_fields_except_from_kebab_case
+            parsed_hash = ActiveModelSerializers::Adapter::JsonApi::Deserialization.parse!(@hash, except: [:id, :title, :author, :'created-at'])
             expected = {
               src: 'http://example.com/images/productivity.png',
               photographer_id: '9',
@@ -114,7 +139,8 @@ module ActiveModelSerializers
               src: 'http://example.com/images/productivity.png',
               user_id: nil,
               photographer_id: '9',
-              comment_ids: %w(1 2)
+              comment_ids: %w(1 2),
+              created_at: '2000-01-01'
             }
             assert_equal(expected, parsed_hash)
           end
@@ -128,7 +154,8 @@ module ActiveModelSerializers
               author_id: nil,
               photographer_id: '9',
               photographer_type: 'Person',
-              comment_ids: %w(1 2)
+              comment_ids: %w(1 2),
+              created_at: '2000-01-01'
             }
             assert_equal(expected, parsed_hash)
           end


### PR DESCRIPTION
#### Purpose

Allow parsing of kebab-case `only` and `except` options when deserializing a payload. Another implementation of #1986 (which includes much more context/motivation for these changes).

#### Changes

When deserializing, transforms attribute and relationship keys earlier so they can be used when filtering out with `only` and `except` options.

Also transforms the keys specified in `only` and `except` prior to comparison.

#### Caveats


#### Related GitHub issues


#### Additional helpful information

#### Benchmarks
<details>

<summary>before bench</summary>

```
AR: attributes 44394.10329048443/ips; 60 objects
AR: json 47005.86972172492/ips; 59 objects
AR: JSON API 47325.83200065749/ips; 59 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "AR: attributes",
      "benchmark_run[result][iterations_per_second]": 44394.103,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 60
    },
    {
      "benchmark_type[category]": "AR: json",
      "benchmark_run[result][iterations_per_second]": 47005.87,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 59
    },
    {
      "benchmark_type[category]": "AR: JSON API",
      "benchmark_run[result][iterations_per_second]": 47325.832,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 59
    }
  ]
}
attributes 476.0226585966201/ips; 3814 objects
json_api 914.7483338401025/ips; 2184 objects
json 496.00841498733206/ips; 3837 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "attributes",
      "benchmark_run[result][iterations_per_second]": 476.023,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 3814
    },
    {
      "benchmark_type[category]": "json_api",
      "benchmark_run[result][iterations_per_second]": 914.748,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 2184
    },
    {
      "benchmark_type[category]": "json",
      "benchmark_run[result][iterations_per_second]": 496.008,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 3837
    }
  ]
}







caching on: caching serializers: gc off 1705.2121475092795/ips; 1244 objects
caching on: fragment caching serializers: gc off 1738.8545947629773/ips; 1342 objects
caching on: non-caching serializers: gc off 2013.1704662247566/ips; 1161 objects
caching off: caching serializers: gc off 1819.7242825310034/ips; 1243 objects
caching off: fragment caching serializers: gc off 1774.1239347041146/ips; 1342 objects
caching off: non-caching serializers: gc off 2033.6678964479788/ips; 1162 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "caching on: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1705.212,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1244
    },
    {
      "benchmark_type[category]": "caching on: fragment caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1738.855,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1342
    },
    {
      "benchmark_type[category]": "caching on: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 2013.17,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1161
    },
    {
      "benchmark_type[category]": "caching off: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1819.724,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1243
    },
    {
      "benchmark_type[category]": "caching off: fragment caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1774.124,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1342
    },
    {
      "benchmark_type[category]": "caching off: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 2033.668,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1162
    }
  ]
}
Configurable Lookup Chain 2191.100706466314/ips; 793 objects
Old Lookup Chain (v0.10) 2276.0792422541817/ips; 792 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "Configurable Lookup Chain",
      "benchmark_run[result][iterations_per_second]": 2191.101,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 793
    },
    {
      "benchmark_type[category]": "Old Lookup Chain (v0.10)",
      "benchmark_run[result][iterations_per_second]": 2276.079,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 792
    }
  ]
}
camel 12820.837961501948/ips; 188 objects
camel_lower 13844.987357867929/ips; 187 objects
dash 13960.717187483073/ips; 187 objects
unaltered 13768120.277963636/ips; 1 objects
underscore 13309.085643885619/ips; 187 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "camel",
      "benchmark_run[result][iterations_per_second]": 12820.838,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 188
    },
    {
      "benchmark_type[category]": "camel_lower",
      "benchmark_run[result][iterations_per_second]": 13844.987,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 187
    },
    {
      "benchmark_type[category]": "dash",
      "benchmark_run[result][iterations_per_second]": 13960.717,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 187
    },
    {
      "benchmark_type[category]": "unaltered",
      "benchmark_run[result][iterations_per_second]": 13768120.278,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1
    },
    {
      "benchmark_type[category]": "underscore",
      "benchmark_run[result][iterations_per_second]": 13309.086,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 187
    }
  ]
}
```

</details>

<details>

<summary>after bench</summary>

```
AR: attributes 46691.82904124213/ips; 60 objects
AR: json 47810.09436594017/ips; 59 objects
AR: JSON API 46890.722008279175/ips; 59 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "AR: attributes",
      "benchmark_run[result][iterations_per_second]": 46691.829,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 60
    },
    {
      "benchmark_type[category]": "AR: json",
      "benchmark_run[result][iterations_per_second]": 47810.094,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 59
    },
    {
      "benchmark_type[category]": "AR: JSON API",
      "benchmark_run[result][iterations_per_second]": 46890.722,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 59
    }
  ]
}
attributes 479.1122173509777/ips; 3814 objects
json_api 917.810676352514/ips; 2184 objects
json 494.8560663720845/ips; 3837 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "attributes",
      "benchmark_run[result][iterations_per_second]": 479.112,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 3814
    },
    {
      "benchmark_type[category]": "json_api",
      "benchmark_run[result][iterations_per_second]": 917.811,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 2184
    },
    {
      "benchmark_type[category]": "json",
      "benchmark_run[result][iterations_per_second]": 494.856,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 3837
    }
  ]
}







caching on: caching serializers: gc off 1734.6645899022585/ips; 1244 objects
caching on: fragment caching serializers: gc off 1785.5697578675797/ips; 1342 objects
caching on: non-caching serializers: gc off 2046.7877807480727/ips; 1161 objects
caching off: caching serializers: gc off 1899.8175038774873/ips; 1243 objects
caching off: fragment caching serializers: gc off 1798.359311716489/ips; 1342 objects
caching off: non-caching serializers: gc off 2048.94772137132/ips; 1162 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "caching on: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1734.665,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1244
    },
    {
      "benchmark_type[category]": "caching on: fragment caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1785.57,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1342
    },
    {
      "benchmark_type[category]": "caching on: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 2046.788,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1161
    },
    {
      "benchmark_type[category]": "caching off: caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1899.818,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1243
    },
    {
      "benchmark_type[category]": "caching off: fragment caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 1798.359,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1342
    },
    {
      "benchmark_type[category]": "caching off: non-caching serializers: gc off",
      "benchmark_run[result][iterations_per_second]": 2048.948,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1162
    }
  ]
}
Configurable Lookup Chain 2232.598734478871/ips; 793 objects
Old Lookup Chain (v0.10) 2357.014230512904/ips; 792 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "Configurable Lookup Chain",
      "benchmark_run[result][iterations_per_second]": 2232.599,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 793
    },
    {
      "benchmark_type[category]": "Old Lookup Chain (v0.10)",
      "benchmark_run[result][iterations_per_second]": 2357.014,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 792
    }
  ]
}
camel 13044.684279179337/ips; 188 objects
camel_lower 14073.858417973293/ips; 187 objects
dash 14040.17341570349/ips; 187 objects
unaltered 13863549.714894457/ips; 1 objects
underscore 13478.061387682537/ips; 187 objects
Benchmark results:
{
  "commit_hash": "bda19502",
  "version": "0.10.14",
  "rails_version": "6.1.7.8",
  "benchmark_run[environment]": null,
  "runs": [
    {
      "benchmark_type[category]": "camel",
      "benchmark_run[result][iterations_per_second]": 13044.684,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 188
    },
    {
      "benchmark_type[category]": "camel_lower",
      "benchmark_run[result][iterations_per_second]": 14073.858,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 187
    },
    {
      "benchmark_type[category]": "dash",
      "benchmark_run[result][iterations_per_second]": 14040.173,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 187
    },
    {
      "benchmark_type[category]": "unaltered",
      "benchmark_run[result][iterations_per_second]": 13863549.715,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 1
    },
    {
      "benchmark_type[category]": "underscore",
      "benchmark_run[result][iterations_per_second]": 13478.061,
      "benchmark_run[result][total_allocated_objects_per_iteration]": 187
    }
  ]
}
```

</details>

