### PR TITLE
Allow customizing the type of polymorphic association

### DIFF
--- a/lib/active_model/serializer/association.rb
+++ b/lib/active_model/serializer/association.rb
@@ -58,7 +58,7 @@ module ActiveModel
         serialization = association_serializer.serializable_hash(adapter_options, {}, adapter_instance)
 
         if polymorphic? && serialization
-          polymorphic_type = association_object.class.name.underscore
+          polymorphic_type = association_serializer.json_key || association_object.class.name.underscore
           serialization = { type: polymorphic_type, polymorphic_type.to_sym => serialization }
         end
 

--- a/test/adapter/polymorphic_test.rb
+++ b/test/adapter/polymorphic_test.rb
@@ -12,8 +12,8 @@ module ActiveModel
           @picture.imageable = @employee
         end
 
-        def serialization(resource, adapter = :attributes)
-          serializable(resource, adapter: adapter, serializer: PolymorphicBelongsToSerializer).as_json
+        def serialization(resource, adapter: :attributes, serializer: PolymorphicBelongsToSerializer)
+          serializable(resource, adapter: adapter, serializer: serializer).as_json
         end
 
         def tag_serialization(adapter = :attributes)
@@ -38,6 +38,23 @@ module ActiveModel
             }
 
           assert_equal(expected, serialization(@picture))
+        end
+
+        def test_polymorphic_belongs_to_with_custom_type
+          expected =
+          {
+            id: 1,
+            title: 'headshot-1.jpg',
+            imageable: {
+              type: 'custom',
+              custom: {
+                id: 42,
+                name: 'Zoop Zoopler'
+              }
+            }
+          }
+
+          assert_equal(expected, serialization(@picture, serializer: PolymorphicBelongsToSerializerWithCustomBelongsToType))
         end
 
         def test_attributes_serialization_without_polymorphic_association
@@ -97,7 +114,7 @@ module ActiveModel
               }
             }
 
-          assert_equal(expected, serialization(@picture, :json))
+          assert_equal(expected, serialization(@picture, adapter: :json))
         end
 
         def test_json_serialization_without_polymorphic_association
@@ -111,7 +128,7 @@ module ActiveModel
             }
 
           simple_picture = Picture.new(id: 2, title: 'headshot-2.jpg')
-          assert_equal(expected, serialization(simple_picture, :json))
+          assert_equal(expected, serialization(simple_picture, adapter: :json))
         end
 
         def test_json_serialization_with_polymorphic_has_many
@@ -165,7 +182,7 @@ module ActiveModel
               }
             }
 
-          assert_equal(expected, serialization(@picture, :json_api))
+          assert_equal(expected, serialization(@picture, adapter: :json_api))
         end
 
         def test_json_api_serialization_with_polymorphic_belongs_to

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -113,3 +113,13 @@ class PolymorphicBelongsToSerializer < ActiveModel::Serializer
   attributes :id, :title
   belongs_to :imageable, serializer: PolymorphicHasManySerializer, polymorphic: true
 end
+
+class PolymorphicHasManySerializerWithCustomType < ActiveModel::Serializer
+  attributes :id, :name
+
+  type :custom
+end
+class PolymorphicBelongsToSerializerWithCustomBelongsToType < ActiveModel::Serializer
+  attributes :id, :title
+  belongs_to :imageable, serializer: PolymorphicHasManySerializerWithCustomType, polymorphic: true
+end


### PR DESCRIPTION
#### Purpose

Allow customizing the type of polymorphic association. We needed this because in our codebase we have model names that we'd like to change but we cannot without also doing the necessary database migrations. It hasn't been a priority yet but we want our new API to use the new naming already.

#### Changes

Read the `json_key` from the association serializer when determining the polymorphic type to use. This changes the JSON serialization:

```diff
{
  id: 1,
  title: 'headshot-1.jpg',
  imageable: {
-    type: 'employee',
-    employee: {
+   type: 'custom',
+   custom: {
      id: 42,
      name: 'Zoop Zoopler'
    }
  }
}
```

#### Caveats

This is a breaking change. I'd love to hear how this change can be introduced in a way that is least disruptive.

#### Related GitHub issues

I _think_ https://github.com/rails-api/active_model_serializers/issues/2131 is related

#### Additional helpful information

n.a.
