### PR TITLE
0.9: Require at least concurrent-ruby v1.2.0 because of bugs in v1.1.10

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 1.9.3"
 
   gem.add_dependency "activemodel", ">= 3.2"
-  gem.add_dependency "concurrent-ruby", "~> 1.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.2"
   gem.add_development_dependency "rails", ">= 3.2"
 end


### PR DESCRIPTION
#### Purpose

I've been trying to upgrade `active_model_serializers` in my project, but I was having issues with infinite recursion when upgrading from v0.9.6 to v0.9.7. My rspec test would look up serializers recursively, finally crashing with `SystemStackError: stack level too deep`.

After much bisecting I narrowed it down to this commit: 1e04d1128bc7bb9d4fd54908fa91a0dcbf988631

Reverting that made my project work again. So I checked what version of `concurrent-ruby` I had, and it was v1.1.10. Upgrading to v1.2.0 fixed the infinite recursion issue, so I was able to undo the revert of the introduction of concurrent-ruby.

While [the CHANGELOG of concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md#release-v120-23-jan-2023) doesn't seem to indicate that there are any significant problems fixed in v1.2.0. Nevertheless, I think it would be prudent to require at least 1.2.0 so that people aren't looking for bugs in their own code for hours.

I was stuck on concurrent-ruby 1.1.10 simply because another gem foolishly depended on `~> 1.1.5`. 😢 

#### Changes

Ensure users are using a bug-free version of concurrent-ruby.

#### Caveats


#### Related GitHub issues

Couldn't find any.


#### Additional helpful information


