### PR TITLE
Support Rails 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
       matrix:
         include:
           # Recent Rubies and Rails
+          - ruby-version: '3.3'
+            rails-version: '8.0'
+          - ruby-version: '3.2'
+            rails-version: '8.0'
+          - ruby-version: '3.2'
+            rails-version: '7.2'
           - ruby-version: '3.2'
             rails-version: '7.1'
           - ruby-version: '3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,9 @@ end
 
 group :test do
   platforms(*(@windows_platforms + [:ruby])) do
-    if version == 'master' || version >= '6'
+    if version == 'master' || version >= '8'
+      gem 'sqlite3', '~> 2.1'
+    elsif version >= '6'
       gem 'sqlite3', '< 1.6'
     else
       gem 'sqlite3', '~> 1.3.13'

--- a/test/action_controller/json_api/linked_test.rb
+++ b/test/action_controller/json_api/linked_test.rb
@@ -88,7 +88,7 @@ module ActionController
 
         setup do
           @routes = Rails.application.routes.draw do
-            ActiveSupport::Deprecation.silence do
+            (Rails.try(:deprecator) || ActiveSupport::Deprecation).silence do
               match ':action', to: LinkedTestController, via: [:get, :post]
             end
           end

--- a/test/active_model_serializers/register_jsonapi_renderer_test_isolated.rb
+++ b/test/active_model_serializers/register_jsonapi_renderer_test_isolated.rb
@@ -66,7 +66,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       make_basic_app
 
       Rails.application.routes.draw do
-        ActiveSupport::Deprecation.silence do
+        (Rails.try(:deprecator) || ActiveSupport::Deprecation).silence do
           match ':action', to: TestController, via: [:get, :post]
         end
       end
@@ -112,7 +112,7 @@ class JsonApiRendererTest < ActionDispatch::IntegrationTest
       make_basic_app
 
       Rails.application.routes.draw do
-        ActiveSupport::Deprecation.silence do
+        (Rails.try(:deprecator) || ActiveSupport::Deprecation).silence do
           match ':action', to: TestController, via: [:get, :post]
         end
       end

--- a/test/support/isolated_unit.rb
+++ b/test/support/isolated_unit.rb
@@ -71,7 +71,10 @@ module TestHelpers
         config.hosts << 'www.example.com' if Rails.version >= '6.0'
       end
       def app.name; 'IsolatedRailsApp'; end # rubocop:disable Style/SingleLineMethods
-      app.respond_to?(:secrets) && app.secrets.secret_key_base = '3b7cd727ee24e8444053437c36cc66c4'
+
+      secret_key_base = '3b7cd727ee24e8444053437c36cc66c4'
+      app.respond_to?(:secrets) && app.secrets.secret_key_base = secret_key_base
+      app.respond_to?(:credentials) && app.credentials.secret_key_base = secret_key_base
 
       @app = app
       yield @app if block_given?


### PR DESCRIPTION
#### Purpose

Support Rails 8 

#### Changes

There are two main changes: 
1. To allow modification of render options (to initialize defaults) from adapters, `dup` it if it's frozen.
2. `ActiveSupport::Deprecation.silence` is replaced by `Rails.deprecator.silence`

This PR also adds Rails 7.2 and 8.0 to the test matrix. 

#### Caveats

No caveats

#### Related GitHub issues

No related issues

#### Additional helpful information

This is my first contribution, so please let me know if something is missing and I'll try to answer it. 
