### PR TITLE
Fix changing config in subclass having global effect

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -192,6 +192,7 @@ module ActiveModel
       base._attributes_data = _attributes_data.dup
       base._reflections = _reflections.dup
       base._links = _links.dup
+      base.config = ActiveSupport::InheritableOptions.new(config)
     end
 
     # @return [Array<Symbol>] Key names of declared attributes

--- a/test/serializers/configuration_test.rb
+++ b/test/serializers/configuration_test.rb
@@ -5,6 +5,10 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class ConfigurationTest < ActiveSupport::TestCase
+      class CustomSerializer < ActiveModel::Serializer
+        config.adapter = :json_api
+      end
+
       def test_collection_serializer
         assert_equal ActiveModel::Serializer::CollectionSerializer, ActiveModelSerializers.config.collection_serializer
       end
@@ -28,6 +32,10 @@ module ActiveModel
 
       def test_default_adapter
         assert_equal :attributes, ActiveModelSerializers.config.adapter
+      end
+
+      def test_subclass_adapter
+        assert_equal :json_api, CustomSerializer.config.adapter
       end
     end
   end


### PR DESCRIPTION
#### Purpose

Overriding configuration such as adapter in subclasses currently affects all serializers on `0-10-stable`.

```rb
ActiveModelSerializers.config.adapter = :json_api

class FooSerializer < ActiveModel::Serializer
  config.adapter = :attributes
end

ActiveModelSerializers.config.adapter #=> :attributes
```

#### Changes

We make copy of configuration object on subclassing, just like was done in https://github.com/rails/rails/pull/53970.

#### Related GitHub issues

This was a regression after removing `ActiveSupport::Configurable` in https://github.com/rails-api/active_model_serializers/pull/2492.
