### PR TITLE
fix: encode JSON in Serializable

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 1.9.3"
 
   gem.add_dependency "activemodel", ">= 3.2"
+  gem.add_dependency "activesupport", ">= 3.2"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_development_dependency "rails", ">= 3.2"
 end

--- a/lib/active_model/serializable.rb
+++ b/lib/active_model/serializable.rb
@@ -10,6 +10,10 @@ module ActiveModel
       base.extend Utils
     end
 
+    def to_json(options={})
+      ActiveSupport::JSON.encode(self, options)
+    end
+
     def as_json(options={})
       instrument do
         if root = options.fetch(:root, json_key)


### PR DESCRIPTION
#### Purpose

This is a potential way to address #2480, although it feels messy to me. Something is attaching a `.to_json` override on Object that is breaking serialization of AMS objects. Adding our own override to `ActiveModel::Serializable` (which just does the exact same thing as `ActiveSupport::ToJsonWithActiveSupportEncoder,` does anyway) does appear to fix it in my testing.

#### Changes


#### Caveats

Didn't write any specs yet because I'm not sure if this is the best way forward.

#### Related GitHub issues

#2480 

#### Additional helpful information


