### PR TITLE
Fix cant modify frozen Hash error due to rails changes

### DIFF
--- a/lib/active_model_serializers/adapter/attributes.rb
+++ b/lib/active_model_serializers/adapter/attributes.rb
@@ -9,7 +9,7 @@ module ActiveModelSerializers
       end
 
       def serializable_hash(options = nil)
-        options = serialization_options(options)
+        options = serialization_options(options.dup)
         options[:fields] ||= instance_options[:fields]
         serialized_hash = serializer.serializable_hash(instance_options, options, self)
 


### PR DESCRIPTION
#### Purpose 
Latest `rails` has been updated to avoid repeated dup(https://github.com/rails/rails/pull/52826/files) of as_json options.

I have also had this issue last week. 
Getting the following error when checking against a not match(rendering empty json array)
```
UsersController autocomplete with unmatched
  Failure/Error: format.json { render json: results }
  FrozenError:
    can't modify frozen Hash: {:prefixes=>["users", "application"], :template=>"autocomplete", :layout=>#<Proc:0x0000000131e8d960 /Users/admin/.rvm/gems/ruby-3.3.5@local/bundler/gems/rails-31818edb0352/actionview/lib/action_view/layouts.rb:393>, :serialization_context=>#<ActiveModelSerializers::SerializationContext:0x0000000131ecd088 @request_url="http://test.host/users/autocomplete", @query_parameters={"term"=>"unmatched"}, @url_helpers=#<Module:0x000000012cd22d00>, @default_url_options={:host=>"localhost:3000"}>, :namespace=>nil}
  # /Users/admin/.rvm/gems/ruby-3.3.5@local/gems/active_model_serializers-0.10.14/lib/active_model_serializers/adapter/attributes.rb:13:in `serializable_hash'
```


#### Changes
Using `.dup` so that code is not using the frozen options.

#### Caveats
N/A

#### Related GitHub issues
N/A

#### Additional helpful information
Related conversation in rails repository https://github.com/rails/rails/pull/52826/files#r1752237530

